### PR TITLE
62-fix-契約を印刷：金額にマイナス値が入力できない

### DIFF
--- a/packages/kokoas-client/src/pages/projContracts/formValidation.ts
+++ b/packages/kokoas-client/src/pages/projContracts/formValidation.ts
@@ -16,7 +16,6 @@ const payAmtValidation  = Yup
     then: Yup
       .number()
       .typeError('数値を入れてください。')
-      .positive('ゼロ以上を入力してください。')
       .required('金額を入力してください。'),
   });
 


### PR DESCRIPTION
## 変更

- 契約の金額フィールドのバリデーションにpositiveNumber の確認を外しました。

## 変更理由

- Fix #62 

