### PR TITLE
見積：スピード改善

### DIFF
--- a/packages/kokoas-client/src/components/ui/selects/FormikSelect.tsx
+++ b/packages/kokoas-client/src/components/ui/selects/FormikSelect.tsx
@@ -8,6 +8,7 @@ export interface FormikSelecProps extends ComponentProps<typeof Select> {
   name: string,
   label?: string
   helperText?: string
+  enabledFormikBlur?: boolean,
   options?: Options,
   onChange?: (e: SelectChangeEvent, label: string) => void
 }
@@ -24,6 +25,7 @@ export function FormikSelect(props : FormikSelecProps) {
     onChange,
     variant = 'outlined',
     name,
+    enabledFormikBlur = true,
     ...otherSelectProps
   } = props;
 
@@ -91,6 +93,11 @@ export function FormikSelect(props : FormikSelecProps) {
         label={label}
         required={required}
         value={field.value}
+        onBlur={(e) => {
+          if (enabledFormikBlur) {
+            field.onBlur(e);
+          }
+        }}
         onChange={(e)=>{
           const newVal = e.target.value ;
           const newValText = options?.find((option) => option.value === newVal)?.label;

--- a/packages/kokoas-client/src/components/ui/textfield/FormikTextFieldV2.tsx
+++ b/packages/kokoas-client/src/components/ui/textfield/FormikTextFieldV2.tsx
@@ -13,6 +13,7 @@ import { useFieldFast } from '../../../hooks/useFieldFast';
 export const FormikTextFieldV2 = (
   props: TextFieldProps & {
     name: string,
+    enabledFormikBlur?: boolean
   },
 ) => {
   const {
@@ -21,6 +22,7 @@ export const FormikTextFieldV2 = (
     onBlur,
     fullWidth = true,
     helperText,
+    enabledFormikBlur = true,
     ...others
   } = props;
   const [field, meta, helpers] = useFieldFast(name);
@@ -53,7 +55,9 @@ export const FormikTextFieldV2 = (
       value={inputValue || ''}
       onChange={handleChange}
       onBlur={((e)=>{
-        field.onBlur(e);
+        if (enabledFormikBlur) {
+          field.onBlur(e);
+        }
         onBlur?.(e);
       })}
       error={isShowError}

--- a/packages/kokoas-client/src/components/ui/textfield/FormikTextFieldV2.tsx
+++ b/packages/kokoas-client/src/components/ui/textfield/FormikTextFieldV2.tsx
@@ -50,7 +50,7 @@ export const FormikTextFieldV2 = (
     <TextField
       {...others}
       {...field}
-      value={inputValue ?? ''}
+      value={inputValue || ''}
       onChange={handleChange}
       onBlur={((e)=>{
         field.onBlur(e);

--- a/packages/kokoas-client/src/pages/projEstimate/FormProjEstimate.tsx
+++ b/packages/kokoas-client/src/pages/projEstimate/FormProjEstimate.tsx
@@ -20,6 +20,8 @@ import { useConfirmBeforeClose } from './hooks/useConfirmBeforeClose';
 import { useSaveHotkey } from './hooks/useSaveHotkey';
 import { EstimateTableLabel } from './fieldComponents/EstimateTableLabel';
 
+const itemsFieldName = getFieldName('items');
+
 export default function FormProjEstimate() {
   const {
     values,
@@ -126,7 +128,7 @@ export default function FormProjEstimate() {
           <Grid item xs={12} md={12}>
             {/* 見積もり内訳のテーブル */}
             <FieldArray
-              name={getFieldName('items')}
+              name={itemsFieldName}
               render={renderQuoteTable}
             />
           </Grid>

--- a/packages/kokoas-client/src/pages/projEstimate/FormProjEstimate.tsx
+++ b/packages/kokoas-client/src/pages/projEstimate/FormProjEstimate.tsx
@@ -61,7 +61,7 @@ export default function FormProjEstimate() {
         <Grid item xs={12} md>
 
           {/* 編集中の見積もり情報 */}
-          {projId &&
+          {!!projId &&
             <EstimatesInfo
               estimateId={estimateId}
               id={estimateDataId}

--- a/packages/kokoas-client/src/pages/projEstimate/FormikProjEstimate.tsx
+++ b/packages/kokoas-client/src/pages/projEstimate/FormikProjEstimate.tsx
@@ -26,7 +26,6 @@ export const FormikProjEstimate = () => {
       initialStatus={((s: TFormStatus)=>s)('busy')}
       enableReinitialize
       validateOnBlur={false}
-      validateOnChange={false}
       validateOnMount={false}
       validationSchema={validationSchema}
       onSubmit={async (values, { setSubmitting }) => {

--- a/packages/kokoas-client/src/pages/projEstimate/FormikProjEstimate.tsx
+++ b/packages/kokoas-client/src/pages/projEstimate/FormikProjEstimate.tsx
@@ -26,6 +26,8 @@ export const FormikProjEstimate = () => {
       initialStatus={((s: TFormStatus)=>s)('busy')}
       enableReinitialize
       validateOnBlur={false}
+      validateOnChange={false}
+      validateOnMount={false}
       validationSchema={validationSchema}
       onSubmit={async (values, { setSubmitting }) => {
         const { saveMode, estimateId  } = values;

--- a/packages/kokoas-client/src/pages/projEstimate/QuoteTable/QuoteTableBody.tsx
+++ b/packages/kokoas-client/src/pages/projEstimate/QuoteTable/QuoteTableBody.tsx
@@ -1,5 +1,5 @@
 import { TableBody } from '@mui/material';
-import { FieldArrayRenderProps, useFormikContext } from 'formik';
+import { useFormikContext } from 'formik';
 import { MouseEvent, useState } from 'react';
 import { TypeOfForm } from '../form';
 import { QuoteTableRow } from './QuoteTableRow';
@@ -7,13 +7,10 @@ import { UnitTypeMenu } from './rowFields/UnitTypeMenu';
 
 
 
-export  function QuoteTableBody(props: {
-  arrayHelpers: FieldArrayRenderProps,
-}) {
-  const { setFieldValue } = useFormikContext<TypeOfForm>();
-  const { arrayHelpers } = props;
-  const { form } = arrayHelpers;
-  const { items, envStatus } = form.values as TypeOfForm;
+export const QuoteTableBody = () => {
+  const { setFieldValue, values } = useFormikContext<TypeOfForm>();
+  const { items, envStatus } = values;
+
 
   const [unitMenuAnchorEl, setUnitMenuAnchorEl] = useState<null | HTMLButtonElement>(null);
 
@@ -38,7 +35,6 @@ export  function QuoteTableBody(props: {
 
           <QuoteTableRow
             rowIdx={itemsIdx}
-            arrayHelpers={arrayHelpers}
             key={item.key}
             envStatus={envStatus}
             handleOpenUnitMenu={handleOpenUnitMenu}
@@ -53,4 +49,4 @@ export  function QuoteTableBody(props: {
     </TableBody>
   );
 
-}
+};

--- a/packages/kokoas-client/src/pages/projEstimate/QuoteTable/QuoteTableBody.tsx
+++ b/packages/kokoas-client/src/pages/projEstimate/QuoteTable/QuoteTableBody.tsx
@@ -1,6 +1,6 @@
 import { TableBody } from '@mui/material';
 import { useFormikContext } from 'formik';
-import { MouseEvent, useState } from 'react';
+import { MouseEvent, useCallback, useEffect, useState } from 'react';
 import { TypeOfForm } from '../form';
 import { QuoteTableRow } from './QuoteTableRow';
 import { UnitTypeMenu } from './rowFields/UnitTypeMenu';
@@ -8,16 +8,18 @@ import { UnitTypeMenu } from './rowFields/UnitTypeMenu';
 
 
 export const QuoteTableBody = () => {
-  const { setFieldValue, values } = useFormikContext<TypeOfForm>();
+  const { setFieldValue, values, touched, dirty } = useFormikContext<TypeOfForm>();
   const { items, envStatus } = values;
+
+  useEffect(() => console.log(touched, dirty ), [touched, dirty]);
 
 
   const [unitMenuAnchorEl, setUnitMenuAnchorEl] = useState<null | HTMLButtonElement>(null);
 
-  const handleOpenUnitMenu = ({ currentTarget }: MouseEvent<HTMLButtonElement>) => {
+  const handleOpenUnitMenu = useCallback(({ currentTarget }: MouseEvent<HTMLButtonElement>) => {
     setUnitMenuAnchorEl(currentTarget);
 
-  };
+  }, []);
 
   const handleClose = ( value?: string) => {
     if (unitMenuAnchorEl?.name && !!value) {

--- a/packages/kokoas-client/src/pages/projEstimate/QuoteTable/QuoteTableBody.tsx
+++ b/packages/kokoas-client/src/pages/projEstimate/QuoteTable/QuoteTableBody.tsx
@@ -1,6 +1,6 @@
 import { TableBody } from '@mui/material';
 import { useFormikContext } from 'formik';
-import { MouseEvent, useCallback, useEffect, useState } from 'react';
+import { MouseEvent, useCallback, useState } from 'react';
 import { TypeOfForm } from '../form';
 import { QuoteTableRow } from './QuoteTableRow';
 import { UnitTypeMenu } from './rowFields/UnitTypeMenu';

--- a/packages/kokoas-client/src/pages/projEstimate/QuoteTable/QuoteTableBody.tsx
+++ b/packages/kokoas-client/src/pages/projEstimate/QuoteTable/QuoteTableBody.tsx
@@ -8,11 +8,8 @@ import { UnitTypeMenu } from './rowFields/UnitTypeMenu';
 
 
 export const QuoteTableBody = () => {
-  const { setFieldValue, values, touched, dirty } = useFormikContext<TypeOfForm>();
+  const { setFieldValue, values } = useFormikContext<TypeOfForm>();
   const { items, envStatus } = values;
-
-  useEffect(() => console.log(touched, dirty ), [touched, dirty]);
-
 
   const [unitMenuAnchorEl, setUnitMenuAnchorEl] = useState<null | HTMLButtonElement>(null);
 

--- a/packages/kokoas-client/src/pages/projEstimate/QuoteTable/QuoteTableRow.tsx
+++ b/packages/kokoas-client/src/pages/projEstimate/QuoteTable/QuoteTableRow.tsx
@@ -113,6 +113,7 @@ export const QuoteTableRow = (
           />
           <FormikTextFieldV2
             disabled={isDisabled}
+            enabledFormikBlur={false}
             name={getItemFieldName(rowIdx, 'materialDetails')}
             size={'small'}
             multiline
@@ -194,6 +195,7 @@ export const QuoteTableRow = (
         <TableCell colSpan={4}>
           <FormikTextFieldV2
             disabled={isDisabled}
+            enabledFormikBlur={false}
             name={getItemFieldName(rowIdx, 'rowDetails')}
             size={'small'}
             multiline

--- a/packages/kokoas-client/src/pages/projEstimate/QuoteTable/QuoteTableRow.tsx
+++ b/packages/kokoas-client/src/pages/projEstimate/QuoteTable/QuoteTableRow.tsx
@@ -1,7 +1,7 @@
 
 
 import { IconButton, SxProps, TableCell, TableRow } from '@mui/material';
-import { FieldArrayRenderProps, useFormikContext } from 'formik';
+import { useFormikContext } from 'formik';
 import { FormikAutocomplete } from '../fieldComponents/FormikAutocomplete';
 import { getItemFieldName, TypeOfForm } from '../form';
 import { useMaterialsOptions } from '../hooks/useMaterialOptions';
@@ -24,12 +24,10 @@ import { headers } from './QuoteTableHead';
 export const QuoteTableRow = (
   {
     rowIdx,
-    arrayHelpers,
     envStatus,
     handleOpenUnitMenu,
   }: {
     rowIdx: number,
-    arrayHelpers: FieldArrayRenderProps,
     envStatus: string,
     handleOpenUnitMenu: (e: MouseEvent<HTMLButtonElement>) => void
   }) => {
@@ -66,7 +64,6 @@ export const QuoteTableRow = (
       <TableRow
         id={key}
         ref={rowMainRef}
-        component={'tr'}
         onFocus={handleFocus}
         onBlur={handleFocus}
         sx={rowSx}
@@ -80,7 +77,7 @@ export const QuoteTableRow = (
           }}
         >
           {!isDisabled && !isLastRow && (
-            <QtRowMove rowIdx={rowIdx} arrayHelpers={arrayHelpers} />
+            <QtRowMove rowIdx={rowIdx} />
           )}
         </TableCell>
 
@@ -184,10 +181,7 @@ export const QuoteTableRow = (
 
         <TableCell width={headers[9].width}>
           {!isDisabled && !isLastRow &&
-          <QtRowAddDelete
-            rowIdx={rowIdx}
-            arrayHelpers={arrayHelpers}
-          />}
+          <QtRowAddDelete rowIdx={rowIdx}  />}
         </TableCell>
 
       </TableRow>

--- a/packages/kokoas-client/src/pages/projEstimate/QuoteTable/QuoteTableRow.tsx
+++ b/packages/kokoas-client/src/pages/projEstimate/QuoteTable/QuoteTableRow.tsx
@@ -86,7 +86,6 @@ export const QuoteTableRow = (
           width={headers[1].width}
         >
           <FormikAutocomplete
-            tabIndex={1}
             name={getItemFieldName(rowIdx, 'majorItem')}
             handleChange={handleMajorItemChange}
             freeSolo={false}

--- a/packages/kokoas-client/src/pages/projEstimate/QuoteTable/renderQuoteTable.tsx
+++ b/packages/kokoas-client/src/pages/projEstimate/QuoteTable/renderQuoteTable.tsx
@@ -1,8 +1,6 @@
 import Table from '@mui/material/Table';
 import TableContainer from '@mui/material/TableContainer';
 import Paper from '@mui/material/Paper';
-
-import { FieldArrayRenderProps } from 'formik';
 import { QuoteTableHead, QuoteTableBody } from './';
 import { QuoteTableActions } from './QuoteTableActions';
 
@@ -12,7 +10,7 @@ import { QuoteTableActions } from './QuoteTableActions';
  * @param arrayHelpers
  * @returns
  */
-export function renderQuoteTable(arrayHelpers : FieldArrayRenderProps) {
+export function renderQuoteTable() {
 
   return (
     <>
@@ -43,7 +41,7 @@ export function renderQuoteTable(arrayHelpers : FieldArrayRenderProps) {
 
           }}
         >
-          <QuoteTableBody arrayHelpers={arrayHelpers}  />
+          <QuoteTableBody />
 
         </Table>
         <QuoteTableActions />

--- a/packages/kokoas-client/src/pages/projEstimate/QuoteTable/rowActions/QtRowAddDelete.tsx
+++ b/packages/kokoas-client/src/pages/projEstimate/QuoteTable/rowActions/QtRowAddDelete.tsx
@@ -1,26 +1,30 @@
 import MoreVertIcon from '@mui/icons-material/MoreVert';
 import { IconButton, Menu, MenuItem } from '@mui/material';
-import { FieldArrayRenderProps } from 'formik';
+import { useFormikContext } from 'formik';
 import { useState } from 'react';
-import { initialValues, TMaterials, TypeOfForm } from '../../form';
-import { v4 as uuidv4 } from 'uuid';
+import { TypeOfForm } from '../../form';
 import { HotKeyTooltip } from 'kokoas-client/src/components';
+import { useManipulateItems } from '../../hooks/useManipulateItems';
 
 export const QtRowAddDelete = ({
-  rowIdx, arrayHelpers,
+  rowIdx,
 } :{
   rowIdx: number
-  arrayHelpers: FieldArrayRenderProps
 }) => {
-
+  const { values } = useFormikContext<TypeOfForm>();
 
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
   const open = Boolean(anchorEl);
-  const { form, remove, insert } = arrayHelpers;
-  const { items, projTypeProfit } = form.values as TypeOfForm;
-  const currentItem = items[rowIdx];
+
+  const { items } = values;
 
   const isJustOneRow = items.length === 1;
+
+  const {
+    handleCopyItemBelow,
+    handleInsertItemBelow,
+    handleRemoveItem,
+  } = useManipulateItems(rowIdx);
 
   const handleOpenMenu = (event: React.MouseEvent<HTMLButtonElement>) => {
     setAnchorEl(event.currentTarget);
@@ -30,31 +34,7 @@ export const QtRowAddDelete = ({
     setAnchorEl(null);
   };
 
-  const handleRemoveRow = () => {
-    remove(rowIdx);
-    handleClose();
-  };
 
-  const handleAddToRowBelow = () => {
-    const newRow: TMaterials = {
-      ...initialValues.items[0],
-      key: uuidv4(),
-      elemProfRate: projTypeProfit,
-    };
-
-    insert(rowIdx + 1, newRow);
-    handleClose();
-  };
-
-  const handleCopyToRowBelow = () => {
-    const newRow: TMaterials = {
-      ...currentItem,
-      key: uuidv4(),
-      //elemProfRate: projTypeProfit,
-    };
-    insert(rowIdx + 1, newRow);
-    handleClose();
-  };
 
   return (
     <>
@@ -72,7 +52,7 @@ export const QtRowAddDelete = ({
 
       >
         <HotKeyTooltip title={'insert'}>
-          <MenuItem onClick={handleAddToRowBelow}>
+          <MenuItem onClick={handleInsertItemBelow}>
             下に追加
           </MenuItem>
         </HotKeyTooltip>
@@ -80,13 +60,13 @@ export const QtRowAddDelete = ({
         <HotKeyTooltip title={'ctrl + delete'}>
           <MenuItem
             disabled={isJustOneRow}
-            onClick={handleRemoveRow}
+            onClick={handleRemoveItem}
           >
             削除
           </MenuItem>
         </HotKeyTooltip>
 
-        <MenuItem onClick={handleCopyToRowBelow}>
+        <MenuItem onClick={handleCopyItemBelow}>
           下にコピー
         </MenuItem>
 

--- a/packages/kokoas-client/src/pages/projEstimate/QuoteTable/rowActions/QtRowMove.tsx
+++ b/packages/kokoas-client/src/pages/projEstimate/QuoteTable/rowActions/QtRowMove.tsx
@@ -1,20 +1,20 @@
 import { IconButton, Stack, SxProps, Theme } from '@mui/material';
 import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp';
 import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
-import { FieldArrayRenderProps, FormikProps } from 'formik';
+import { useFormikContext } from 'formik';
 import { TypeOfForm } from '../../form';
-import { useState } from 'react';
+import { useCallback, useState } from 'react';
 import { QtRowMoveAnywhere } from './QtRowMoveAnywhere';
+import { useMoveItem } from '../../hooks/useMoveItem';
+
 
 export const QtRowMove = ({
-  rowIdx, arrayHelpers,
+  rowIdx,
 }: {
   rowIdx: number
-  arrayHelpers: FieldArrayRenderProps,
 }) => {
+  const { values: { envStatus, items } } = useFormikContext<TypeOfForm>();
   const [expandBtns, setExpandBtns] = useState(false);
-  const { form, move } = arrayHelpers;
-  const { values: { envStatus, items } } = form as FormikProps<TypeOfForm>;
 
   const transitionStyle = (isTop: boolean): SxProps<Theme> => {
     const shiftPx = isTop ? -14 : 14;
@@ -25,13 +25,15 @@ export const QtRowMove = ({
     };
   };
 
+  const move = useMoveItem();
+
   const isAtBottom = rowIdx === (items.length - 1);
   const isAtTop = rowIdx === 0;
   const isVisible = !envStatus;
 
-  const handleMoveRowUp = () => move(rowIdx, rowIdx - 1);
+  const handleMoveRowUp = useCallback(() => move(rowIdx, rowIdx - 1), [move, rowIdx]);
 
-  const handleMoveRowDown = () => move(rowIdx, rowIdx + 1);
+  const handleMoveRowDown = useCallback(() => move(rowIdx, rowIdx + 1), [move, rowIdx]);
 
   return (
 

--- a/packages/kokoas-client/src/pages/projEstimate/QuoteTable/rowFields/CostPriceField.tsx
+++ b/packages/kokoas-client/src/pages/projEstimate/QuoteTable/rowFields/CostPriceField.tsx
@@ -26,6 +26,7 @@ export const CostPriceField = ({
       name={name}
       size={'small'}
       disabled={isDisabled}
+      enabledFormikBlur={false}
       onChange={handleChange}
       onFocus={({ target }) => target.select()}
     />

--- a/packages/kokoas-client/src/pages/projEstimate/QuoteTable/rowFields/ProfitRateField.tsx
+++ b/packages/kokoas-client/src/pages/projEstimate/QuoteTable/rowFields/ProfitRateField.tsx
@@ -31,6 +31,7 @@ export const ProfitRateField = ({
       name={name}
       size={'small'}
       disabled={isDisabled}
+      enabledFormikBlur={false}
       onChange={handleChange}
       onFocus={({ target }) => target.select()}
       InputProps={{

--- a/packages/kokoas-client/src/pages/projEstimate/QuoteTable/rowFields/QuantityField.tsx
+++ b/packages/kokoas-client/src/pages/projEstimate/QuoteTable/rowFields/QuantityField.tsx
@@ -34,6 +34,7 @@ export const QuantityField = ({
       name={name}
       size={'small'}
       disabled={isDisabled}
+      enabledFormikBlur={false}
       onChange={handleChange}
       onFocus={({ target }) => target.select()}
       InputProps={{

--- a/packages/kokoas-client/src/pages/projEstimate/QuoteTable/rowFields/RowUnitPriceAfterTax.tsx
+++ b/packages/kokoas-client/src/pages/projEstimate/QuoteTable/rowFields/RowUnitPriceAfterTax.tsx
@@ -29,6 +29,7 @@ export const RowUnitPriceAfterTax = ({
       name={name}
       size={'small'}
       disabled={isDisabled}
+      enabledFormikBlur={false}
       onChange={handleChange}
       onFocus={({ target }) => target.select()}
     />

--- a/packages/kokoas-client/src/pages/projEstimate/QuoteTable/rowFields/TaxTypeField.tsx
+++ b/packages/kokoas-client/src/pages/projEstimate/QuoteTable/rowFields/TaxTypeField.tsx
@@ -29,6 +29,7 @@ export const TaxTypeField = ({
       label=''
       name={name}
       size={'small'}
+      enabledFormikBlur={false}
       options={taxChoices.map((c) => ({ label: c, value: c }))}
       disabled={isDisabled}
       onChange={handleChange}

--- a/packages/kokoas-client/src/pages/projEstimate/QuoteTable/rowFields/UnitPriceField.tsx
+++ b/packages/kokoas-client/src/pages/projEstimate/QuoteTable/rowFields/UnitPriceField.tsx
@@ -29,6 +29,7 @@ export const UnitPriceField = ({
       name={name}
       size={'small'}
       disabled={isDisabled}
+      enabledFormikBlur={false}
       onChange={handleChange}
       onFocus={({ target }) => target.select()}
     />

--- a/packages/kokoas-client/src/pages/projEstimate/QuoteTable/rowFields/UnitTypeMenu.tsx
+++ b/packages/kokoas-client/src/pages/projEstimate/QuoteTable/rowFields/UnitTypeMenu.tsx
@@ -12,13 +12,9 @@ export const UnitTypeMenu = ({
 }) => {
   return (
     <Menu
-      id="basic-menu"
       anchorEl={anchorEl}
       open={open}
       onClose={()=>handleClose()}
-      MenuListProps={{
-        'aria-labelledby': 'basic-button',
-      }}
     >
       {unitChoices.map((unit) => (
         <MenuItem key={unit} onClick={()=>handleClose(unit)}>

--- a/packages/kokoas-client/src/pages/projEstimate/fieldComponents/FormikAutocomplete.tsx
+++ b/packages/kokoas-client/src/pages/projEstimate/fieldComponents/FormikAutocomplete.tsx
@@ -1,7 +1,6 @@
 import { Autocomplete, AutocompleteRenderInputParams, FormControl, FormHelperText, TextField, TextFieldProps } from '@mui/material';
 import { useFieldFast } from 'kokoas-client/src/hooks/useFieldFast';
-import { ComponentProps, SyntheticEvent, useCallback, useEffect, useMemo, useState } from 'react';
-import { Options } from 'types';
+import { ComponentProps, SyntheticEvent, useCallback, useEffect, useState } from 'react';
 import { useDebounce } from 'usehooks-ts';
 
 /*
@@ -24,7 +23,7 @@ export const FormikAutocomplete = (
     ...otherAutoCompleteProps
   }: Omit<ComponentProps<typeof Autocomplete>, 'renderInput'> & {
     name: string,
-    options: Options
+    options: string[]
     handleChange?: (newVal?: string) => void
     disabled?: boolean
     variant?: TextFieldProps['variant']
@@ -46,8 +45,6 @@ export const FormikAutocomplete = (
   useEffect(() => {
     setInputValue(field.value);
   }, [field.value]);
-
-  const simpleOptions = useMemo(() => (options as Options).map(({ value }) => value), [options]);
 
   const handleAccept = useCallback((_: SyntheticEvent, newValue : string) => {
     setInputValue(newValue);
@@ -78,7 +75,7 @@ export const FormikAutocomplete = (
         value={inputValue}
         onChange={handleAccept}
         onInputChange={handleInputChange}
-        options={simpleOptions}
+        options={options}
         renderInput={handleRenderInput}
         disabled={disabled}
       />

--- a/packages/kokoas-client/src/pages/projEstimate/fieldComponents/FormikAutocomplete.tsx
+++ b/packages/kokoas-client/src/pages/projEstimate/fieldComponents/FormikAutocomplete.tsx
@@ -1,6 +1,6 @@
-import { Autocomplete, FormControl, FormHelperText, TextField, TextFieldProps } from '@mui/material';
+import { Autocomplete, AutocompleteRenderInputParams, FormControl, FormHelperText, TextField, TextFieldProps } from '@mui/material';
 import { useFieldFast } from 'kokoas-client/src/hooks/useFieldFast';
-import { ComponentProps, useEffect, useMemo, useState } from 'react';
+import { ComponentProps, SyntheticEvent, useCallback, useEffect, useMemo, useState } from 'react';
 import { Options } from 'types';
 import { useDebounce } from 'usehooks-ts';
 
@@ -49,6 +49,25 @@ export const FormikAutocomplete = (
 
   const simpleOptions = useMemo(() => (options as Options).map(({ value }) => value), [options]);
 
+  const handleAccept = useCallback((_: SyntheticEvent, newValue : string) => {
+    setInputValue(newValue);
+    handleChange?.(newValue);
+  }, [handleChange]);
+
+  const handleInputChange = useCallback((_: SyntheticEvent, newValue : string) => {
+    if (freeSolo) {
+      setInputValue(newValue);
+    }
+  }, [freeSolo]);
+
+  const handleRenderInput = useCallback((params: AutocompleteRenderInputParams) =>(
+    <TextField {...params}
+      type="search"
+      size="small"
+      variant={variant}
+    />
+  ), [variant]);
+
   return (
     <FormControl variant="standard" size='small' fullWidth>
       <Autocomplete
@@ -57,24 +76,10 @@ export const FormikAutocomplete = (
         fullWidth
         freeSolo={freeSolo}
         value={inputValue}
-        onChange={(_, newValue : string) => {
-          setInputValue(newValue);
-          handleChange?.(newValue);
-        }}
-        onInputChange={(_, newValue) => {
-          if (freeSolo) {
-            setInputValue(newValue);
-          }
-        }}
+        onChange={handleAccept}
+        onInputChange={handleInputChange}
         options={simpleOptions}
-        renderInput={(params) =>
-          (
-            <TextField {...params}
-              type="search"
-              size="small"
-              variant={variant}
-            />
-          )}
+        renderInput={handleRenderInput}
         disabled={disabled}
       />
       {(!!error && touched) &&

--- a/packages/kokoas-client/src/pages/projEstimate/fieldComponents/FormikAutocomplete.tsx
+++ b/packages/kokoas-client/src/pages/projEstimate/fieldComponents/FormikAutocomplete.tsx
@@ -1,4 +1,4 @@
-import { Autocomplete, AutocompleteRenderInputParams, FormControl, FormHelperText, TextField, TextFieldProps } from '@mui/material';
+import { Autocomplete, AutocompleteRenderInputParams, TextField, TextFieldProps } from '@mui/material';
 import { useFieldFast } from 'kokoas-client/src/hooks/useFieldFast';
 import { ComponentProps, SyntheticEvent, useCallback, useEffect, useState } from 'react';
 import { useDebounce } from 'usehooks-ts';
@@ -31,7 +31,7 @@ export const FormikAutocomplete = (
 ) => {
 
   const [field, meta, helper] = useFieldFast(name);
-  const { touched, error } = meta;
+  const { error } = meta;
   const { setValue } = helper;
   const [inputValue, setInputValue] = useState<string>(field.value);
   const debouncedValue = useDebounce<string>(inputValue, 800);
@@ -58,31 +58,26 @@ export const FormikAutocomplete = (
   }, [freeSolo]);
 
   const handleRenderInput = useCallback((params: AutocompleteRenderInputParams) =>(
-    <TextField {...params}
+    <TextField 
+      {...params}
       type="search"
       size="small"
       variant={variant}
+      helperText={error ? error : ''}
     />
-  ), [variant]);
+  ), [variant, error]);
 
   return (
-    <FormControl variant="standard" size='small' fullWidth>
-      <Autocomplete
-        {...field}
-        {...otherAutoCompleteProps}
-        fullWidth
-        freeSolo={freeSolo}
-        value={inputValue}
-        onChange={handleAccept}
-        onInputChange={handleInputChange}
-        options={options}
-        renderInput={handleRenderInput}
-        disabled={disabled}
-      />
-      {(!!error && touched) &&
-        <FormHelperText error={!!error && touched}>
-          {error}
-        </FormHelperText>}
-    </FormControl>
+    <Autocomplete
+      {...otherAutoCompleteProps}
+      fullWidth
+      freeSolo={freeSolo}
+      value={inputValue}
+      onChange={handleAccept}
+      onInputChange={handleInputChange}
+      options={options}
+      renderInput={handleRenderInput}
+      disabled={disabled}
+    />
   );
 };

--- a/packages/kokoas-client/src/pages/projEstimate/hooks/useAdvancedTableRow.ts
+++ b/packages/kokoas-client/src/pages/projEstimate/hooks/useAdvancedTableRow.ts
@@ -15,6 +15,7 @@ export const useAdvancedTableRow = (rowIdx : number) => {
     values,
   } = useFormikContext<TypeOfForm>();
   const { envStatus } = values;
+  const [focused, setFocused] = useState(false);
 
   const isWithContract = !!envStatus;
   const {
@@ -40,11 +41,10 @@ export const useAdvancedTableRow = (rowIdx : number) => {
     }
   }, [isLastRowModified, rowIdx, isWithContract, setValues, getNewRow]);
 
-  const [focused, setFocused] = useState(false);
+
 
   const handleFocus : FocusEventHandler = useCallback(
     (e) => {
-      //
       if (!isLastRow) return;
 
       const currentTarget = e.currentTarget;

--- a/packages/kokoas-client/src/pages/projEstimate/hooks/useManipulateItems.tsx
+++ b/packages/kokoas-client/src/pages/projEstimate/hooks/useManipulateItems.tsx
@@ -1,0 +1,39 @@
+import { useFormikContext } from 'formik';
+import { produce } from 'immer';
+import { useCallback } from 'react';
+import { TypeOfForm } from '../form';
+import { useInitialRow } from './useInitialRow';
+
+export const useManipulateItems = (rowIdx: number) => {
+  const { setValues } = useFormikContext<TypeOfForm>();
+
+  const {
+    getNewRow,
+  } = useInitialRow();
+
+  const handleInsertItemBelow = useCallback(() => {
+    setValues((prev) => produce(prev, ({ items }) => {
+      items.splice(rowIdx + 1, 0, getNewRow());
+    }));
+  }, [setValues, getNewRow, rowIdx]);
+
+  const handleCopyItemBelow = useCallback(() => {
+    setValues((prev) => produce(prev, ({ items }) => {
+      const newRow = items[rowIdx];
+
+      items.splice(rowIdx + 1, 0, newRow);
+    }));
+  }, [setValues, rowIdx]);
+
+  const handleRemoveItem = useCallback(() => {
+    setValues((prev) => produce(prev, ({ items }) => {
+      items.splice(rowIdx, 1);
+    }));
+  }, [setValues, rowIdx]);
+
+  return {
+    handleInsertItemBelow,
+    handleCopyItemBelow,
+    handleRemoveItem,
+  };
+};

--- a/packages/kokoas-client/src/pages/projEstimate/hooks/useManipulateItems.tsx
+++ b/packages/kokoas-client/src/pages/projEstimate/hooks/useManipulateItems.tsx
@@ -3,6 +3,7 @@ import { produce } from 'immer';
 import { useCallback } from 'react';
 import { TypeOfForm } from '../form';
 import { useInitialRow } from './useInitialRow';
+import { v4 as uuidV4 } from 'uuid';
 
 export const useManipulateItems = (rowIdx: number) => {
   const { setValues } = useFormikContext<TypeOfForm>();
@@ -21,7 +22,13 @@ export const useManipulateItems = (rowIdx: number) => {
     setValues((prev) => produce(prev, ({ items }) => {
       const newRow = items[rowIdx];
 
-      items.splice(rowIdx + 1, 0, newRow);
+      items.splice(
+        rowIdx + 1, 0,
+        {
+          ...newRow,
+          key: uuidV4(),
+        },
+      );
     }));
   }, [setValues, rowIdx]);
 

--- a/packages/kokoas-client/src/pages/projEstimate/hooks/useMaterialOptions.ts
+++ b/packages/kokoas-client/src/pages/projEstimate/hooks/useMaterialOptions.ts
@@ -21,7 +21,9 @@ export const useMaterialsOptions = (
     data: majorItemOpts = [],
   } = useMaterialsMajor({
     select: useCallback((d) => {
-      return d.map(({ 大項目名 }) => 大項目名.value);
+      const options = d
+        .map(({ 大項目名 }) => 大項目名.value);
+      return [''].concat(options);
     }, []),
   });
 
@@ -41,7 +43,7 @@ export const useMaterialsOptions = (
         }
 
         return accu;
-      }, [] as string[]);
+      }, [''] as string[]);
 
       return {
         middleItemOpts: derived,
@@ -68,7 +70,7 @@ export const useMaterialsOptions = (
             accu.push(部材名.value);
         }
         return accu;
-      }, [] as string[]);
+      }, [''] as string[]);
 
       return {
         materialOpts: derived,

--- a/packages/kokoas-client/src/pages/projEstimate/hooks/useMaterialOptions.ts
+++ b/packages/kokoas-client/src/pages/projEstimate/hooks/useMaterialOptions.ts
@@ -21,10 +21,7 @@ export const useMaterialsOptions = (
     data: majorItemOpts = [],
   } = useMaterialsMajor({
     select: useCallback((d) => {
-      return d.map<Option>(({ 大項目名 }) => ({
-        label: 大項目名.value,
-        value: 大項目名.value,
-      }));
+      return d.map(({ 大項目名 }) => 大項目名.value);
     }, []),
   });
 
@@ -39,15 +36,12 @@ export const useMaterialsOptions = (
       const derived = d.reduce((accu, { 大項目名, 中項目名 }) => {
         if (!majorItem || 大項目名?.value === majorItem ) {
           // Ignore duplicates
-          if (!accu.some(({ value }) => value === 中項目名.value ))
-            accu.push({
-              label: 中項目名.value,
-              value: 中項目名.value,
-            });
+          if (!accu.some((value) => value === 中項目名.value ))
+            accu.push(中項目名.value);
         }
 
         return accu;
-      }, [] as Options);
+      }, [] as string[]);
 
       return {
         middleItemOpts: derived,
@@ -70,14 +64,11 @@ export const useMaterialsOptions = (
           || (!majorItem && (!middleItem || 中項目名?.value === middleItem))
         ) {
           // Ignore duplicates
-          if (!(accu.some(({ value }) => value === 部材名.value )))
-            accu.push({
-              label: 部材名?.value,
-              value: 部材名?.value,
-            });
+          if (!(accu.some((value) => value === 部材名.value )))
+            accu.push(部材名.value);
         }
         return accu;
-      }, [] as Options);
+      }, [] as string[]);
 
       return {
         materialOpts: derived,

--- a/packages/kokoas-client/src/pages/projEstimate/hooks/useMoveItem.tsx
+++ b/packages/kokoas-client/src/pages/projEstimate/hooks/useMoveItem.tsx
@@ -1,0 +1,16 @@
+import { useFormikContext } from 'formik';
+import { produce } from 'immer';
+import { useCallback } from 'react';
+import { TypeOfForm } from '../form';
+
+export const useMoveItem = () => {
+  const { setValues } = useFormikContext<TypeOfForm>();
+
+  const move = useCallback((fromIdx: number, toIdx: number) => {
+    setValues((prev) => produce(prev, ({ items }) => {
+      [items[fromIdx], items[toIdx]] = [items[toIdx], items[fromIdx]];
+    }));
+  }, [setValues]);
+
+  return move;
+};

--- a/packages/kokoas-client/src/pages/projEstimate/hooks/useSummary.ts
+++ b/packages/kokoas-client/src/pages/projEstimate/hooks/useSummary.ts
@@ -21,7 +21,6 @@ export const useSummary = () => {
   const { values } = useFormikContext<TypeOfForm>();
 
   useLazyEffect(() => {
-    console.log('FIRED!');
     // 合計欄：原価合計、粗利、税抜金額、税込金額の算出処理
     const result = values.items.reduce((acc, cur) => {
 


### PR DESCRIPTION
## 変更内容

1. FormikTextVieldV2に`enabledFormikBlur`というpropを追加しました。任意でデフォールトは`true`。
2. 内訳の中のフィールドに、FormikのonBlurを `enabledFormikBlur`で無効化しました。
3. 大項目、中項目、部材の選択肢の型は `{label: string, value: string}` 「以下、Option」 から `string[]`　になりました。
4. FormikのfieldArrayHelpersの利用をやめて、FormikのsetValuesに変えました。

## 変更理由

1. FormikのonBlurは裏で、フォーム全体のバリデーションを実行するので、フォーム全体もレンダリングされます。オプトアウト出来るように、propにenabledFormikBlurを追加しました。FormikTextVieldV2から派生する、FormikNumberFieldやFormikMoneyFieldにも適用されます。
2. 内訳の中に `tab`　を使うのは多いようで、サクサクに出来るように、FormikのonBlurを無効化にしました。
3. 変換処理のコストを軽減するために。ただ、選択肢に、値以外の情報「フリガナ等」を載せたいなら、撤回します。
  - 変更前： `Option` → `string[]`
  - 変更後：`string[]` のまま。
4. FormikのfieldArrayHelpersはレンダリングのたび、リファレンスが変わるので、依存しているコンポーネントも再レンダリングされます。よって、安定しているFormikのsetValuesを利用し、fieldArrayHelpersの機能を再現させました。

## 残っている課題

- Formikの仕組みは、変わったフィールドは一つでも、全フィールドのバリデーションを実行しています。見積のようにフィールドが多くなると、重くなります。解決方法は検討中です。
