### PR TITLE
コード規約：kokoas-serverで警告なしでconsole.logを使えるようにする

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -78,6 +78,14 @@ module.exports = {
       }
     },
     {
+      "files":[
+        "**/kokoas-server/**/*"
+      ],
+      "rules" : {
+        "no-console": "off",
+      }
+    },
+    {
       "files" : [
         "**/**.d.ts"
       ],


### PR DESCRIPTION
## 変更

- コード規約：kokoas-serverでconsole.logを許可する

## 変更理由

- サーバの具合が分かるため。

## 備考

- 時間があったら、ちゃんとしたログファイルを生成させるようにします。