### PR TITLE
ブラウザのタブ名をメニュに合わせる

### DIFF
--- a/packages/kokoas-client/src/components/ui/labels/PageTitle.tsx
+++ b/packages/kokoas-client/src/components/ui/labels/PageTitle.tsx
@@ -1,18 +1,25 @@
 
 import { Grid, Typography } from '@mui/material';
+import { useEffect } from 'react';
 
 interface PageTitleProps {
   color?: string,
   textColor?: string,
   label: string
+  secondaryLabel?: string,
 }
 
 export const PageTitle = (props: PageTitleProps) => {
   const {
     color = '#9CDAF9',
     textColor = '#000',
+    secondaryLabel,
     label,
   } =  props;
+
+  useEffect(() => {
+    document.title = [label, secondaryLabel].filter(Boolean).join(' - ');
+  }, [label, secondaryLabel]);
 
   return (
     <Grid item xs={12} p={2}

--- a/packages/kokoas-client/src/pages/projContracts/FormContract.tsx
+++ b/packages/kokoas-client/src/pages/projContracts/FormContract.tsx
@@ -26,7 +26,7 @@ export const FormContract = ({
 }) => {
   const { values } = useFormikContext<TypeOfForm>();
   const navigate = useNavigate();
-  const { projEstimateId, projId, projName, envelopeStatus } = values;
+  const { projEstimateId, projId, projName, envelopeStatus, projEstimateDataId } = values;
 
 
   const { summary } = calculated ?? {};
@@ -39,7 +39,7 @@ export const FormContract = ({
     <Form noValidate>
       <ScrollToFieldError />
       <MainContainer justifyContent={'space-between'}>
-        <PageTitle label='契約' />
+        <PageTitle label='契約' secondaryLabel={projEstimateDataId} />
 
         <Grid item xs={12} md={4} >
           <SearchProjects

--- a/packages/kokoas-client/src/pages/projContracts/api/convertToForm.ts
+++ b/packages/kokoas-client/src/pages/projContracts/api/convertToForm.ts
@@ -1,6 +1,7 @@
 import { calculateEstimateRecord } from 'api-kintone';
 import { parseISO } from 'date-fns';
 import { produce } from 'immer';
+import { formatDataId } from 'libs';
 import { IConnectRecipients, IProjestimates, TEnvelopeStatus, TSignMethod } from 'types';
 import { parseKintoneDate } from '../../../lib/date';
 import { initialValues, TypeOfForm } from '../form';
@@ -34,7 +35,7 @@ export const convertToForm = ({
     payDestination,
     completeDate,
     signMethod,
-
+    dataId,
   } = record ?? {};
 
   const newPaymentFields = produce(initialValues.paymentFields, draft => {
@@ -65,6 +66,7 @@ export const convertToForm = ({
     projName: projName?.value || '',
     projEstimateRevision: $revision?.value || '',
     projEstimateId: projEstimateId?.value ?? '',
+    projEstimateDataId: formatDataId(dataId.value),
 
 
     /* 契約 */

--- a/packages/kokoas-client/src/pages/projContracts/form.ts
+++ b/packages/kokoas-client/src/pages/projContracts/form.ts
@@ -15,6 +15,7 @@ export const initialValues = {
   /* 工事 */
   projId: '',
   projEstimateId: '',
+  projEstimateDataId: '',
   projName: '',
   projAddress: '',
 

--- a/packages/kokoas-client/src/pages/projEstimate/FormProjEstimate.tsx
+++ b/packages/kokoas-client/src/pages/projEstimate/FormProjEstimate.tsx
@@ -47,7 +47,7 @@ export default function FormProjEstimate() {
 
       <ScrollToFieldError />
       <MainContainer>
-        <PageTitle label={`見積もり${isEditMode ? '編集' : '登録'}`} />
+        <PageTitle label={`見積もり${isEditMode ? '編集' : '登録'}`} secondaryLabel={estimateDataId} />
 
         <Grid item xs={10} md={5}>
 

--- a/packages/kokoas-client/src/pages/projEstimate/api/convertEstimateToForm.ts
+++ b/packages/kokoas-client/src/pages/projEstimate/api/convertEstimateToForm.ts
@@ -1,6 +1,6 @@
 import { calculateEstimateRow } from 'api-kintone';
 import { format, parseISO } from 'date-fns';
-import { roundTo } from 'libs';
+import { formatDataId, roundTo } from 'libs';
 import { IProjestimates, TaxType } from 'types';
 import { initialValues, TypeOfForm } from '../form';
 
@@ -68,9 +68,9 @@ export const convertEstimateToForm = (
     };
   });
 
-  /* 
-    仮想行の追加 
-    useAdvancedTableRow listens to changes on the last row to insert a virtual row, 
+  /*
+    仮想行の追加
+    useAdvancedTableRow listens to changes on the last row to insert a virtual row,
     but that makes the form "dirty".
 
     To keep "dirty" false on initial load, I added it here.
@@ -84,7 +84,7 @@ export const convertEstimateToForm = (
   /* フォーム */
   return {
     estimateId: uuid.value,
-    estimateDataId: dataId.value,
+    estimateDataId: formatDataId(dataId.value),
     customerName: custName.value,
     projId: projId.value,
     projTypeProfit : +projTypeProfit.value,

--- a/packages/kokoas-client/src/pages/projEstimate/fieldComponents/EstimatesInfo.tsx
+++ b/packages/kokoas-client/src/pages/projEstimate/fieldComponents/EstimatesInfo.tsx
@@ -1,5 +1,4 @@
 import { Chip, FormControl, FormLabel, Stack, Typography } from '@mui/material';
-import { formatDataId } from 'libs';
 
 
 const LabeledInfo = ({
@@ -51,7 +50,7 @@ export const EstimatesInfo = ({
         <Stack direction={'row'} spacing={1}>
           <LabeledInfo
             label={'ID'}
-            info={formatDataId(id)}
+            info={id}
           />
           <LabeledInfo
             label={'作成日'}

--- a/packages/kokoas-client/src/pages/projRegister/FormConstruction.tsx
+++ b/packages/kokoas-client/src/pages/projRegister/FormConstruction.tsx
@@ -27,6 +27,7 @@ export const FormConstruction  = () => {
     storeId,
     territory,
     projTypeId,
+    projDataId,
     custGroupId,
   } = values;
 
@@ -39,7 +40,12 @@ export const FormConstruction  = () => {
       <ScrollToFieldError />
 
       <MainContainer>
-        <PageTitle label="工事情報登録" color="#60498C" textColor='#FFF' />
+        <PageTitle
+          label="工事情報登録"
+          color="#60498C"
+          textColor='#FFF'
+          secondaryLabel={projDataId}
+        />
         <Grid container item xl={8}
           spacing={2} mb={12}
         >


### PR DESCRIPTION

## 変更内容

- ブラウザのタブ名をメニュに合わせる
- データIDもタイトルに載せる。(見積画面、契約画面、工事登録)

## 変更理由

- https://trello.com/c/ElriYHht