### PR TITLE
T178 工事画面で顧客情報表示の修正

### DIFF
--- a/packages/kokoas-client/src/helpers/translations.ts
+++ b/packages/kokoas-client/src/helpers/translations.ts
@@ -14,4 +14,7 @@ export const translations: Record<string, string> = {
   store: '店舗名',
   yumeAg: 'ゆめてつAG',
 
+  tel: '電話番号',
+  email: 'メアド',
+
 };

--- a/packages/kokoas-client/src/hooksQuery/index.ts
+++ b/packages/kokoas-client/src/hooksQuery/index.ts
@@ -2,6 +2,7 @@ export * from './useCommonOptions';
 export * from './useContractsByProjId';
 export * from './useCustGroupById';
 export * from './useCustGroupByProjId';
+export * from './useCustomersByCustGroupId';
 export * from './useCustomersByIds';
 export * from './useEmployeeByIds';
 export * from './useEmployeeOptions';

--- a/packages/kokoas-client/src/hooksQuery/useCustomersByCustGroupId.ts
+++ b/packages/kokoas-client/src/hooksQuery/useCustomersByCustGroupId.ts
@@ -1,0 +1,14 @@
+import { useMemo } from 'react';
+import { useCustGroupById } from './useCustGroupById';
+import { useCustomersByIds } from './useCustomersByIds';
+
+export const useCustomersByCustGroupId = (custGroupId?: string) => {
+  const { data: custGroupRecord } = useCustGroupById(custGroupId ?? '');
+
+  const custIds = useMemo(
+    () => custGroupRecord?.members.value.map((m) => m.value.customerId.value),
+    [custGroupRecord],
+  );
+
+  return useCustomersByIds(custIds);
+};

--- a/packages/kokoas-client/src/hooksQuery/useCustomersByCustGroupId.ts
+++ b/packages/kokoas-client/src/hooksQuery/useCustomersByCustGroupId.ts
@@ -2,6 +2,11 @@ import { useMemo } from 'react';
 import { useCustGroupById } from './useCustGroupById';
 import { useCustomersByIds } from './useCustomersByIds';
 
+/**
+ * 顧客グループ番号で顧客データを取得する。
+ *
+ * custGroup n-n customers
+ */
 export const useCustomersByCustGroupId = (custGroupId?: string) => {
   const { data: custGroupRecord } = useCustGroupById(custGroupId ?? '');
 

--- a/packages/kokoas-client/src/hooksQuery/useCustomersByIds.ts
+++ b/packages/kokoas-client/src/hooksQuery/useCustomersByIds.ts
@@ -8,12 +8,18 @@ import { getCustomersByIds } from 'api-kintone';
  * データ関連：
  * custGroup n-n customer
  */
-export const useCustomersByIds = (custIds : string[]) => {
+export const useCustomersByIds = <T = Awaited<ReturnType<typeof getCustomersByIds>>>(
+  custIds: string[] | undefined = [],
+  options?: {
+    select: (data: Awaited<ReturnType<typeof getCustomersByIds>>) => T
+  },
+) => {
   return useQuery(
     [AppIds.customers, { custIds }],
     () => getCustomersByIds(custIds),
     {
-      enabled: !!custIds.length,
+      enabled: !!custIds?.length,
+      ...options,
     },
   );
 };

--- a/packages/kokoas-client/src/hooksQuery/useCustomersByIds.ts
+++ b/packages/kokoas-client/src/hooksQuery/useCustomersByIds.ts
@@ -15,7 +15,7 @@ export const useCustomersByIds = <T = Awaited<ReturnType<typeof getCustomersById
   },
 ) => {
   return useQuery(
-    [AppIds.customers, { custIds }],
+    [AppIds.customers, 'custIds', custIds],
     () => getCustomersByIds(custIds),
     {
       enabled: !!custIds?.length,

--- a/packages/kokoas-client/src/hooksQuery/useSaveCustGroup.ts
+++ b/packages/kokoas-client/src/hooksQuery/useSaveCustGroup.ts
@@ -12,10 +12,12 @@ export const useSaveCustGroup = () => {
     saveCustGroup,
     {
       ...commonOptions,
-      onSuccess: (data) => {
+      onSuccess: (data, { customerRecords }) => {
         commonOptions.onSuccess();
+
+        const ids = customerRecords?.map(({ $id }) => $id?.value);
         queryClient.invalidateQueries({ queryKey: [AppIds.custGroups, { custGroupId: data.id }] });
-        queryClient.invalidateQueries({ queryKey: [AppIds.customers, { custGroupId: data.id }] });
+        queryClient.invalidateQueries({ queryKey: [AppIds.customers, 'custIds', ids ] });
 
       },
     },

--- a/packages/kokoas-client/src/hooksQuery/useSaveCustGroup.ts
+++ b/packages/kokoas-client/src/hooksQuery/useSaveCustGroup.ts
@@ -1,13 +1,23 @@
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { saveCustGroup } from 'api-kintone';
+import { AppIds } from 'config';
 import { useCommonOptions } from './useCommonOptions';
 
 export const useSaveCustGroup = () => {
   const commonOptions = useCommonOptions();
+  const queryClient = useQueryClient();
+
+
   return useMutation(
     saveCustGroup,
     {
       ...commonOptions,
+      onSuccess: (data) => {
+        commonOptions.onSuccess();
+        queryClient.invalidateQueries({ queryKey: [AppIds.custGroups, { custGroupId: data.id }] });
+        queryClient.invalidateQueries({ queryKey: [AppIds.customers, { custGroupId: data.id }] });
+
+      },
     },
-  ); 
+  );
 };

--- a/packages/kokoas-client/src/pages/projRegister/sections/CustInfo/Column1.tsx
+++ b/packages/kokoas-client/src/pages/projRegister/sections/CustInfo/Column1.tsx
@@ -1,26 +1,23 @@
 import { Grid, Stack } from '@mui/material';
+import { translations } from 'kokoas-client/src/helpers/translations';
 import { LabeledInfo } from '../../../../components/ui/typographies';
 
 export const Column1 = ({
   custDetail: {
     custNames,
     custNamesReading,
-    email, emailRel,
-    phone1, phone1Rel,
-    phone2, phone2Rel,
+    contactTuples,
     address,
   },
 }: {
   custDetail: {
     custNames: string,
     custNamesReading: string,
-    email: string,
-    emailRel: string,
+
+    /** 一つ目の顧客情報 */
+    contactTuples: string[][]
     address: string,
-    phone1: string,
-    phone1Rel: string,
-    phone2: string,
-    phone2Rel: string,
+
   }
 }) => {
   return (
@@ -33,9 +30,17 @@ export const Column1 = ({
           label="現住所"
           info={address}
         />
-        <LabeledInfo label="メアド" info={email ? [email, emailRel].join(',') : ''} />
-        <LabeledInfo label="電話番号１" info={phone1 ? [phone1, phone1Rel].join(',') : ''} />
-        <LabeledInfo label="電話番号２" info={phone2 ? [phone2, phone2Rel].join(',') : ''} />
+
+        {
+          contactTuples.map(([contactType, value]) => {
+            return  (
+              <LabeledInfo
+                key={contactType + value}
+                label={translations[contactType]} info={value}
+              />);
+          })
+        }
+
       </Stack>
     </Grid>
   );

--- a/packages/kokoas-client/src/pages/projRegister/sections/CustInfo/Column1.tsx
+++ b/packages/kokoas-client/src/pages/projRegister/sections/CustInfo/Column1.tsx
@@ -3,8 +3,8 @@ import { LabeledInfo } from '../../../../components/ui/typographies';
 
 export const Column1 = ({
   custDetail: {
-    customerName,
-    custNameReading,
+    custNames,
+    custNamesReading,
     email, emailRel,
     phone1, phone1Rel,
     phone2, phone2Rel,
@@ -12,8 +12,8 @@ export const Column1 = ({
   },
 }: {
   custDetail: {
-    customerName: string,
-    custNameReading: string,
+    custNames: string,
+    custNamesReading: string,
     email: string,
     emailRel: string,
     address: string,
@@ -27,8 +27,8 @@ export const Column1 = ({
     <Grid item xs={12} sm={6}>
       <Stack spacing={2}>
 
-        <LabeledInfo label="氏名" info={customerName} />
-        <LabeledInfo label="氏名フリガナ" info={custNameReading} />
+        <LabeledInfo label="氏名" info={custNames} />
+        <LabeledInfo label="氏名フリガナ" info={custNamesReading} />
         <LabeledInfo
           label="現住所"
           info={address}

--- a/packages/kokoas-client/src/pages/projRegister/sections/CustInfo/Column2.tsx
+++ b/packages/kokoas-client/src/pages/projRegister/sections/CustInfo/Column2.tsx
@@ -7,14 +7,14 @@ export const Column2 = (
     adminInfo: {
       storeName,
       custGroupId,
-      customerId,
+      customerIds,
       agents,
     },
   }: {
     adminInfo: {
       storeName: string,
       custGroupId: string,
-      customerId: string,
+      customerIds: string,
       agents: Array<ComponentProps<typeof LabeledInfo> & { key: string }>
     }
   },
@@ -30,7 +30,7 @@ export const Column2 = (
           })}
 
         <LabeledInfo label={'グループ番号'} info={custGroupId} />
-        <LabeledInfo label={'顧客番号'} info={customerId} />
+        <LabeledInfo label={'顧客番号'} info={customerIds} />
       </Stack>
 
     </Grid>


### PR DESCRIPTION
## 変更

- 顧客情報取得はreact-query化しました。
- 住所の表示の修正。〒　の位置は違う出でした。
- 顧客が複数いる場合、「顧客名」と「顧客名フリガナ」と「顧客番号」もコンマで区切って、表示する。
- 顧客が複数いる場合でも、住所と連絡先は一つ目の顧客を表示する。

## 変更理由

- https://trello.com/c/4NFYQpXF


## 備考

- データを簡単にキャッシュ出来るのはいいですが、保存・更新処理などで、キャッシュの更新も必要です。一番確実なやりかたは invalidateQueriesですが、クエリのキーの指定に間違えやすいので、 クエリのキーの管理が必要になってくるかもしれません。当PRでは未対応です。