### PR TITLE
27 顧客登録画面で、都道府県の選択の順番をReverseにする。

### DIFF
--- a/packages/kokoas-client/src/api/others/address.ts
+++ b/packages/kokoas-client/src/api/others/address.ts
@@ -1,6 +1,9 @@
 
 
-export const getPrefectures = async (area?: string) => {
+export const getPrefectures = async (
+  area?: string, 
+  reverse = false,
+) => {
 
   return kintone.proxy(`http://geoapi.heartrails.com/api/json?method=getPrefectures${area ? `&area=${area}` : ''}`, 'GET', {}, {})
     .then(([body]: any[]) => {
@@ -14,7 +17,8 @@ export const getPrefectures = async (area?: string) => {
         }
       } = JSON.parse(body as string);
 
-      return prefecture;
+
+      return reverse ? prefecture.reverse() : prefecture;
     });
 };
 

--- a/packages/kokoas-client/src/app.ts
+++ b/packages/kokoas-client/src/app.ts
@@ -7,6 +7,7 @@ import { onIndexShow } from './helpers/kintone';
 
 
 (async () => {
+
   kintone.events.on(onIndexShow, onIndexShowHandler);
 
 })();

--- a/packages/kokoas-client/src/pageShowHandlers/onIndexShowHandler.tsx
+++ b/packages/kokoas-client/src/pageShowHandlers/onIndexShowHandler.tsx
@@ -13,7 +13,7 @@ export default function onIndexShowHandler() {
 
   if (!container) {
     generateRoot();
-
+    console.log('Running in ', process.env.NODE_ENV);
     container = document.getElementById('app');
     const root = createRoot( container!);
     root.render(<App />);

--- a/packages/kokoas-client/src/pages/customer/register/parts/Customers/AddressDialog.tsx
+++ b/packages/kokoas-client/src/pages/customer/register/parts/Customers/AddressDialog.tsx
@@ -60,7 +60,7 @@ export const AddressDialog = (props: {
     if (!area) return;
     setIsLoading(true);
     setPrefectures([]);
-    getPrefectures(area).then(resp => {
+    getPrefectures(area, true).then(resp => {
       setPrefectures(resp);
       setCities([]);
       setIsLoading(false);
@@ -90,7 +90,6 @@ export const AddressDialog = (props: {
 
   useEffect(()=>{
     if (postal) {
-      console.log(postal);
       handleClose();
       startTransition(()=>{
         setFieldValue(postalFN, postal );


### PR DESCRIPTION
## 変更

- 都道府県APIに、reverseの引数を追加しました。
- consoleに実装環境を出力するようにしました。以下が出ます。

    本番
    `running in production`

    開発
    `running in development`

## 理由

- #27 の対応のため。
- 環境によって、接続DBとAPIが変わることになるので、分かるようにします。


