### PR TITLE
T213 顧客登録：複数人の場合でも、連絡先を常に表示する

### DIFF
--- a/packages/kokoas-client/src/pages/customer/register/FormikIndividualCustomer.tsx
+++ b/packages/kokoas-client/src/pages/customer/register/FormikIndividualCustomer.tsx
@@ -1,5 +1,4 @@
 import { Formik } from 'formik';
-import {  validationSchema } from './form';
 import { FormIndividualCustomer } from './FormIndividualCustomer';
 import { useNavigate  } from 'react-router-dom';
 import { MemoContextProvider } from './parts/Memo/memoForm/MemoContext';
@@ -12,6 +11,7 @@ import { formToDBCustomers } from './helper/formToDBCustomers';
 import { formToDBCustGroup } from './helper/formToDBCustGroup';
 import { useEmployees } from '../../../hooksQuery';
 import { useResolveParam } from './hooks/useResolveParam';
+import { validationSchema } from './validationSchema';
 
 
 

--- a/packages/kokoas-client/src/pages/customer/register/form.ts
+++ b/packages/kokoas-client/src/pages/customer/register/form.ts
@@ -65,6 +65,8 @@ export const validationSchema =  Yup.object().shape(
           'custName': Yup.string().required('必須です。'),
           'custNameReading': Yup.string().required('必須です。'),
 
+
+
           'postal': Yup.string()
             .when(['isSameAddress', 'index'] as CustomerInstanceKeys[], {
               is: (isSameAddress: boolean, index: number) => {
@@ -73,28 +75,17 @@ export const validationSchema =  Yup.object().shape(
               then: Yup.string().matches(postalRegExp, '半角数字。例：4418124'),
             }),
 
-          'phone1': Yup.string()
-            .when('isSameAddress' as CustomerInstanceKeys, {
-              is: false,
-              then: Yup.string().matches(phoneRegExp, '半角数字。例：07012641265').required('必須です。'),
-            }),
+          'phone1': Yup.string().matches(phoneRegExp, '半角数字。例：07012641265').required('必須です。'),
+          'phone1Rel': Yup.string().required('連絡先の続柄を選択してください'),
 
-          'phone1Rel': Yup.string()
-            .when('isSameAddress' as CustomerInstanceKeys, {
-              is: false,
-              then: Yup.string().required('連絡先の続柄を選択してください'),
-            }),
-
-          'phone2': Yup.string()
-            .matches(phoneRegExp, '半角数字。例：07012641265'),
+          'phone2': Yup.string().matches(phoneRegExp, '半角数字。例：07012641265'),
           'phone2Rel': Yup.string()
             .when('phone2', {
               is: (val: string) => !!val,
               then: Yup.string().required('連絡先の続柄を選択してください'),
             }),
 
-          'email': Yup.string()
-            .email('有効なメールアドレスを入力ください。例：info@cocosumo.jp'),
+          'email': Yup.string().email('有効なメールアドレスを入力ください。例：info@cocosumo.jp'),
           'emailRel': Yup.string()
             .when('email', {
               is: (val: string) => !!val,

--- a/packages/kokoas-client/src/pages/customer/register/form.ts
+++ b/packages/kokoas-client/src/pages/customer/register/form.ts
@@ -1,6 +1,5 @@
-import * as Yup from 'yup';
+
 import { nativeMath, string as randomStr } from 'random-js';
-import { phoneRegExp, postalRegExp } from '../../../helpers/yupValidator';
 
 export const initialCustomerValue = {
   key: randomStr()(nativeMath, 5),
@@ -46,57 +45,6 @@ export type TypeOfForm = typeof initialValues;
 export type KeyOfForm = keyof TypeOfForm;
 export type CustomerInstance = typeof initialCustomerValue;
 export type  CustomerInstanceKeys = (keyof CustomerInstance);
-
-/**
- * Set Validation for fields that requires it.
- * Refer to YUM documentation.
- */
-export const validationSchema =  Yup.object().shape(
-  {
-    'store' : Yup
-      .string()
-      .required('必須です。'),
-    'cocoAG1' : Yup
-      .string()
-      .required('必須です。'),
-    'customers': Yup.array()
-      .of(
-        Yup.object().shape({
-          'custName': Yup.string().required('必須です。'),
-          'custNameReading': Yup.string().required('必須です。'),
-
-
-
-          'postal': Yup.string()
-            .when(['isSameAddress', 'index'] as CustomerInstanceKeys[], {
-              is: (isSameAddress: boolean, index: number) => {
-                return index === 0 || index > 0 && !isSameAddress;
-              },
-              then: Yup.string().matches(postalRegExp, '半角数字。例：4418124'),
-            }),
-
-          'phone1': Yup.string().matches(phoneRegExp, '半角数字。例：07012641265').required('必須です。'),
-          'phone1Rel': Yup.string().required('連絡先の続柄を選択してください'),
-
-          'phone2': Yup.string().matches(phoneRegExp, '半角数字。例：07012641265'),
-          'phone2Rel': Yup.string()
-            .when('phone2', {
-              is: (val: string) => !!val,
-              then: Yup.string().required('連絡先の続柄を選択してください'),
-            }),
-
-          'email': Yup.string().email('有効なメールアドレスを入力ください。例：info@cocosumo.jp'),
-          'emailRel': Yup.string()
-            .when('email', {
-              is: (val: string) => !!val,
-              then: Yup.string().required('連絡先の続柄を選択してください。'),
-            }),
-
-        } as Partial<Record<CustomerInstanceKeys, any>>),
-      ),
-  } as Partial<Record<KeyOfForm, any>>,
-);
-
 
 export const getCustFieldName = (fieldName : CustomerInstanceKeys) => fieldName;
 export const getFieldName = (fieldName: KeyOfForm) => fieldName;

--- a/packages/kokoas-client/src/pages/customer/register/helper/formToDBCustomers.ts
+++ b/packages/kokoas-client/src/pages/customer/register/helper/formToDBCustomers.ts
@@ -20,12 +20,6 @@ export const formToDBCustomers = (formData: TypeOfForm): Array<Partial<ICustomer
         postal : isSameAddress ? mainCust.postal : postal,
         address1 : isSameAddress ? mainCust.address1 : address1,
         address2: isSameAddress ? mainCust.address2 : address2,
-        phone1: isSameAddress ? '' : phone1,
-        phone1Rel: isSameAddress ? '' : phone1Rel,
-        phone2: isSameAddress ? '' : phone2,
-        phone2Rel: isSameAddress ? '' : phone2Rel,
-        email: isSameAddress ? '' : email,
-        emailRel: isSameAddress ? '' : emailRel,
       };
 
       return {
@@ -44,9 +38,9 @@ export const formToDBCustomers = (formData: TypeOfForm): Array<Partial<ICustomer
         contacts: {
           type: 'SUBTABLE',
           value: [
-            ['tel', deps.phone1, deps.phone1Rel],
-            ['tel', deps.phone2, deps.phone2Rel],
-            ['email', deps.email, deps.emailRel],
+            ['tel', phone1, phone1Rel],
+            ['tel', phone2, phone2Rel],
+            ['email', email, emailRel],
           ]
             .map(([type, val, rel]) => ({
               id: '',

--- a/packages/kokoas-client/src/pages/customer/register/parts/Customers/Address.tsx
+++ b/packages/kokoas-client/src/pages/customer/register/parts/Customers/Address.tsx
@@ -56,7 +56,7 @@ export const Address = (props: AddressProps) => {
     <>
       { !isFirstCustomer &&
       <Grid item xs={12}>
-        <FormikLabeledCheckBox name={`${namePrefix}${getCustFieldName('isSameAddress')}`} label="住所と連絡先は【契約者１】と同じ" defaultVal={isSameAddress} />
+        <FormikLabeledCheckBox name={`${namePrefix}${getCustFieldName('isSameAddress')}`} label="住所は【契約者１】と同じ" defaultVal={isSameAddress} />
       </Grid>}
 
       {!isSameAddress &&

--- a/packages/kokoas-client/src/pages/customer/register/parts/Customers/AddressFields.tsx
+++ b/packages/kokoas-client/src/pages/customer/register/parts/Customers/AddressFields.tsx
@@ -3,7 +3,6 @@ import { FormikTextFieldV2 as FormikTextField } from 'kokoas-client/src/componen
 import { useFormikContext } from 'formik';
 import { SearchAddress } from 'kokoas-client/src/components/ui/selects/address/SearchAddress';
 import { getCustFieldName, TypeOfForm } from '../../form';
-import { Contacts } from './Contacts';
 
 export const AddressFields = ({
   namePrefix,
@@ -46,7 +45,7 @@ export const AddressFields = ({
       <Grid item xs={12} mb={2}>
         <FormikTextField name={`${namePrefix}${getCustFieldName('address2')}`} label="住所（建物名）" placeholder='マンション山豊101' />
       </Grid>
-      <Contacts namePrefix={namePrefix} />
+
     </Grid>
   );
 };

--- a/packages/kokoas-client/src/pages/customer/register/parts/Customers/Customer.tsx
+++ b/packages/kokoas-client/src/pages/customer/register/parts/Customers/Customer.tsx
@@ -1,0 +1,83 @@
+import { Button, Grid } from '@mui/material';
+import { grey, yellow } from '@mui/material/colors';
+import { ArrayHelpers } from 'formik';
+import { PageSubTitle } from 'kokoas-client/src/components';
+import { getCustFieldName, TypeOfForm } from '../../form';
+import PersonRemoveIcon from '@mui/icons-material/PersonRemove';
+import { NameInput } from './NameInput';
+import { SelectGender } from './SelectGender';
+import { MemoizedSelectBirthdate } from './SelectBirthdate';
+import { Address } from './Address';
+
+
+interface CustomerProps extends ArrayHelpers {
+  customers: TypeOfForm['customers']
+  namePrefix: string,
+  index: number,
+}
+
+export const Customer =  (props: CustomerProps) => {
+  //const [animated, setAnimated] = useState(false);
+  const {
+    namePrefix,
+    index,
+    remove,
+    customers,
+
+  } = props;
+
+  const { birthYear, birthMonth } = customers[index] ?? { birthYear: '', birthMonth: '' };
+
+  const isFirstCustomer = !index;
+
+  const custNameFN = `${namePrefix}${getCustFieldName('custName')}`;
+  const custNameReadingFN = `${namePrefix}${getCustFieldName('custNameReading')}`;
+
+  return (
+    <Grid
+      container
+      item
+      xs={12}
+      spacing={2}
+      mb={2}
+      px={2}
+      pb={2}
+      sx={{
+        backgroundColor: (index % 2) ? yellow[50] : grey[50],
+      }}
+    >
+      <PageSubTitle label={`契約者${index + 1}`} xs={isFirstCustomer ? 12 : 8} />
+      {
+        !isFirstCustomer &&
+        <Grid
+          container
+          justifyContent={'flex-end'}
+          item
+          xs={4}
+        >
+
+          <Button variant="outlined" color="error"
+            onClick={()=>{
+              remove(index);
+            }}
+            startIcon={<PersonRemoveIcon />} fullWidth
+          >
+            削除
+          </Button>
+
+        </Grid>
+      }
+
+      <NameInput
+        custNameFN={custNameFN}
+        custNameReadingFN={custNameReadingFN}
+      />
+      <SelectGender namePrefix={namePrefix} />
+      <MemoizedSelectBirthdate namePrefix={namePrefix} birthYear={birthYear} birthMonth={birthMonth} />
+      <Address namePrefix={namePrefix} index={index} />
+
+
+    </Grid>
+
+  );
+};

--- a/packages/kokoas-client/src/pages/customer/register/parts/Customers/Customer.tsx
+++ b/packages/kokoas-client/src/pages/customer/register/parts/Customers/Customer.tsx
@@ -8,6 +8,7 @@ import { NameInput } from './NameInput';
 import { SelectGender } from './SelectGender';
 import { MemoizedSelectBirthdate } from './SelectBirthdate';
 import { Address } from './Address';
+import { Contacts } from './Contacts';
 
 
 interface CustomerProps extends ArrayHelpers {
@@ -75,7 +76,7 @@ export const Customer =  (props: CustomerProps) => {
       <SelectGender namePrefix={namePrefix} />
       <MemoizedSelectBirthdate namePrefix={namePrefix} birthYear={birthYear} birthMonth={birthMonth} />
       <Address namePrefix={namePrefix} index={index} />
-
+      <Contacts namePrefix={namePrefix} />
 
     </Grid>
 

--- a/packages/kokoas-client/src/pages/customer/register/parts/Customers/Customers.tsx
+++ b/packages/kokoas-client/src/pages/customer/register/parts/Customers/Customers.tsx
@@ -1,93 +1,11 @@
 import {  Button, Grid } from '@mui/material';
-import { PageSubTitle } from '../../../../../components/ui/labels';
-import { SelectGender } from './SelectGender';
-import { MemoizedSelectBirthdate } from './SelectBirthdate';
-import { FieldArray, ArrayHelpers, useFormikContext } from 'formik';
-import {  CustomerInstance, getCustFieldName, initialCustomerValue, KeyOfForm, TypeOfForm } from '../../form';
-import PersonRemoveIcon from '@mui/icons-material/PersonRemove';
+import { FieldArray, useFormikContext } from 'formik';
+import {  CustomerInstance, initialCustomerValue, KeyOfForm, TypeOfForm } from '../../form';
 import PersonAddIcon from '@mui/icons-material/PersonAdd';
-import { Address } from './Address';
 import { nativeMath, string as randomStr } from 'random-js';
-import { NameInput } from './NameInput';
-import { grey, yellow } from '@mui/material/colors';
-
-
-
-
-interface CustomerProps extends ArrayHelpers {
-  customers: TypeOfForm['customers']
-  namePrefix: string,
-  index: number,
-}
+import { Customer } from './Customer';
 
 const maxCust = 3;
-
-
-const Customer =  (props: CustomerProps) => {
-  //const [animated, setAnimated] = useState(false);
-  const {
-    namePrefix,
-    index,
-    remove,
-    customers,
-
-  } = props;
-
-  const { birthYear, birthMonth } = customers[index] ?? { birthYear: '', birthMonth: '' };
-
-  const isFirstCustomer = !index;
-
-  const custNameFN = `${namePrefix}${getCustFieldName('custName')}`;
-  const custNameReadingFN = `${namePrefix}${getCustFieldName('custNameReading')}`;
-
-  return (
-    <Grid
-      container
-      item
-      xs={12}
-      spacing={2}
-      mb={2}
-      px={2}
-      pb={2}
-      sx={{
-        backgroundColor: (index % 2) ? yellow[50] : grey[50],
-      }}
-    >
-      <PageSubTitle label={`契約者${index + 1}`} xs={isFirstCustomer ? 12 : 8} />
-      {
-        !isFirstCustomer &&
-        <Grid
-          container
-          justifyContent={'flex-end'}
-          item
-          xs={4}
-        >
-
-          <Button variant="outlined" color="error"
-            onClick={()=>{
-              remove(index);
-            }}
-            startIcon={<PersonRemoveIcon />} fullWidth
-          >
-            削除
-          </Button>
-
-        </Grid>
-      }
-
-      <NameInput
-        custNameFN={custNameFN}
-        custNameReadingFN={custNameReadingFN}
-      />
-      <SelectGender namePrefix={namePrefix} />
-      <MemoizedSelectBirthdate namePrefix={namePrefix} birthYear={birthYear} birthMonth={birthMonth} />
-      <Address namePrefix={namePrefix} index={index} />
-
-
-    </Grid>
-
-  );
-};
 
 export const Customers = () => {
   const { values: { customers } } = useFormikContext<TypeOfForm>();

--- a/packages/kokoas-client/src/pages/customer/register/validationSchema.ts
+++ b/packages/kokoas-client/src/pages/customer/register/validationSchema.ts
@@ -1,0 +1,53 @@
+import { phoneRegExp, postalRegExp } from 'kokoas-client/src/helpers/yupValidator';
+import * as Yup from 'yup';
+import { CustomerInstanceKeys, KeyOfForm } from './form';
+
+/**
+ * Set Validation for fields that requires it.
+ * Refer to YUM documentation.
+ */
+export const validationSchema =  Yup.object().shape(
+  {
+    'store' : Yup
+      .string()
+      .required('必須です。'),
+    'cocoAG1' : Yup
+      .string()
+      .required('必須です。'),
+    'customers': Yup.array()
+      .of(
+        Yup.object().shape({
+          'custName': Yup.string().required('必須です。'),
+          'custNameReading': Yup.string().required('必須です。'),
+
+
+
+          'postal': Yup.string()
+            .when(['isSameAddress', 'index'] as CustomerInstanceKeys[], {
+              is: (isSameAddress: boolean, index: number) => {
+                return index === 0 || index > 0 && !isSameAddress;
+              },
+              then: Yup.string().matches(postalRegExp, '半角数字。例：4418124'),
+            }),
+
+          'phone1': Yup.string().matches(phoneRegExp, '半角数字。例：07012641265').required('必須です。'),
+          'phone1Rel': Yup.string().required('連絡先の続柄を選択してください'),
+
+          'phone2': Yup.string().matches(phoneRegExp, '半角数字。例：07012641265'),
+          'phone2Rel': Yup.string()
+            .when('phone2', {
+              is: (val: string) => !!val,
+              then: Yup.string().required('連絡先の続柄を選択してください'),
+            }),
+
+          'email': Yup.string().email('有効なメールアドレスを入力ください。例：info@cocosumo.jp'),
+          'emailRel': Yup.string()
+            .when('email', {
+              is: (val: string) => !!val,
+              then: Yup.string().required('連絡先の続柄を選択してください。'),
+            }),
+
+        } as Partial<Record<CustomerInstanceKeys, any>>),
+      ),
+  } as Partial<Record<KeyOfForm, any>>,
+);


### PR DESCRIPTION
## 変更内容

- 住所は連絡先は【契約者１】と同じ →　住所は【契約者１】と同じ
- 連絡先を常に表示するようになりました。
- そこに関わるバリデーションと保存処理の更新
- ついでに、リファクタリングをしました。（ファイル分割）

## 変更理由

- https://trello.com/c/hEejGfY9