### PR TITLE
add onFocus to fields.

### DIFF
--- a/packages/kokoas-client/src/pages/projEstimate/QuoteTable/rowFields/CostPriceField.tsx
+++ b/packages/kokoas-client/src/pages/projEstimate/QuoteTable/rowFields/CostPriceField.tsx
@@ -1,6 +1,5 @@
 
 import { FormikMoneyField } from 'kokoas-client/src/components';
-
 import { KeyOfForm, TKMaterials } from '../../form';
 import { useCalculateRow } from '../../hooks/useCalculateRow';
 
@@ -28,6 +27,7 @@ export const CostPriceField = ({
       size={'small'}
       disabled={isDisabled}
       onChange={handleChange}
+      onFocus={({ target }) => target.select()}
     />
   );
 };

--- a/packages/kokoas-client/src/pages/projEstimate/QuoteTable/rowFields/ProfitRateField.tsx
+++ b/packages/kokoas-client/src/pages/projEstimate/QuoteTable/rowFields/ProfitRateField.tsx
@@ -32,6 +32,7 @@ export const ProfitRateField = ({
       size={'small'}
       disabled={isDisabled}
       onChange={handleChange}
+      onFocus={({ target }) => target.select()}
       InputProps={{
         endAdornment: (
           <InputAdornment position='end'>

--- a/packages/kokoas-client/src/pages/projEstimate/QuoteTable/rowFields/QuantityField.tsx
+++ b/packages/kokoas-client/src/pages/projEstimate/QuoteTable/rowFields/QuantityField.tsx
@@ -35,6 +35,7 @@ export const QuantityField = ({
       size={'small'}
       disabled={isDisabled}
       onChange={handleChange}
+      onFocus={({ target }) => target.select()}
       InputProps={{
         endAdornment:  (
           <InputAdornment position="end">

--- a/packages/kokoas-client/src/pages/projEstimate/QuoteTable/rowFields/RowUnitPriceAfterTax.tsx
+++ b/packages/kokoas-client/src/pages/projEstimate/QuoteTable/rowFields/RowUnitPriceAfterTax.tsx
@@ -30,6 +30,7 @@ export const RowUnitPriceAfterTax = ({
       size={'small'}
       disabled={isDisabled}
       onChange={handleChange}
+      onFocus={({ target }) => target.select()}
     />
   );
 };

--- a/packages/kokoas-client/src/pages/projEstimate/QuoteTable/rowFields/UnitPriceField.tsx
+++ b/packages/kokoas-client/src/pages/projEstimate/QuoteTable/rowFields/UnitPriceField.tsx
@@ -30,6 +30,7 @@ export const UnitPriceField = ({
       size={'small'}
       disabled={isDisabled}
       onChange={handleChange}
+      onFocus={({ target }) => target.select()}
     />
   );
 };


### PR DESCRIPTION
## 変更

- 内訳内のフィールドを「クリック」でフォーカスされたら、ハイライトする。

## 変更理由

- https://trello.com/c/oBQByAhk


## 備考

- 数字のフィールドだけ対応しました。テクストフィールドにも同じにするかどうか要確認です。必要になったら、別PRで対応します。