### PR TITLE
T203 工事名称の変更

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -60,7 +60,15 @@ module.exports = {
     "react/jsx-pascal-case": [2], // https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-pascal-case.md
     "@typescript-eslint/no-unused-vars": ["error", { "argsIgnorePattern": "^_",  }],
     "import/no-extraneous-dependencies": "off", // Was having problems with this in a monorepo. Need help to resolve.
-
+    "no-irregular-whitespace": [
+      "error",
+      {
+        "skipStrings": true,
+        "skipComments": true,
+        "skipRegExps": true,
+        "skipTemplates": true
+      }
+    ]
   },
   "overrides": [
     {

--- a/packages/kokoas-client/src/pages/projRegister/sections/ConstructionInfo/ConstructionInfo.tsx
+++ b/packages/kokoas-client/src/pages/projRegister/sections/ConstructionInfo/ConstructionInfo.tsx
@@ -80,7 +80,7 @@ export const ConstructionInfo = (
             onChange={(_, newTextVal) => {
               setValues((prev) => ({
                 ...prev,
-                projName: `${prev.custName} ${newTextVal}`,
+                projName: `${prev.custName}様邸　${newTextVal}`,
               }));
             }}
           />}


### PR DESCRIPTION
## 変更内容

- eslintに全角を許すようにルールを入れました。
- 工事名称が現状「契約者名」+半角スペース+「工事種別」になっていたが、
→「契約者名」+様邸+全角スペース+「工事種別」に変更。


## 変更理由

https://trello.com/c/LbLqhoF1