### PR TITLE
T220 見積画面：ショートカットを実装

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -61,6 +61,7 @@
         "react": "^18.1.0",
         "react-awesome-reveal": "^3.8.1",
         "react-dom": "^18.1.0",
+        "react-hotkeys-hook": "^4.0.6",
         "react-icons": "^4.4.0",
         "react-imask": "^6.4.2",
         "react-loadable": "^5.5.0",
@@ -24501,6 +24502,15 @@
       "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-2.0.4.tgz",
       "integrity": "sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw=="
     },
+    "node_modules/react-hotkeys-hook": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/react-hotkeys-hook/-/react-hotkeys-hook-4.0.6.tgz",
+      "integrity": "sha512-QYSGEuvhjrDs4JbcQ8hVGPTJe02HBmLFuibVsAZPT+rJVOLqc9FqMKL8KXdBf6YFRSN2vN8zXBxyKnTTh9DScA==",
+      "peerDependencies": {
+        "react": ">=16.8.1",
+        "react-dom": ">=16.8.1"
+      }
+    },
     "node_modules/react-icons": {
       "version": "4.7.1",
       "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.7.1.tgz",
@@ -48759,6 +48769,12 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-2.0.4.tgz",
       "integrity": "sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw=="
+    },
+    "react-hotkeys-hook": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/react-hotkeys-hook/-/react-hotkeys-hook-4.0.6.tgz",
+      "integrity": "sha512-QYSGEuvhjrDs4JbcQ8hVGPTJe02HBmLFuibVsAZPT+rJVOLqc9FqMKL8KXdBf6YFRSN2vN8zXBxyKnTTh9DScA==",
+      "requires": {}
     },
     "react-icons": {
       "version": "4.7.1",

--- a/package.json
+++ b/package.json
@@ -122,6 +122,7 @@
     "react": "^18.1.0",
     "react-awesome-reveal": "^3.8.1",
     "react-dom": "^18.1.0",
+    "react-hotkeys-hook": "^4.0.6",
     "react-icons": "^4.4.0",
     "react-imask": "^6.4.2",
     "react-loadable": "^5.5.0",

--- a/packages/kokoas-client/src/components/ui/buttons/HotKeyTooltip.tsx
+++ b/packages/kokoas-client/src/components/ui/buttons/HotKeyTooltip.tsx
@@ -1,0 +1,30 @@
+import { Stack, Tooltip, Typography } from '@mui/material';
+import { ComponentProps } from 'react';
+import KeyboardIcon from '@mui/icons-material/Keyboard';
+
+export const HotKeyTooltip = (
+  {
+    title,
+    ...others
+  }: ComponentProps<typeof Tooltip>,
+) => {
+
+
+
+  return (
+    <Tooltip
+      {...others}
+      enterDelay={1500}
+      title={(
+        <Stack direction={'row'} spacing={2}>
+          <KeyboardIcon />
+          <Typography>
+            {title}
+          </Typography>
+        </Stack>
+     )}
+
+    />
+
+  );
+};

--- a/packages/kokoas-client/src/components/ui/buttons/HotKeyTooltip.tsx
+++ b/packages/kokoas-client/src/components/ui/buttons/HotKeyTooltip.tsx
@@ -9,8 +9,6 @@ export const HotKeyTooltip = (
   }: ComponentProps<typeof Tooltip>,
 ) => {
 
-
-
   return (
     <Tooltip
       {...others}
@@ -23,7 +21,6 @@ export const HotKeyTooltip = (
           </Typography>
         </Stack>
      )}
-
     />
 
   );

--- a/packages/kokoas-client/src/components/ui/labels/PageSubTitle.tsx
+++ b/packages/kokoas-client/src/components/ui/labels/PageSubTitle.tsx
@@ -1,8 +1,9 @@
 import { Divider, Grid, Typography } from '@mui/material';
+import { ReactNode } from 'react';
 
 
 interface PageSubTitleProps {
-  label: string
+  label: ReactNode
   xs?: number,
 }
 

--- a/packages/kokoas-client/src/pages/projEstimate/FormProjEstimate.tsx
+++ b/packages/kokoas-client/src/pages/projEstimate/FormProjEstimate.tsx
@@ -18,6 +18,7 @@ import { EstimatesInfo } from './fieldComponents/EstimatesInfo';
 import { ButtonMenu } from './fieldComponents/ButtonMenu';
 import { useConfirmBeforeClose } from './hooks/useConfirmBeforeClose';
 import { useSaveHotkey } from './hooks/useSaveHotkey';
+import { EstimateTableLabel } from './fieldComponents/EstimateTableLabel';
 
 export default function FormProjEstimate() {
   const {
@@ -130,7 +131,7 @@ export default function FormProjEstimate() {
           </Grid>
 
           <Grid item xs={12} mt={4}>
-            <PageSubTitle label="内訳" />
+            <PageSubTitle label={<EstimateTableLabel />} />
           </Grid>
 
           <Grid item xs={12} md={12}>

--- a/packages/kokoas-client/src/pages/projEstimate/FormProjEstimate.tsx
+++ b/packages/kokoas-client/src/pages/projEstimate/FormProjEstimate.tsx
@@ -17,15 +17,14 @@ import { MismatchedProfit } from './fieldComponents/MismatchedProfit';
 import { EstimatesInfo } from './fieldComponents/EstimatesInfo';
 import { ButtonMenu } from './fieldComponents/ButtonMenu';
 import { useConfirmBeforeClose } from './hooks/useConfirmBeforeClose';
+import { useSaveHotkey } from './hooks/useSaveHotkey';
 
 export default function FormProjEstimate() {
-
-
-
-  const { 
+  const {
     values,
     dirty,
   } = useFormikContext<TypeOfForm>();
+
   const {
     projId,
     projTypeProfit,
@@ -36,15 +35,15 @@ export default function FormProjEstimate() {
     envStatus,
   } = values;
 
+  useSaveHotkey();
   useConfirmBeforeClose({ enabled: dirty });
 
   const isEditMode = !!estimateId;
   const isDisabled = !!envStatus;
 
-
   return (
     <Form noValidate>
-      
+
       <ScrollToFieldError />
       <MainContainer>
         <PageTitle label={`見積もり${isEditMode ? '編集' : '登録'}`} />
@@ -84,7 +83,7 @@ export default function FormProjEstimate() {
         </Grid>
 
         {!!projId && <>
-        
+
           <Grid item xs={12} md={3}>
             <FormikTextField name={getFieldName('projTypeName')} label="工事種別名" disabled />
           </Grid>
@@ -163,8 +162,8 @@ export default function FormProjEstimate() {
           </Grid>
 
           {!isDisabled && <FormActions />}
-        
-        
+
+
         </>}
 
       </MainContainer>

--- a/packages/kokoas-client/src/pages/projEstimate/QuoteTable/QuoteTableActions.tsx
+++ b/packages/kokoas-client/src/pages/projEstimate/QuoteTable/QuoteTableActions.tsx
@@ -4,6 +4,7 @@ import { produce } from 'immer';
 import { initialValues, TypeOfForm } from '../form';
 import { v4 as uuidv4 } from 'uuid';
 import AddIcon from '@mui/icons-material/Add';
+import { HotKeyTooltip } from 'kokoas-client/src/components/ui/buttons/HotKeyTooltip';
 
 export const QuoteTableActions = () => {
   const { setValues, values } = useFormikContext<TypeOfForm>();
@@ -11,26 +12,28 @@ export const QuoteTableActions = () => {
 
   return (
     <Stack direction="row" justifyContent={'flex-end'}>
-      <Button
-        variant="contained"
-        color="success"
-        disabled={!!envStatus}
-        startIcon={<AddIcon />}
-        onClick={() => {
-          setValues(
-            prev => produce(prev, draft => {
-              draft.items.push({
-                ...initialValues.items[0],
-                key: uuidv4(),
-                elemProfRate: draft.projTypeProfit,
-              });
-            }),
-            false,
-          );
-        }}
-      >
-        行追加
-      </Button>
+      <HotKeyTooltip title='insert'>
+        <Button
+          variant="contained"
+          color="success"
+          disabled={!!envStatus}
+          startIcon={<AddIcon />}
+          onClick={() => {
+            setValues(
+              prev => produce(prev, draft => {
+                draft.items.push({
+                  ...initialValues.items[0],
+                  key: uuidv4(),
+                  elemProfRate: draft.projTypeProfit,
+                });
+              }),
+              false,
+            );
+          }}
+        >
+          行追加
+        </Button>
+      </HotKeyTooltip>
     </Stack>
   );
 };

--- a/packages/kokoas-client/src/pages/projEstimate/QuoteTable/QuoteTableRow.tsx
+++ b/packages/kokoas-client/src/pages/projEstimate/QuoteTable/QuoteTableRow.tsx
@@ -18,6 +18,7 @@ import { isEven } from 'libs';
 import { grey } from '@mui/material/colors';
 import { useAdvancedTableRow } from '../hooks/useAdvancedTableRow';
 import { TblCellStack } from '../fieldComponents/TblCellStack';
+import { useQuoteTRowHotKeys } from '../hooks/useQuoteTRowHotKeys';
 
 export const QuoteTableRow = (
   {
@@ -47,6 +48,8 @@ export const QuoteTableRow = (
   } = useMaterialsOptions(rowIdx);
 
 
+  const rowMainRef = useQuoteTRowHotKeys(rowIdx);
+  const rowSubRef = useQuoteTRowHotKeys(rowIdx);
 
   const isLastRow = rowIdx === items.length - 1;
   const isDisabled = !!envStatus;
@@ -60,6 +63,8 @@ export const QuoteTableRow = (
   return (
     <>
       <TableRow
+        ref={rowMainRef}
+        component={'tr'}
         onFocus={handleFocus}
         onBlur={handleFocus}
         sx={rowSx}
@@ -179,6 +184,7 @@ export const QuoteTableRow = (
 
       </TableRow>
       <TableRow
+        ref={rowSubRef}
         onFocus={handleFocus}
         onBlur={handleFocus}
         sx={rowSx}

--- a/packages/kokoas-client/src/pages/projEstimate/QuoteTable/QuoteTableRow.tsx
+++ b/packages/kokoas-client/src/pages/projEstimate/QuoteTable/QuoteTableRow.tsx
@@ -34,7 +34,7 @@ export const QuoteTableRow = (
   }) => {
 
   const { values: { items } } = useFormikContext<TypeOfForm>();
-  const { costPrice, unit } = items[rowIdx];
+  const { costPrice, unit, key } = items[rowIdx];
 
   const { focused, handleFocus } = useAdvancedTableRow(rowIdx);
 
@@ -63,6 +63,7 @@ export const QuoteTableRow = (
   return (
     <>
       <TableRow
+        id={key}
         ref={rowMainRef}
         component={'tr'}
         onFocus={handleFocus}

--- a/packages/kokoas-client/src/pages/projEstimate/QuoteTable/rowActions/QtRowAddDelete.tsx
+++ b/packages/kokoas-client/src/pages/projEstimate/QuoteTable/rowActions/QtRowAddDelete.tsx
@@ -4,6 +4,7 @@ import { FieldArrayRenderProps } from 'formik';
 import { useState } from 'react';
 import { initialValues, TMaterials, TypeOfForm } from '../../form';
 import { v4 as uuidv4 } from 'uuid';
+import { HotKeyTooltip } from 'kokoas-client/src/components/ui/buttons/HotKeyTooltip';
 
 export const QtRowAddDelete = ({
   rowIdx, arrayHelpers,
@@ -70,16 +71,20 @@ export const QtRowAddDelete = ({
         }}
 
       >
-        <MenuItem onClick={handleAddToRowBelow}>
-          下に追加
-        </MenuItem>
+        <HotKeyTooltip title={'insert'}>
+          <MenuItem onClick={handleAddToRowBelow}>
+            下に追加
+          </MenuItem>
+        </HotKeyTooltip>
 
-        <MenuItem
-          disabled={isJustOneRow}
-          onClick={handleRemoveRow}
-        >
-          削除
-        </MenuItem>
+        <HotKeyTooltip title={'ctrl + delete'}>
+          <MenuItem
+            disabled={isJustOneRow}
+            onClick={handleRemoveRow}
+          >
+            削除
+          </MenuItem>
+        </HotKeyTooltip>
 
         <MenuItem onClick={handleCopyToRowBelow}>
           下にコピー

--- a/packages/kokoas-client/src/pages/projEstimate/fieldComponents/EstimateTableLabel.tsx
+++ b/packages/kokoas-client/src/pages/projEstimate/fieldComponents/EstimateTableLabel.tsx
@@ -1,0 +1,25 @@
+import { IconButton, Stack, Tooltip, Typography } from '@mui/material';
+import HelpIcon from '@mui/icons-material/Help';
+import { HelpHotKeys } from './HelpHotkeys';
+
+
+export const EstimateTableLabel = () => {
+
+  return (
+    <Stack
+      direction={'row'}
+      spacing={1}
+      alignItems="center"
+    >
+      <Typography component={'span'} variant={'h6'}>
+        {'内訳'}
+      </Typography>
+      <Tooltip title={<HelpHotKeys />}>
+        <IconButton size={'small'}>
+          <HelpIcon />
+        </IconButton>
+      </Tooltip>
+    </Stack>
+
+  );
+};

--- a/packages/kokoas-client/src/pages/projEstimate/fieldComponents/HelpHotkeys.tsx
+++ b/packages/kokoas-client/src/pages/projEstimate/fieldComponents/HelpHotkeys.tsx
@@ -1,0 +1,29 @@
+import { Grid } from '@mui/material';
+import { Fragment } from 'react';
+
+const hotkeysHelp = [
+  ['ctrl + s', '一時保存'],
+  ['insert', '行追加'],
+  ['ctrl + delete', '行削除'],
+  ['ctrl + enter', '次の行に移動'],
+];
+
+export const HelpHotKeys = () => {
+
+  return (
+    <Grid container width={150}>
+      {
+        hotkeysHelp.map(([key, info]) => (
+          <Fragment key={key}>
+            <Grid item xs={6}>
+              {key}
+            </Grid>
+            <Grid item xs={6}>
+              {info}
+            </Grid>
+          </Fragment>
+        ))
+      }
+    </Grid>
+  );
+};

--- a/packages/kokoas-client/src/pages/projEstimate/fieldComponents/formActions/BtnSaveTemporary.tsx
+++ b/packages/kokoas-client/src/pages/projEstimate/fieldComponents/formActions/BtnSaveTemporary.tsx
@@ -2,6 +2,7 @@ import { Box, Button } from '@mui/material';
 import SaveAltIcon from '@mui/icons-material/SaveAlt';
 import { useFormikContext } from 'formik';
 import { TypeOfForm } from '../../form';
+import { HotKeyTooltip } from 'kokoas-client/src/components/ui/buttons/HotKeyTooltip';
 
 /** 一時保存 */
 export const BtnSaveTemporary = () => {
@@ -15,18 +16,21 @@ export const BtnSaveTemporary = () => {
   };
 
   return (
-    <Button
-      variant={'outlined'}
-      size="medium"
-      aria-label="cancel"
-      color={'secondary'}
-      onClick={handleSave}
-    >
-      <SaveAltIcon />
-      <Box ml={1} width={'60px'}>
-        一時保存
-      </Box>
 
-    </Button>
+    <HotKeyTooltip title={'ctrl + s'}>
+      <Button
+        variant={'outlined'}
+        size="medium"
+        aria-label="cancel"
+        color={'secondary'}
+        onClick={handleSave}
+      >
+        <SaveAltIcon />
+        <Box ml={1} width={'60px'}>
+          一時保存
+        </Box>
+
+      </Button>
+    </HotKeyTooltip>
   );
 };

--- a/packages/kokoas-client/src/pages/projEstimate/hooks/useAdvancedTableRow.ts
+++ b/packages/kokoas-client/src/pages/projEstimate/hooks/useAdvancedTableRow.ts
@@ -6,6 +6,10 @@ import { v4 as uuidv4 }  from 'uuid';
 import { useInitialRow } from './useInitialRow';
 import { useIsLastRowModified } from './useIsLastRowModified';
 
+
+/**
+ * 自動行追加
+ */
 export const useAdvancedTableRow = (rowIdx : number) => {
   const {
     setValues,
@@ -14,7 +18,10 @@ export const useAdvancedTableRow = (rowIdx : number) => {
   const { envStatus } = values;
 
   const isWithContract = !!envStatus;
-  const initialRow = useInitialRow();
+  const {
+    initialRow,
+    getNewRow,
+  } = useInitialRow();
 
   const {
     isLastRow,
@@ -23,20 +30,20 @@ export const useAdvancedTableRow = (rowIdx : number) => {
 
   useEffect(() => {
     if (
-      isLastRowModified 
+      isLastRowModified
       && !isWithContract // 契約がある時、行追加しない
     ) {
       // 最終行は初期と異なる際、 行を自動追加する
       setValues(
         (prev) => produce(prev, (draft) => {
           draft.items.push({
-            ...initialRow,
+            ...getNewRow(),
             key: uuidv4(),
           });
 
         }));
     }
-  }, [isLastRowModified, setValues, initialRow, rowIdx, isWithContract]);
+  }, [isLastRowModified, rowIdx, isWithContract, setValues, getNewRow]);
 
   const [focused, setFocused] = useState(false);
 

--- a/packages/kokoas-client/src/pages/projEstimate/hooks/useAdvancedTableRow.ts
+++ b/packages/kokoas-client/src/pages/projEstimate/hooks/useAdvancedTableRow.ts
@@ -36,11 +36,7 @@ export const useAdvancedTableRow = (rowIdx : number) => {
       // 最終行は初期と異なる際、 行を自動追加する
       setValues(
         (prev) => produce(prev, (draft) => {
-          draft.items.push({
-            ...getNewRow(),
-            key: uuidv4(),
-          });
-
+          draft.items.push(getNewRow());
         }));
     }
   }, [isLastRowModified, rowIdx, isWithContract, setValues, getNewRow]);

--- a/packages/kokoas-client/src/pages/projEstimate/hooks/useAdvancedTableRow.ts
+++ b/packages/kokoas-client/src/pages/projEstimate/hooks/useAdvancedTableRow.ts
@@ -2,7 +2,6 @@ import { useFormikContext } from 'formik';
 import { produce } from 'immer';
 import { FocusEventHandler, useCallback, useEffect, useState } from 'react';
 import { TypeOfForm } from '../form';
-import { v4 as uuidv4 }  from 'uuid';
 import { useInitialRow } from './useInitialRow';
 import { useIsLastRowModified } from './useIsLastRowModified';
 

--- a/packages/kokoas-client/src/pages/projEstimate/hooks/useInitialRow.ts
+++ b/packages/kokoas-client/src/pages/projEstimate/hooks/useInitialRow.ts
@@ -1,17 +1,30 @@
 import { useFormikContext } from 'formik';
-import { useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 import { initialValues, TypeOfForm } from '../form';
+import { v4 as uuidV4 } from 'uuid';
 
 export const useInitialRow = () => {
   const {
     values : { projTypeProfit },
   } = useFormikContext<TypeOfForm>();
 
-  return useMemo(() => {
+  const initialRow = useMemo(() => {
     return {
       ...initialValues.items[0],
       elemProfRate: projTypeProfit,
     };
   }, [projTypeProfit]);
+
+  const getNewRow = useCallback(() : TypeOfForm['items'][number] => {
+    return ({
+      ...initialRow,
+      key: uuidV4(),
+    });
+  }, [initialRow]);
+
+  return {
+    initialRow,
+    getNewRow,
+  };
 
 };

--- a/packages/kokoas-client/src/pages/projEstimate/hooks/useQuoteTRowHotKeys.ts
+++ b/packages/kokoas-client/src/pages/projEstimate/hooks/useQuoteTRowHotKeys.ts
@@ -1,0 +1,32 @@
+import { useFormikContext } from 'formik';
+import { produce } from 'immer';
+import { debounce } from 'lodash';
+import { useMemo } from 'react';
+import { useHotkeys } from 'react-hotkeys-hook';
+import { TypeOfForm } from '../form';
+import { useInitialRow } from './useInitialRow';
+
+
+export const useQuoteTRowHotKeys = (rowIdx: number) => {
+  const { setValues } = useFormikContext<TypeOfForm>();
+  const {
+    getNewRow,
+  } = useInitialRow();
+
+  const insertRow = useMemo(
+    () => debounce(
+      () => setValues(prev => produce(prev, ({ items }) => {
+        items.splice(rowIdx + 1, 0, getNewRow());
+      })),
+      50,
+    ),
+    [getNewRow, rowIdx, setValues],
+  );
+
+  return useHotkeys<HTMLTableRowElement>('insert',
+    insertRow,
+    {
+      enableOnFormTags: ['INPUT', 'textarea'],
+    },
+  );
+};

--- a/packages/kokoas-client/src/pages/projEstimate/hooks/useQuoteTRowHotKeys.ts
+++ b/packages/kokoas-client/src/pages/projEstimate/hooks/useQuoteTRowHotKeys.ts
@@ -1,32 +1,88 @@
 import { useFormikContext } from 'formik';
 import { produce } from 'immer';
-import { debounce } from 'lodash';
-import { useMemo } from 'react';
+import debounce from 'lodash/debounce';
+import { useCallback, useMemo } from 'react';
 import { useHotkeys } from 'react-hotkeys-hook';
 import { TypeOfForm } from '../form';
 import { useInitialRow } from './useInitialRow';
 
+const hotkeys = [
+  'insert', // 行追加
+  'meta+delete', // 行削除
+  'meta+enter', // 次の行へ行く
+];
+
 
 export const useQuoteTRowHotKeys = (rowIdx: number) => {
-  const { setValues } = useFormikContext<TypeOfForm>();
+  const {
+    setValues,
+    values: { items },
+  } = useFormikContext<TypeOfForm>();
+
+  const isLastRow = rowIdx === items.length - 1;
+
   const {
     getNewRow,
   } = useInitialRow();
 
+  /** 行追加  debouncing subsequent calls.*/
   const insertRow = useMemo(
     () => debounce(
-      () => setValues(prev => produce(prev, ({ items }) => {
-        items.splice(rowIdx + 1, 0, getNewRow());
+      () => setValues(prev => produce(prev, (draft) => {
+        draft.items.splice(rowIdx + 1, 0, getNewRow());
       })),
-      50,
+      200,
+      {
+        'leading': true,
+        'trailing': false,
+      },
     ),
     [getNewRow, rowIdx, setValues],
   );
 
-  return useHotkeys<HTMLTableRowElement>('insert',
-    insertRow,
+  /**　行削除  */
+  const deleteRow = useMemo(
+    () => debounce(
+      () => {
+        if (!isLastRow) {
+          setValues(prev => produce(prev, (draft) => {
+            draft.items.splice(rowIdx, 1);
+          }));
+        }
+      },
+      200,
+    ),
+    [ rowIdx, setValues, isLastRow],
+  );
+
+  const gotoNextRow = useCallback(() => {
+
+    if (!isLastRow) {
+      const nextRowId = items[rowIdx + 1].key;
+      (document
+        // td# でも可能ですが、エスケープが必要になるので、セレクターは以下の形にしました。
+        .querySelector(`tr[id='${nextRowId}'] input`) as HTMLInputElement)
+        .focus();
+    }
+  }, [items, rowIdx, isLastRow]);
+
+  return useHotkeys<HTMLTableRowElement>(
+    hotkeys,
+    (_, handler) => {
+      const { keys } = handler;
+      if (keys?.includes('insert')) {
+        insertRow();
+      } else if (keys?.includes('delete')) {
+        deleteRow();
+      } else if (keys?.includes('enter')) {
+        gotoNextRow();
+      }
+    },
     {
       enableOnFormTags: ['INPUT', 'textarea'],
+      keyup: false,
+      keydown: true,
     },
+    [insertRow, deleteRow, gotoNextRow],
   );
 };

--- a/packages/kokoas-client/src/pages/projEstimate/hooks/useSaveHotkey.ts
+++ b/packages/kokoas-client/src/pages/projEstimate/hooks/useSaveHotkey.ts
@@ -1,0 +1,26 @@
+import { useFormikContext } from 'formik';
+import debounce from 'lodash/debounce';
+import { useMemo } from 'react';
+import { useHotkeys } from 'react-hotkeys-hook';
+import { TypeOfForm } from '../form';
+
+/**
+ * 保存 windows:　crt+s, mac: cmd+s
+ */
+export const useSaveHotkey = () => {
+  const { submitForm, setValues } = useFormikContext<TypeOfForm>();
+
+  const debouncedSave = useMemo(
+    () => debounce(() => { // スパム対策
+      submitForm();
+    }, 800),
+    [submitForm],
+  );
+
+  useHotkeys('meta+s', (e) => {
+    e.preventDefault();
+    setValues((prev) => ({ ...prev, saveMode: 'temporary' })); // 一時保存に設定
+    debouncedSave();
+  });
+
+};

--- a/packages/kokoas-client/src/pages/projEstimate/hooks/useSaveHotkey.ts
+++ b/packages/kokoas-client/src/pages/projEstimate/hooks/useSaveHotkey.ts
@@ -17,10 +17,14 @@ export const useSaveHotkey = () => {
     [submitForm],
   );
 
-  useHotkeys('meta+s', (e) => {
-    e.preventDefault();
-    setValues((prev) => ({ ...prev, saveMode: 'temporary' })); // 一時保存に設定
-    debouncedSave();
-  });
+  useHotkeys('meta+s',
+    (e) => {
+      e.preventDefault();
+      setValues((prev) => ({ ...prev, saveMode: 'temporary' })); // 一時保存に設定
+      debouncedSave();
+    },
+    {
+      enableOnFormTags: ['INPUT', 'textarea'],
+    });
 
 };


### PR DESCRIPTION
## 変更内容

- **ショートカットキー**

  - ctrl + enter
  次の行の頭に行く

  - insert
  行を挿入する

  - ctrl + delete
  行削除

  - ctrl + s
  保存

- 関わるボタンにショートカットキーが分かるものを実装しました。

## 変更理由

- https://trello.com/c/lo6XL8pY

## 備考

- [react-hotkeys-hook](https://react-hotkeys-hook.vercel.app/) というパッケージを追加しましたので、`npm i` の実行が必要です。