### PR TITLE
見積の内訳：エラーを表示するように

### DIFF
--- a/packages/kokoas-client/src/components/reactHookForm/OutlinedNumberInput.tsx
+++ b/packages/kokoas-client/src/components/reactHookForm/OutlinedNumberInput.tsx
@@ -3,15 +3,19 @@ import { forwardRef } from 'react';
 
 export const OutlinedNumberInput = forwardRef<OutlinedInputProps, OutlinedInputProps>((props, ref ) => {
 
+  const {
+    inputProps = {
+      style: { textAlign: 'right' },
+    },
+  } = props;
+
   return (
     <OutlinedInput
       {...props}
       inputRef={ref}
       size={'small'}
       type={'number'}
-      inputProps={{
-        style: { textAlign: 'right' },
-      }}
+      inputProps={inputProps}
     />
   );
 });

--- a/packages/kokoas-client/src/pages/projEstimate/form.ts
+++ b/packages/kokoas-client/src/pages/projEstimate/form.ts
@@ -4,7 +4,7 @@ import { validationSchema } from './validationSchema';
 
 export type TypeOfForm =  Yup.InferType<typeof validationSchema> ;
 export type KeyOfForm = keyof TypeOfForm;
-type KRowFields = keyof TypeOfForm['items'][number];
+export type KRowFields = keyof TypeOfForm['items'][number];
 
 
 

--- a/packages/kokoas-client/src/pages/projEstimate/hooks/useEstField.ts
+++ b/packages/kokoas-client/src/pages/projEstimate/hooks/useEstField.ts
@@ -1,0 +1,41 @@
+import { OutlinedInputProps } from '@mui/material';
+import { useFormContext, UseFormReturn, useFormState } from 'react-hook-form';
+import { getItemsFieldName, KRowFields, TypeOfForm } from '../form';
+
+
+/* 
+  Abstraction of common props used in 見積 fields.
+  This trigger re-render, and might need to ditch MUI and purely resort to native html and css if this cause bottlenecks.
+*/
+export const useEstField = ({
+  rowIdx,
+  fieldName,
+}:{
+  rowIdx: number,
+  fieldName: KRowFields
+}): OutlinedInputProps & {
+  formContext : UseFormReturn<TypeOfForm>,
+  fieldName: 'items.0.costPrice'
+} => {
+
+  const rowFieldName = getItemsFieldName(rowIdx, fieldName);
+  const formContext = useFormContext<TypeOfForm>();
+  const { control } = formContext;
+  const {
+    errors: {
+      items,
+    },
+  } = useFormState({
+    name: rowFieldName,
+    control,
+  });
+
+  const error = !!items?.[rowIdx]?.[fieldName];
+  
+  return {
+    fieldName: rowFieldName,
+    formContext,
+    error: !!error,
+    onFocus: ({ target }) => target.select(),
+  };
+};

--- a/packages/kokoas-client/src/pages/projEstimate/tables/estimatesVirtual/EstBody.tsx
+++ b/packages/kokoas-client/src/pages/projEstimate/tables/estimatesVirtual/EstBody.tsx
@@ -3,18 +3,16 @@ import { useOverlayContext } from 'kokoas-client/src/hooks/useOverlayContext';
 import { useFieldArray } from 'react-hook-form';
 import { TypeOfForm } from '../../form';
 import { useVirtualizer  } from '@tanstack/react-virtual';
-import { Box } from '@mui/material';
 import { useManipulateItemRows } from '../../hooks/useManipulateItemRows';
 import { EstRowMove, EstRowManipulate } from './rowActions';
 import { EstRow } from './EstRow';
 import { useSmartHandlers } from '../../hooks/useSmartHandlers';
 import { EstHeader } from './EstHeader';
-import { grey } from '@mui/material/colors';
 import { EstFooterActions } from './EstFooterActions';
 import { Fragment, useMemo } from 'react';
 import debounce from 'lodash/debounce';
 import { EstRowContainer } from './EstRowContainer';
-import { ErrorPopover } from './utilities/ErrorPopover';
+import { EstBodyContainer } from './EstBodyContainer';
 
 export const EstBody = ({
   isDisabled,
@@ -57,16 +55,8 @@ export const EstBody = ({
 
   return (
     <Fragment>
-
-      <Box
-        sx={{
-          height: `${rowVirtualizer.getTotalSize()}px`,
-          width: '100%',
-          position: 'relative',
-          border:1,
-          borderColor: grey[200],
-          borderRadius: 1,
-        }}
+      <EstBodyContainer 
+        height={rowVirtualizer.getTotalSize()}
       >
         <EstHeader />
         {rowVirtualizer.getVirtualItems().map((virtualRow) => {
@@ -81,6 +71,7 @@ export const EstBody = ({
               rowIdx={virtualRow.index}
               rowSize={virtualRow.size}
               rowStart={virtualRow.start}
+             
             >
               <EstRowMove
                 {...rowMethods}
@@ -111,9 +102,9 @@ export const EstBody = ({
           );
         })}
 
-      </Box>
+      </EstBodyContainer>
       <EstFooterActions {...rowMethods} />
-      <ErrorPopover />
+
     </Fragment>
   );
 };

--- a/packages/kokoas-client/src/pages/projEstimate/tables/estimatesVirtual/EstBody.tsx
+++ b/packages/kokoas-client/src/pages/projEstimate/tables/estimatesVirtual/EstBody.tsx
@@ -14,6 +14,7 @@ import { EstFooterActions } from './EstFooterActions';
 import { Fragment, useMemo } from 'react';
 import debounce from 'lodash/debounce';
 import { EstRowContainer } from './EstRowContainer';
+import { ErrorPopover } from './utilities/ErrorPopover';
 
 export const EstBody = ({
   isDisabled,
@@ -56,6 +57,7 @@ export const EstBody = ({
 
   return (
     <Fragment>
+
       <Box
         sx={{
           height: `${rowVirtualizer.getTotalSize()}px`,
@@ -111,6 +113,7 @@ export const EstBody = ({
 
       </Box>
       <EstFooterActions {...rowMethods} />
+      <ErrorPopover />
     </Fragment>
   );
 };

--- a/packages/kokoas-client/src/pages/projEstimate/tables/estimatesVirtual/EstBodyContainer.tsx
+++ b/packages/kokoas-client/src/pages/projEstimate/tables/estimatesVirtual/EstBodyContainer.tsx
@@ -1,0 +1,56 @@
+import { Box, BoxProps, PopperProps, SxProps } from '@mui/material';
+import { grey } from '@mui/material/colors';
+import {  useCallback, SyntheticEvent, useState, useMemo } from 'react';
+import { ErrorPopover } from './utilities/ErrorPopover';
+import { estArrayFieldName, KeyOfForm, TypeOfForm } from '../../form';
+import { useFormContext } from 'react-hook-form';
+
+export const EstBodyContainer = ({
+  height,
+  children,
+}: BoxProps & {
+  height: number,
+
+}) => {
+
+  const [ancholErrEl, setAnchorErrEl] = useState<PopperProps['anchorEl']>();
+  const [errorMessage, setErrorMessage] = useState<string | undefined>();
+  const { getFieldState } = useFormContext<TypeOfForm>();
+
+  const handleMouseOver: BoxProps['onMouseOver'] = useCallback((e:  SyntheticEvent) => {
+    const target = e.target as HTMLInputElement;
+
+    if (target?.tagName === 'INPUT' && target?.name?.includes(estArrayFieldName)) {
+      const { error } = getFieldState(target.name as KeyOfForm);
+      if (error) {
+        setAnchorErrEl(target);
+        setErrorMessage(error?.message);
+      }
+    } else if (ancholErrEl) {
+      setAnchorErrEl(undefined);
+      setErrorMessage(undefined);
+    }
+  }, [getFieldState, ancholErrEl ]);
+
+  const sx: SxProps = useMemo(() => ({
+    height: `${height}px`,
+    width: '100%',
+    position: 'relative',
+    border:1,
+    borderColor: grey[200],
+    borderRadius: 1,
+  }), [height]);
+
+  return (
+    <Box
+      sx={sx}
+      onMouseOver={handleMouseOver}
+    >
+      {children}
+      <ErrorPopover 
+        ancholErrEl={ancholErrEl}
+        errorMessage={errorMessage}
+      />
+    </Box>
+  );
+};

--- a/packages/kokoas-client/src/pages/projEstimate/tables/estimatesVirtual/EstBodyContainer.tsx
+++ b/packages/kokoas-client/src/pages/projEstimate/tables/estimatesVirtual/EstBodyContainer.tsx
@@ -28,7 +28,6 @@ export const EstBodyContainer = ({
       }
     } else if (ancholErrEl) {
       setAnchorErrEl(undefined);
-      setErrorMessage(undefined);
     }
   }, [getFieldState, ancholErrEl ]);
 

--- a/packages/kokoas-client/src/pages/projEstimate/tables/estimatesVirtual/EstErrors.tsx
+++ b/packages/kokoas-client/src/pages/projEstimate/tables/estimatesVirtual/EstErrors.tsx
@@ -1,5 +1,0 @@
-
-// WIP, will handle errors inside the table
-export const EstErrors = () => {
-
-};

--- a/packages/kokoas-client/src/pages/projEstimate/tables/estimatesVirtual/rowFields/CostPrice.tsx
+++ b/packages/kokoas-client/src/pages/projEstimate/tables/estimatesVirtual/rowFields/CostPrice.tsx
@@ -1,7 +1,6 @@
 import { OutlinedInputProps } from '@mui/material';
 import { OutlinedMoneyInput } from 'kokoas-client/src/components/reactHookForm/OutlinedMoneyInput';
-import { useFormContext, useFormState } from 'react-hook-form';
-import { getItemsFieldName, TypeOfForm } from '../../../form';
+import { useEstField } from '../../../hooks/useEstField';
 import { UseSmartHandlers } from '../../../hooks/useSmartHandlers';
 
 export const CostPrice = ({
@@ -12,29 +11,24 @@ export const CostPrice = ({
   handleChange: UseSmartHandlers['handleChangeCostPrice']
 
 }) => {
-  const fieldName = getItemsFieldName(rowIdx, 'costPrice');
-  const { register, control } = useFormContext<TypeOfForm>();
-  const {
-    errors: {
-      items,
-    },
-  } = useFormState({
-    name: fieldName,
-    control,
+  const { 
+    formContext: { register }, 
+    fieldName,
+    ...fieldProps
+  } = useEstField({
+    fieldName: 'costPrice',
+    rowIdx,
   });
-
-  const error = items?.[rowIdx]?.costPrice;
-
 
   return (
     <OutlinedMoneyInput
+      {...fieldProps}
       {...register(
         fieldName,
         {
           onChange: () => handleChange(rowIdx),
         })}
-      onFocus={({ target }) => target.select()}
-      error={!!error}
+      
     />
   );
 };

--- a/packages/kokoas-client/src/pages/projEstimate/tables/estimatesVirtual/rowFields/CostPrice.tsx
+++ b/packages/kokoas-client/src/pages/projEstimate/tables/estimatesVirtual/rowFields/CostPrice.tsx
@@ -1,6 +1,6 @@
 import { OutlinedInputProps } from '@mui/material';
 import { OutlinedMoneyInput } from 'kokoas-client/src/components/reactHookForm/OutlinedMoneyInput';
-import { useFormContext } from 'react-hook-form';
+import { useFormContext, useFormState } from 'react-hook-form';
 import { getItemsFieldName, TypeOfForm } from '../../../form';
 import { UseSmartHandlers } from '../../../hooks/useSmartHandlers';
 
@@ -10,19 +10,28 @@ export const CostPrice = ({
 }: OutlinedInputProps & {
   rowIdx: number
   handleChange: UseSmartHandlers['handleChangeCostPrice']
-  
+
 }) => {
   const fieldName = getItemsFieldName(rowIdx, 'costPrice');
-  const { register } = useFormContext<TypeOfForm>();
+  const { register, control } = useFormContext<TypeOfForm>();
+  const {
+    errors: {
+      items,
+    },
+  } = useFormState({
+    name: fieldName,
+    control,
+  });
 
   return (
     <OutlinedMoneyInput
       {...register(
-        fieldName, 
+        fieldName,
         {
           onChange: () => handleChange(rowIdx),
         })}
       onFocus={({ target }) => target.select()}
+      error={!!items?.[rowIdx]}
     />
   );
 };

--- a/packages/kokoas-client/src/pages/projEstimate/tables/estimatesVirtual/rowFields/CostPrice.tsx
+++ b/packages/kokoas-client/src/pages/projEstimate/tables/estimatesVirtual/rowFields/CostPrice.tsx
@@ -23,6 +23,9 @@ export const CostPrice = ({
     control,
   });
 
+  const error = items?.[rowIdx]?.costPrice;
+
+
   return (
     <OutlinedMoneyInput
       {...register(
@@ -31,7 +34,7 @@ export const CostPrice = ({
           onChange: () => handleChange(rowIdx),
         })}
       onFocus={({ target }) => target.select()}
-      error={!!items?.[rowIdx]}
+      error={!!error}
     />
   );
 };

--- a/packages/kokoas-client/src/pages/projEstimate/tables/estimatesVirtual/rowFields/ProfitRate.tsx
+++ b/packages/kokoas-client/src/pages/projEstimate/tables/estimatesVirtual/rowFields/ProfitRate.tsx
@@ -1,6 +1,5 @@
 import { OutlinedPercentInput } from 'kokoas-client/src/components/reactHookForm/OutlinedPercentInput';
-import { useFormContext } from 'react-hook-form';
-import { getItemsFieldName, TypeOfForm } from '../../../form';
+import { useEstField } from '../../../hooks/useEstField';
 import { UseSmartHandlers } from '../../../hooks/useSmartHandlers';
 
 export const ProfitRate = ({
@@ -10,17 +9,26 @@ export const ProfitRate = ({
   rowIdx: number
   handleChange: UseSmartHandlers['handleChangeProfitRate']
 }) => {
-  const { register } = useFormContext<TypeOfForm>();
 
+  const { 
+    formContext: { register }, 
+    fieldName,
+    ...fieldProps
+  } = useEstField({
+    fieldName: 'materialProfRate',
+    rowIdx,
+  });
+  
   return (
     <OutlinedPercentInput
+      {...fieldProps}
       {...register(
-        getItemsFieldName(rowIdx, 'materialProfRate'),
+        fieldName,
         {
           onChange: () => handleChange(rowIdx),
         },
       )}
-      onFocus={({ target }) => target.select()}
+  
     />
   );
 };

--- a/packages/kokoas-client/src/pages/projEstimate/tables/estimatesVirtual/rowFields/QuantityField.tsx
+++ b/packages/kokoas-client/src/pages/projEstimate/tables/estimatesVirtual/rowFields/QuantityField.tsx
@@ -1,9 +1,7 @@
-import { IconButton, InputAdornment, OutlinedInput } from '@mui/material';
-import { MouseEvent, useCallback, useState } from 'react';
-import { Controller, useFormContext, useWatch } from 'react-hook-form';
-import { getItemsFieldName, TypeOfForm } from '../../../form';
+import { OutlinedNumberInput } from 'kokoas-client/src/components/reactHookForm/OutlinedNumberInput';
+import { useEstField } from '../../../hooks/useEstField';
 import { UseSmartHandlers } from '../../../hooks/useSmartHandlers';
-import { UnitTypeMenu } from './UnitTypeMenu';
+import { UnitType } from './UnitType';
 
 export const QuantityField = ({
   rowIdx,
@@ -12,72 +10,32 @@ export const QuantityField = ({
   rowIdx: number,
   handleChange: UseSmartHandlers['handleChangeQuantity']
 }) => {
-  const {
-    control,
-    register,
-  } = useFormContext<TypeOfForm>();
-  const [unitMenuAnchorEl, setUnitMenuAnchorEl] = useState<null | HTMLButtonElement>(null);
 
-  const unit = useWatch({
-    name: getItemsFieldName(rowIdx, 'unit'),
-    control,
+
+  const { 
+    formContext: { register }, 
+    fieldName,
+    ...fieldProps
+  } = useEstField({
+    fieldName: 'quantity',
+    rowIdx,
   });
 
-  const handleOpenUnitMenu = useCallback(({ currentTarget }: MouseEvent<HTMLButtonElement>) => {
-    setUnitMenuAnchorEl(currentTarget);
-  }, []);
-
   return (
-    <>
-      <OutlinedInput
-        {...register(
-          getItemsFieldName(rowIdx, 'quantity'), 
-          {
-            onChange: () => handleChange(rowIdx),
-          },
-        )}
-        size='small'
-        type={'number'}
-        style={{ textAlign: 'right' }}
-        onFocus={({ target }) => target.select()}
-        endAdornment={(
-          <InputAdornment position='end'>
-            <IconButton
-              size='small'
-              onClick={handleOpenUnitMenu}
-              sx={{ fontSize: '12px' }}
-            >
-              {unit}
-            </IconButton>
-          </InputAdornment>
-          )}
-      />
-
-      <Controller
-        name={getItemsFieldName(rowIdx, 'unit')}
-        control={control}
-        render={({
-          field: {
-            onChange,
-          },
-        }) => {
-
-          return (
-            <UnitTypeMenu
-              open={!!unitMenuAnchorEl}
-              anchorEl={unitMenuAnchorEl}
-              handleClose={() => setUnitMenuAnchorEl(null)}
-              handleChange={(e) => {
-                const { value } = e.currentTarget.dataset;
-                onChange(value);
-                setUnitMenuAnchorEl(null);
-              }}
-            />
-          );
-        }}
-      />
-
-    </>
+    
+    <OutlinedNumberInput
+      {...fieldProps}
+      {...register(
+        fieldName, 
+        {
+          onChange: () => handleChange(rowIdx),
+        },
+      )}
+      inputProps={{
+        style: { textAlign: 'left' },
+      }}
+      endAdornment={(<UnitType rowIdx={rowIdx} /> )}
+    />
 
   );
 };

--- a/packages/kokoas-client/src/pages/projEstimate/tables/estimatesVirtual/rowFields/RowUnitPriceAfterTax.tsx
+++ b/packages/kokoas-client/src/pages/projEstimate/tables/estimatesVirtual/rowFields/RowUnitPriceAfterTax.tsx
@@ -1,6 +1,7 @@
 import { OutlinedMoneyInput } from 'kokoas-client/src/components/reactHookForm/OutlinedMoneyInput';
-import { useFormContext, useWatch } from 'react-hook-form';
-import { getItemsFieldName, TypeOfForm } from '../../../form';
+import { useWatch } from 'react-hook-form';
+import { getItemsFieldName } from '../../../form';
+import { useEstField } from '../../../hooks/useEstField';
 import { UseSmartHandlers } from '../../../hooks/useSmartHandlers';
 
 export const RowUnitPriceAfterTax = ({
@@ -10,7 +11,14 @@ export const RowUnitPriceAfterTax = ({
   rowIdx: number,
   handleChange: UseSmartHandlers['handleChangeRowUnitPriceAfterTax']
 }) => {
-  const { register, control } = useFormContext<TypeOfForm>();
+  const { 
+    formContext: { register, control }, 
+    fieldName,
+    ...fieldProps
+  } = useEstField({
+    fieldName: 'rowUnitPriceAfterTax',
+    rowIdx,
+  });
 
   const [
     costPrice,
@@ -24,16 +32,17 @@ export const RowUnitPriceAfterTax = ({
   });
 
 
+
   return (
     <OutlinedMoneyInput
+      {...fieldProps}
       {...register(
-        getItemsFieldName(rowIdx, 'rowUnitPriceAfterTax'),
+        fieldName,
         {
           onChange: () => handleChange(rowIdx),
         })
       }
       disabled={!!envStatus || !+(costPrice ?? 0)}
-      onFocus={({ target }) => target.select()}
     />
   );
 };

--- a/packages/kokoas-client/src/pages/projEstimate/tables/estimatesVirtual/rowFields/UnitPrice.tsx
+++ b/packages/kokoas-client/src/pages/projEstimate/tables/estimatesVirtual/rowFields/UnitPrice.tsx
@@ -1,6 +1,7 @@
 import { OutlinedMoneyInput } from 'kokoas-client/src/components/reactHookForm/OutlinedMoneyInput';
-import { useFormContext, useWatch } from 'react-hook-form';
-import { getItemsFieldName, TypeOfForm } from '../../../form';
+import { useWatch } from 'react-hook-form';
+import { getItemsFieldName } from '../../../form';
+import { useEstField } from '../../../hooks/useEstField';
 import { UseSmartHandlers } from '../../../hooks/useSmartHandlers';
 
 export const UnitPrice = ({
@@ -11,10 +12,15 @@ export const UnitPrice = ({
   handleChange: UseSmartHandlers['handleChangeUnitPrice']
 }) => {
 
-  const {
-    register,
-    control,
-  } = useFormContext<TypeOfForm>();
+  const { 
+    formContext: { register, control }, 
+    fieldName,
+    ...fieldProps
+  } = useEstField({
+    fieldName: 'unitPrice',
+    rowIdx,
+  });
+
 
   const [
     costPrice,
@@ -29,14 +35,14 @@ export const UnitPrice = ({
 
   return (
     <OutlinedMoneyInput
+      {...fieldProps}
       {...register(
-        getItemsFieldName(rowIdx, 'unitPrice'),
+        fieldName,
         {
           onChange: () => handleChange(rowIdx),
         })
       }
       disabled={!!envStatus || !+(costPrice ?? 0)}
-      onFocus={({ target }) => target.select()}
     />
 
   );

--- a/packages/kokoas-client/src/pages/projEstimate/tables/estimatesVirtual/rowFields/UnitType.tsx
+++ b/packages/kokoas-client/src/pages/projEstimate/tables/estimatesVirtual/rowFields/UnitType.tsx
@@ -1,0 +1,62 @@
+import { IconButton, InputAdornment } from '@mui/material';
+import { MouseEvent, useCallback, useState } from 'react';
+import { Controller, useFormContext } from 'react-hook-form';
+import { getItemsFieldName, TypeOfForm } from '../../../form';
+import { UnitTypeMenu } from './UnitTypeMenu';
+
+
+export const UnitType = ({
+  rowIdx,
+} : {
+  rowIdx: number
+}) => {
+  const {
+    control,
+  } = useFormContext<TypeOfForm>();
+  const [unitMenuAnchorEl, setUnitMenuAnchorEl] = useState<null | HTMLButtonElement>(null);
+
+  const handleOpenUnitMenu = useCallback(({ currentTarget }: MouseEvent<HTMLButtonElement>) => {
+    setUnitMenuAnchorEl(currentTarget);
+  }, []);
+
+  return (
+
+    <Controller
+      name={getItemsFieldName(rowIdx, 'unit')}
+      control={control}
+      render={({
+        field: {
+          onChange,
+          value: unit,
+        },
+      }) => {
+
+        return (
+          <>
+            <InputAdornment position='end'>
+              <IconButton
+                size='small'
+                onClick={handleOpenUnitMenu}
+                sx={{ fontSize: '12px' }}
+              >
+                {unit}
+              </IconButton>
+            </InputAdornment>
+            <UnitTypeMenu
+              open={!!unitMenuAnchorEl}
+              anchorEl={unitMenuAnchorEl}
+              handleClose={() => setUnitMenuAnchorEl(null)}
+              handleChange={(e) => {
+                const { value } = e.currentTarget.dataset;
+                onChange(value);
+                setUnitMenuAnchorEl(null);
+              }}
+            />
+          </>
+         
+        );
+      }}
+    />
+  );
+
+};

--- a/packages/kokoas-client/src/pages/projEstimate/tables/estimatesVirtual/utilities/ErrorPopover.tsx
+++ b/packages/kokoas-client/src/pages/projEstimate/tables/estimatesVirtual/utilities/ErrorPopover.tsx
@@ -1,7 +1,6 @@
 import Popper, { PopperProps } from '@mui/material/Popper';
 import Fade from '@mui/material/Fade';
 import { Alert, Box } from '@mui/material';
-import { useRef } from 'react';
 import { red } from '@mui/material/colors';
 
 export const  ErrorPopover = ({
@@ -11,7 +10,6 @@ export const  ErrorPopover = ({
   ancholErrEl: PopperProps['anchorEl']
   errorMessage?: string,
 }) => {
-  const arrowRef = useRef<HTMLSpanElement>(null);
 
   const open = !!(document.body.contains(ancholErrEl as HTMLInputElement)) && !!errorMessage;
 
@@ -37,28 +35,29 @@ export const  ErrorPopover = ({
       {({ TransitionProps }) => (
         <Fade {...TransitionProps} timeout={350}>
           <div>
-            <Box ref={arrowRef} sx={{
-              top: 0,
-              left: 16,
-              marginTop: '-0.9em',
-              width: '3em',
-              height: '1em',
-              position: 'absolute',
-              fontSize: 16,
-              '&::before': {
-                borderWidth: '0 1em 1em 1em',
-                borderColor: `transparent transparent ${red[50]} transparent`,
-                content: '""',
-                margin: 'auto',
-                display: 'block',
-                width: 0,
-                height: 0,
-                borderStyle: 'solid',
-              },
-            }}
+            <Box
+              sx={{
+                top: 0,
+                left: 16,
+                marginTop: '-0.9em',
+                width: '3em',
+                height: '1em',
+                position: 'absolute',
+                fontSize: 16,
+                '&::before': {
+                  borderWidth: '0 1em 1em 1em',
+                  borderColor: `transparent transparent ${red[50]} transparent`,
+                  content: '""',
+                  margin: 'auto',
+                  display: 'block',
+                  width: 0,
+                  height: 0,
+                  borderStyle: 'solid',
+                },
+              }}
             />
             <Alert
-              severity='warning'
+              severity='error'
               sx={{
                 boxShadow: 3,
               }}

--- a/packages/kokoas-client/src/pages/projEstimate/tables/estimatesVirtual/utilities/ErrorPopover.tsx
+++ b/packages/kokoas-client/src/pages/projEstimate/tables/estimatesVirtual/utilities/ErrorPopover.tsx
@@ -2,6 +2,7 @@ import { FieldError, useFormContext, useFormState } from 'react-hook-form';
 import { KeyOfForm, TypeOfForm } from '../../../form';
 import { useCallback, useEffect, useState } from 'react';
 import { Alert, Popper, PopperProps } from '@mui/material';
+import { useOverlayContext } from 'kokoas-client/src/hooks/useOverlayContext';
 
 const EstTableFieldName : KeyOfForm = 'items';
 
@@ -22,7 +23,7 @@ export const ErrorPopover = () => {
   }, []);
 
   const activeElement = document.activeElement;
-
+  const overlay = useOverlayContext();
 
   useEffect(() => {
 
@@ -56,12 +57,11 @@ export const ErrorPopover = () => {
     const getBoundingClientRect = () =>
       actualErrorField.getBoundingClientRect();
 
-    console.log(getBoundingClientRect());
     setOpen(true);
-    setAnchorEl({ getBoundingClientRect });
+    setAnchorEl({ getBoundingClientRect, contextElement: overlay.current as Element });
     setErrorMessage(activeErrorField?.message || '');
 
-  }, [handleClose, items, activeElement]);
+  }, [handleClose, items, activeElement, overlay]);
 
   return (
     <Popper
@@ -70,9 +70,9 @@ export const ErrorPopover = () => {
       //disablePortal={false}
       placement="bottom-start"
       transition
-      sx={(theme) => ({
+      /* sx={(theme) => ({
         zIndex: theme.zIndex.appBar + 1,
-      })}
+      })} */
       anchorEl={anchorEl}
     >
       <Alert severity="error">

--- a/packages/kokoas-client/src/pages/projEstimate/tables/estimatesVirtual/utilities/ErrorPopover.tsx
+++ b/packages/kokoas-client/src/pages/projEstimate/tables/estimatesVirtual/utilities/ErrorPopover.tsx
@@ -1,83 +1,35 @@
-import { FieldError, useFormContext, useFormState } from 'react-hook-form';
-import { KeyOfForm, TypeOfForm } from '../../../form';
-import { useCallback, useEffect, useState } from 'react';
-import { Alert, Popper, PopperProps } from '@mui/material';
-import { useOverlayContext } from 'kokoas-client/src/hooks/useOverlayContext';
+import Popper, { PopperProps } from '@mui/material/Popper';
+import Fade from '@mui/material/Fade';
+import { Alert } from '@mui/material';
 
-const EstTableFieldName : KeyOfForm = 'items';
+export const  ErrorPopover = ({
+  ancholErrEl,
+  errorMessage,
+}: {
+  ancholErrEl: PopperProps['anchorEl']
+  errorMessage?: string,
+}) => {
 
-export const ErrorPopover = () => {
-  const [open, setOpen] = useState(false);
-  const [anchorEl, setAnchorEl] = useState<PopperProps['anchorEl']>(null);
-  const [errorMessage, setErrorMessage] = useState<string | undefined>('');
-
-  const { control } = useFormContext<TypeOfForm>();
-
-  const { errors: { items } } = useFormState({
-    control,
-    name: EstTableFieldName,
-  });
-
-  const handleClose = useCallback(() => {
-    setOpen(false);
-  }, []);
-
-  const activeElement = document.activeElement;
-  const overlay = useOverlayContext();
-
-  useEffect(() => {
-
-    const activeElementName = activeElement?.getAttribute('name');
-
-    if (!activeElementName
-      || !activeElementName.includes(EstTableFieldName)
-    ) {
-      handleClose();
-      return;
-    }
-
-    const activeErrorField = items?.reduce?.((acc, curr) => {
-      if (curr) {
-        for (const field of Object.values(curr)) {
-          if ((field as FieldError).ref?.name === activeElementName) {
-            acc = field as FieldError;
-          }
-        }
-      }
-      return acc;
-    }, Object.create(null) as FieldError);
-
-    const actualErrorField = document.querySelector(`[name="${activeElementName}"]`);
-
-    if (!actualErrorField || !activeErrorField) {
-      handleClose();
-      return;
-    }
-
-    const getBoundingClientRect = () =>
-      actualErrorField.getBoundingClientRect();
-
-    setOpen(true);
-    setAnchorEl({ getBoundingClientRect, contextElement: overlay.current as Element });
-    setErrorMessage(activeErrorField?.message || '');
-
-  }, [handleClose, items, activeElement, overlay]);
+  const open = !!(document.body.contains(ancholErrEl as HTMLInputElement)) && !!errorMessage;
 
   return (
+  
     <Popper
-      id={'popper'}
       open={open}
-      //disablePortal={false}
-      placement="bottom-start"
+      anchorEl={ancholErrEl}
       transition
-      /* sx={(theme) => ({
+      placement="bottom-start"
+      sx={(theme) => ({
         zIndex: theme.zIndex.appBar + 1,
-      })} */
-      anchorEl={anchorEl}
+      })}
     >
-      <Alert severity="error">
-        {errorMessage}
-      </Alert>
+      {({ TransitionProps }) => (
+        <Fade {...TransitionProps} timeout={350}>
+          <Alert severity='warning'>
+            {errorMessage}
+          </Alert>
+        </Fade>
+      )}
     </Popper>
 
   );

--- a/packages/kokoas-client/src/pages/projEstimate/tables/estimatesVirtual/utilities/ErrorPopover.tsx
+++ b/packages/kokoas-client/src/pages/projEstimate/tables/estimatesVirtual/utilities/ErrorPopover.tsx
@@ -4,66 +4,6 @@ import { Alert, Box } from '@mui/material';
 import { useRef } from 'react';
 import { red } from '@mui/material/colors';
 
-
-/* 
-const useStyles = makeStyles((theme: Theme) => ({
-  root: {
-    flexGrow: 1,
-  },
-  scrollContainer: {
-    height: 400,
-    overflow: 'auto',
-    marginBottom: theme.spacing(3),
-  },
-  scroll: {
-    position: 'relative',
-    width: '230%',
-    backgroundColor: theme.palette.background.paper,
-    height: '230%',
-  },
-  legend: {
-    marginTop: theme.spacing(2),
-    maxWidth: 300,
-  },
-  paper: {
-    maxWidth: 400,
-    overflow: 'auto',
-  },
-  select: {
-    width: 200,
-  },
-  popper: {
-    zIndex: 1,
-    '&[x-placement*="bottom"] $arrow': {
-      top: 0,
-      left: 0,
-      marginTop: '-0.9em',
-      width: '3em',
-      height: '1em',
-      '&::before': {
-        borderWidth: '0 1em 1em 1em',
-        borderColor: `transparent transparent ${theme.palette.background.paper} transparent`,
-      },
-    },
-
-   
-  },
-  arrow: {
-    position: 'absolute',
-    fontSize: 7,
-    width: '3em',
-    height: '3em',
-    '&::before': {
-      content: '""',
-      margin: 'auto',
-      display: 'block',
-      width: 0,
-      height: 0,
-      borderStyle: 'solid',
-    },
-  },
-}));
- */
 export const  ErrorPopover = ({
   ancholErrEl,
   errorMessage,
@@ -76,7 +16,7 @@ export const  ErrorPopover = ({
   const open = !!(document.body.contains(ancholErrEl as HTMLInputElement)) && !!errorMessage;
 
   return (
-  
+
     <Popper
       open={open}
       anchorEl={ancholErrEl}
@@ -117,11 +57,16 @@ export const  ErrorPopover = ({
               },
             }}
             />
-            <Alert severity='warning'>
+            <Alert
+              severity='warning'
+              sx={{
+                boxShadow: 3,
+              }}
+            >
               {errorMessage}
             </Alert>
           </div>
-   
+
         </Fade>
       )}
     </Popper>

--- a/packages/kokoas-client/src/pages/projEstimate/tables/estimatesVirtual/utilities/ErrorPopover.tsx
+++ b/packages/kokoas-client/src/pages/projEstimate/tables/estimatesVirtual/utilities/ErrorPopover.tsx
@@ -44,7 +44,7 @@ export const  ErrorPopover = ({
               width: '3em',
               height: '1em',
               position: 'absolute',
-              fontSize: 7,
+              fontSize: 16,
               '&::before': {
                 borderWidth: '0 1em 1em 1em',
                 borderColor: `transparent transparent ${red[50]} transparent`,

--- a/packages/kokoas-client/src/pages/projEstimate/tables/estimatesVirtual/utilities/ErrorPopover.tsx
+++ b/packages/kokoas-client/src/pages/projEstimate/tables/estimatesVirtual/utilities/ErrorPopover.tsx
@@ -1,7 +1,69 @@
 import Popper, { PopperProps } from '@mui/material/Popper';
 import Fade from '@mui/material/Fade';
-import { Alert } from '@mui/material';
+import { Alert, Box } from '@mui/material';
+import { useRef } from 'react';
+import { red } from '@mui/material/colors';
 
+
+/* 
+const useStyles = makeStyles((theme: Theme) => ({
+  root: {
+    flexGrow: 1,
+  },
+  scrollContainer: {
+    height: 400,
+    overflow: 'auto',
+    marginBottom: theme.spacing(3),
+  },
+  scroll: {
+    position: 'relative',
+    width: '230%',
+    backgroundColor: theme.palette.background.paper,
+    height: '230%',
+  },
+  legend: {
+    marginTop: theme.spacing(2),
+    maxWidth: 300,
+  },
+  paper: {
+    maxWidth: 400,
+    overflow: 'auto',
+  },
+  select: {
+    width: 200,
+  },
+  popper: {
+    zIndex: 1,
+    '&[x-placement*="bottom"] $arrow': {
+      top: 0,
+      left: 0,
+      marginTop: '-0.9em',
+      width: '3em',
+      height: '1em',
+      '&::before': {
+        borderWidth: '0 1em 1em 1em',
+        borderColor: `transparent transparent ${theme.palette.background.paper} transparent`,
+      },
+    },
+
+   
+  },
+  arrow: {
+    position: 'absolute',
+    fontSize: 7,
+    width: '3em',
+    height: '3em',
+    '&::before': {
+      content: '""',
+      margin: 'auto',
+      display: 'block',
+      width: 0,
+      height: 0,
+      borderStyle: 'solid',
+    },
+  },
+}));
+ */
 export const  ErrorPopover = ({
   ancholErrEl,
   errorMessage,
@@ -9,6 +71,7 @@ export const  ErrorPopover = ({
   ancholErrEl: PopperProps['anchorEl']
   errorMessage?: string,
 }) => {
+  const arrowRef = useRef<HTMLSpanElement>(null);
 
   const open = !!(document.body.contains(ancholErrEl as HTMLInputElement)) && !!errorMessage;
 
@@ -33,9 +96,32 @@ export const  ErrorPopover = ({
     >
       {({ TransitionProps }) => (
         <Fade {...TransitionProps} timeout={350}>
-          <Alert severity='warning'>
-            {errorMessage}
-          </Alert>
+          <div>
+            <Box ref={arrowRef} sx={{
+              top: 0,
+              left: 16,
+              marginTop: '-0.9em',
+              width: '3em',
+              height: '1em',
+              position: 'absolute',
+              fontSize: 7,
+              '&::before': {
+                borderWidth: '0 1em 1em 1em',
+                borderColor: `transparent transparent ${red[50]} transparent`,
+                content: '""',
+                margin: 'auto',
+                display: 'block',
+                width: 0,
+                height: 0,
+                borderStyle: 'solid',
+              },
+            }}
+            />
+            <Alert severity='warning'>
+              {errorMessage}
+            </Alert>
+          </div>
+   
         </Fade>
       )}
     </Popper>

--- a/packages/kokoas-client/src/pages/projEstimate/tables/estimatesVirtual/utilities/ErrorPopover.tsx
+++ b/packages/kokoas-client/src/pages/projEstimate/tables/estimatesVirtual/utilities/ErrorPopover.tsx
@@ -1,0 +1,57 @@
+import Popover from '@mui/material/Popover';
+import Typography from '@mui/material/Typography';
+import { FieldError, useFormContext, useFormState } from 'react-hook-form';
+import { TypeOfForm } from '../../../form';
+import { useCallback, useEffect, useState } from 'react';
+
+export const ErrorPopover = () => {
+  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
+  const [errorMessage, setErrorMessage] = useState<string | undefined>();
+
+  const { control } = useFormContext<TypeOfForm>();
+  const { errors: { items } } = useFormState({
+    control,
+    name: 'items',
+  });
+  const handleClose = useCallback(() => {
+    setAnchorEl(null);
+  }, []);
+
+  const open = Boolean(anchorEl);
+  const id = open ? 'error-popover' : undefined;
+
+  useEffect(() => {
+
+    const firstError = items?.find?.(Boolean);
+
+    if (firstError) {
+      const errorField = Object.values(firstError)[0] as FieldError;
+      const ref = errorField.ref;
+      setAnchorEl(ref as HTMLElement);
+      setErrorMessage(errorField?.message);
+    } else {
+      handleClose();
+    }
+  }, [handleClose, items]);
+
+  return (
+
+    <Popover
+      id={id}
+      open={open}
+      anchorEl={anchorEl}
+      onClose={handleClose}
+      anchorOrigin={{
+        vertical: 'bottom',
+        horizontal: 'left',
+      }}
+      disableAutoFocus={true}
+      disableEnforceFocus={true}
+    >
+      <Typography sx={{ p: 2 }}>
+        {errorMessage}
+      </Typography>
+    </Popover>
+
+  );
+};

--- a/packages/kokoas-client/src/pages/projEstimate/tables/estimatesVirtual/utilities/ErrorPopover.tsx
+++ b/packages/kokoas-client/src/pages/projEstimate/tables/estimatesVirtual/utilities/ErrorPopover.tsx
@@ -22,6 +22,14 @@ export const  ErrorPopover = ({
       sx={(theme) => ({
         zIndex: theme.zIndex.appBar + 1,
       })}
+      modifiers={[
+        {
+          name: 'offset',
+          options: {
+            offset: [0, 8],
+          },
+        },
+      ]}
     >
       {({ TransitionProps }) => (
         <Fade {...TransitionProps} timeout={350}>


### PR DESCRIPTION
## 変更

- エラー表示を復元しました。
- エラーはMuiのTextfieldのHelpertextで表示していましたが、ツールチップ的に表示するようにしました。
- エラー箇所をホバーしない限り、エラーが表示しない。
- よくあるエラーメッセージを日本語化しました。

## 変更理由

- レンダリングのスピードを重視に、エラーをどう表示するか迷っていましたので、一旦外しました。
- 出来るだけ少ないコンポーネントでレンダリングするためです。Textfieldだと、LabelやHelpertextなどのコンポーネントで作られているので、重くなります。
- レンダリングの負担を軽減するためにもなりますが、これでエラーフィールドがある際、行の構成が崩れなくなります。
- #78 から追加しましたが、このPRで本格的に実装しました。これで、よく使うバリデーションを再利用出来ます。


## 変更前

![image](https://user-images.githubusercontent.com/2501255/211123523-2fcba7d3-db28-4689-9fd6-00538c427f49.png)

## 変更後

![image](https://user-images.githubusercontent.com/2501255/211123935-8652e06a-bce3-4748-b32d-1012f3b30395.png)
