### PR TITLE
見積：閲覧のみの内訳を追加

### DIFF
--- a/packages/kokoas-client/src/pages/projEstimate/FormContents.tsx
+++ b/packages/kokoas-client/src/pages/projEstimate/FormContents.tsx
@@ -12,7 +12,6 @@ import { TypeOfForm } from './form';
 import { useConfirmBeforeClose } from './hooks';
 import { GoToContractButton } from './navigationComponents/GoToContractButton';
 import { EstimateTableLabel } from './staticComponents/EstimateTableLabel';
-//import { EstTable } from './tables/estimate/EstTable';
 import { EstBody } from './tables/estimatesVirtual/EstBody';
 import { SubTotalTable } from './tables/SubTotalTable/SubTotalTable';
 import SummaryTable from './tables/SummaryTable/SummaryTable';

--- a/packages/kokoas-client/src/pages/projEstimate/FormContents.tsx
+++ b/packages/kokoas-client/src/pages/projEstimate/FormContents.tsx
@@ -13,6 +13,7 @@ import { useConfirmBeforeClose } from './hooks';
 import { GoToContractButton } from './navigationComponents/GoToContractButton';
 import { EstimateTableLabel } from './staticComponents/EstimateTableLabel';
 import { EstBody } from './tables/estimatesVirtual/EstBody';
+import { EstBodyReadOnly } from './tables/estimatesVirtual/readonly/EstBodyReadOnly';
 import { SubTotalTable } from './tables/SubTotalTable/SubTotalTable';
 import SummaryTable from './tables/SummaryTable/SummaryTable';
 
@@ -101,7 +102,8 @@ export const FormContents = () => {
         <Grid item xs={12}>
           {/* 見積もり内訳のテーブル */}
           {/* <EstTable isDisabled={disabled} /> */}
-          <EstBody isDisabled={disabled} />
+          {!disabled &&  <EstBody isDisabled={disabled} />}
+          {disabled && <EstBodyReadOnly />}
         </Grid>
 
         <Grid item xs={12} mt={4}>

--- a/packages/kokoas-client/src/pages/projEstimate/api/convertEstimateToForm.ts
+++ b/packages/kokoas-client/src/pages/projEstimate/api/convertEstimateToForm.ts
@@ -99,10 +99,14 @@ export const convertEstimateToForm = (
     totalAmountBeforeTax,
   } = calculateSummary(newItems);
 
-  newItems.push({
-    ...initialValues.items[0],
-    materialProfRate: +projTypeProfit.value,
-  });
+  // 契約ないなら、仮想行を追加する
+  if (!envStatus) {
+    newItems.push({
+      ...initialValues.items[0],
+      materialProfRate: +projTypeProfit.value,
+    });
+  }
+
 
 
 

--- a/packages/kokoas-client/src/pages/projEstimate/formActions/ActionButtons.tsx
+++ b/packages/kokoas-client/src/pages/projEstimate/formActions/ActionButtons.tsx
@@ -1,5 +1,7 @@
 import { Stack, Zoom } from '@mui/material';
-import { useIsMutating } from '@tanstack/react-query';
+import { useIsFetching, useIsMutating } from '@tanstack/react-query';
+import { useWatch } from 'react-hook-form';
+import { TypeOfForm } from '../form';
 import { UseSaveForm } from '../hooks';
 import { ProjEstimateShortcuts } from '../navigationComponents/ProjEstimateShortcuts';
 import { BtnCancelEdit } from './BtnCancelEdit';
@@ -14,12 +16,21 @@ export const ActionButtons = ({
   handleSubmit: UseSaveForm['handleSubmit']
   handleSubmitFinal: UseSaveForm['handleSubmitFinal']
 }) => {
+  const [envStatus, estimateId] = useWatch<TypeOfForm>({
+    name: ['envStatus', 'estimateId'],
+  });
+  const loading = useIsFetching();
   const mutating = useIsMutating();
 
   return (
     <FormActionsContainer>
       <Zoom
-        in={!mutating}
+        in={
+          !mutating // 保存中じゃない
+          && !loading // データ取得中じゃない
+          && !envStatus // 契約ない
+          && !!estimateId // 見積番号あり
+}
         mountOnEnter
         unmountOnExit
       >

--- a/packages/kokoas-client/src/pages/projEstimate/tables/estimatesVirtual/EstBody.tsx
+++ b/packages/kokoas-client/src/pages/projEstimate/tables/estimatesVirtual/EstBody.tsx
@@ -12,7 +12,7 @@ import { EstFooterActions } from './EstFooterActions';
 import { Fragment, useMemo } from 'react';
 import debounce from 'lodash/debounce';
 import { EstRowContainer } from './EstRowContainer';
-import { EstBodyContainer } from './EstBodyContainer';
+import { EstBodyContainerEditable } from './EstBodyContainerEditable';
 
 export const EstBody = ({
   isDisabled,
@@ -55,7 +55,7 @@ export const EstBody = ({
 
   return (
     <Fragment>
-      <EstBodyContainer
+      <EstBodyContainerEditable
         height={rowVirtualizer.getTotalSize()}
       >
         <EstHeader />
@@ -102,7 +102,7 @@ export const EstBody = ({
           );
         })}
 
-      </EstBodyContainer>
+      </EstBodyContainerEditable>
       <EstFooterActions {...rowMethods} />
 
     </Fragment>

--- a/packages/kokoas-client/src/pages/projEstimate/tables/estimatesVirtual/EstBodyContainer.tsx
+++ b/packages/kokoas-client/src/pages/projEstimate/tables/estimatesVirtual/EstBodyContainer.tsx
@@ -1,55 +1,27 @@
-import { Box, BoxProps, PopperProps, SxProps } from '@mui/material';
+import { Box, BoxProps } from '@mui/material';
 import { grey } from '@mui/material/colors';
-import {  useCallback, SyntheticEvent, useState, useMemo } from 'react';
-import { ErrorPopover } from './utilities/ErrorPopover';
-import { estArrayFieldName, KeyOfForm, TypeOfForm } from '../../form';
-import { useFormContext } from 'react-hook-form';
 
-export const EstBodyContainer = ({
-  height,
-  children,
-}: BoxProps & {
-  height: number,
+export const EstBodyContainer = (
+  props: BoxProps & {
+    height: number,
+  }) => {
 
-}) => {
-
-  const [ancholErrEl, setAnchorErrEl] = useState<PopperProps['anchorEl']>();
-  const [errorMessage, setErrorMessage] = useState<string | undefined>();
-  const { getFieldState } = useFormContext<TypeOfForm>();
-
-  const handleMouseOver: BoxProps['onMouseOver'] = useCallback((e:  SyntheticEvent) => {
-    const target = e.target as HTMLInputElement;
-
-    if (target?.tagName === 'INPUT' && target?.name?.includes(estArrayFieldName)) {
-      const { error } = getFieldState(target.name as KeyOfForm);
-      if (error) {
-        setAnchorErrEl(target);
-        setErrorMessage(error?.message);
-      }
-    } else if (ancholErrEl) {
-      setAnchorErrEl(undefined);
-    }
-  }, [getFieldState, ancholErrEl ]);
-
-  const sx: SxProps = useMemo(() => ({
-    height: `${height}px`,
-    width: '100%',
-    position: 'relative',
-    border:1,
-    borderColor: grey[200],
-    borderRadius: 1,
-  }), [height]);
+  const {
+    height,
+    ...otherProps
+  } = props;
 
   return (
     <Box
-      sx={sx}
-      onMouseOver={handleMouseOver}
-    >
-      {children}
-      <ErrorPopover 
-        ancholErrEl={ancholErrEl}
-        errorMessage={errorMessage}
-      />
-    </Box>
+      sx={{
+        height: `${height}px`,
+        width: '100%',
+        position: 'relative',
+        border:1,
+        borderColor: grey[200],
+        borderRadius: 1,
+      }}
+      {...otherProps}
+    />
   );
 };

--- a/packages/kokoas-client/src/pages/projEstimate/tables/estimatesVirtual/EstBodyContainerEditable.tsx
+++ b/packages/kokoas-client/src/pages/projEstimate/tables/estimatesVirtual/EstBodyContainerEditable.tsx
@@ -1,0 +1,45 @@
+import {  BoxProps, PopperProps } from '@mui/material';
+import {  useCallback, SyntheticEvent, useState } from 'react';
+import { ErrorPopover } from './utilities/ErrorPopover';
+import { estArrayFieldName, KeyOfForm, TypeOfForm } from '../../form';
+import { useFormContext } from 'react-hook-form';
+import { EstBodyContainer } from './EstBodyContainer';
+
+export const EstBodyContainerEditable = ({
+  height,
+  children,
+}: BoxProps & {
+  height: number,
+}) => {
+
+  const [ancholErrEl, setAnchorErrEl] = useState<PopperProps['anchorEl']>();
+  const [errorMessage, setErrorMessage] = useState<string | undefined>();
+  const { getFieldState } = useFormContext<TypeOfForm>();
+
+  const handleMouseOver: BoxProps['onMouseOver'] = useCallback((e:  SyntheticEvent) => {
+    const target = e.target as HTMLInputElement;
+
+    if (target?.tagName === 'INPUT' && target?.name?.includes(estArrayFieldName)) {
+      const { error } = getFieldState(target.name as KeyOfForm);
+      if (error) {
+        setAnchorErrEl(target);
+        setErrorMessage(error?.message);
+      }
+    } else if (ancholErrEl) {
+      setAnchorErrEl(undefined);
+    }
+  }, [getFieldState, ancholErrEl ]);
+
+  return (
+    <EstBodyContainer
+      height={height}
+      onMouseOver={handleMouseOver}
+    >
+      {children}
+      <ErrorPopover
+        ancholErrEl={ancholErrEl}
+        errorMessage={errorMessage}
+      />
+    </EstBodyContainer>
+  );
+};

--- a/packages/kokoas-client/src/pages/projEstimate/tables/estimatesVirtual/readonly/EstBodyReadOnly.tsx
+++ b/packages/kokoas-client/src/pages/projEstimate/tables/estimatesVirtual/readonly/EstBodyReadOnly.tsx
@@ -1,0 +1,48 @@
+import { useVirtualizer } from '@tanstack/react-virtual';
+import { useOverlayContext } from 'kokoas-client/src/hooks/useOverlayContext';
+import { useFieldArray } from 'react-hook-form';
+import { TypeOfForm } from '../../../form';
+import { EstBodyContainer } from '../EstBodyContainer';
+import { EstHeader } from '../EstHeader';
+import { EstRowContainerReadOnly } from './EstRowContainerReadOnly';
+import { EstRowReadOnly } from './EstRowReadOnly';
+
+export const EstBodyReadOnly = () => {
+
+
+  const { fields: items } = useFieldArray<TypeOfForm>({
+    name: 'items',
+  });
+  const overlayRef = useOverlayContext();
+
+  const rowsCount = items.length;
+  const rowVirtualizer = useVirtualizer({
+    count: rowsCount,
+    getScrollElement: () => overlayRef.current,
+    estimateSize: () => 60,
+    overscan: 5,
+    paddingStart: 60,
+  });
+
+  return (
+    <EstBodyContainer height={rowVirtualizer.getTotalSize()}>
+      <EstHeader />
+      {rowVirtualizer.getVirtualItems().map((virtualRow) => {
+        const item = items[virtualRow.index];
+
+        return (
+          <EstRowContainerReadOnly
+            key={item.id}
+            rowIdx={virtualRow.index}
+            rowSize={virtualRow.size}
+            rowStart={virtualRow.start}
+          >
+            <div />
+            <EstRowReadOnly item={item} />
+            <div />
+          </EstRowContainerReadOnly>
+        );
+      })}
+    </EstBodyContainer>
+  );
+};

--- a/packages/kokoas-client/src/pages/projEstimate/tables/estimatesVirtual/readonly/EstCell.tsx
+++ b/packages/kokoas-client/src/pages/projEstimate/tables/estimatesVirtual/readonly/EstCell.tsx
@@ -1,0 +1,12 @@
+import { Typography, TypographyProps } from '@mui/material';
+import { grey } from '@mui/material/colors';
+
+export const EstCell = (props : TypographyProps) => {
+  return (
+    <Typography
+      {...props}
+      color={grey[900]}
+      fontSize={12}
+    />
+  );
+};

--- a/packages/kokoas-client/src/pages/projEstimate/tables/estimatesVirtual/readonly/EstRowContainerReadOnly.tsx
+++ b/packages/kokoas-client/src/pages/projEstimate/tables/estimatesVirtual/readonly/EstRowContainerReadOnly.tsx
@@ -1,0 +1,42 @@
+import { Stack, StackProps } from '@mui/material';
+import { grey, yellow } from '@mui/material/colors';
+
+export const EstRowContainerReadOnly = (props: StackProps & {
+  rowIdx: number,
+  rowSize: number,
+  rowStart: number,
+}) => {
+
+  const {
+    rowIdx,
+    rowSize,
+    rowStart,
+    ...otherProps
+  } = props;
+
+  return (
+    <Stack
+      direction={'row'}
+      justifyContent={'space-between'}
+      py={2}
+      spacing={1}
+      sx={{
+        position: 'absolute',
+        top: 0,
+        left: 0,
+        width: '100%',
+        minWidth: '600px',
+        background: rowIdx % 2 ? grey[50] : undefined,
+        '&:focus-within': {
+          background: yellow[50],
+        },
+        transition: 'all 0.5s',
+        height: `${rowSize}px`,
+      }}
+      style={{
+        transform: `translateY(${rowStart}px)`,
+      }}
+      {...otherProps}
+    />
+  );
+};

--- a/packages/kokoas-client/src/pages/projEstimate/tables/estimatesVirtual/readonly/EstRowReadOnly.tsx
+++ b/packages/kokoas-client/src/pages/projEstimate/tables/estimatesVirtual/readonly/EstRowReadOnly.tsx
@@ -1,0 +1,84 @@
+import { FieldArrayWithId } from 'react-hook-form';
+import { TypeOfForm } from '../../../form';
+import { EstRowFormat } from '../EstRowFormat';
+import { EstCell } from './EstCell';
+
+export const EstRowReadOnly = ({
+  item,
+}:{
+  item: FieldArrayWithId<TypeOfForm, 'items', 'id'>
+})  => {
+  const {
+    majorItem,
+    middleItem,
+    material,
+    materialDetails,
+    costPrice,
+    quantity,
+    unit,
+    materialProfRate,
+    taxable,
+    unitPrice,
+    rowUnitPriceAfterTax,
+    rowDetails,
+  } = item;
+  return (
+    <EstRowFormat
+      majorItem={(
+        <EstCell>
+          {majorItem}
+        </EstCell>
+      )}
+      middleItem={(
+        <EstCell>
+          {middleItem}
+        </EstCell>
+      )}
+      material={(
+        <EstCell>
+          {material}
+        </EstCell>
+      )}
+      materialDetails={(
+        <EstCell>
+          {materialDetails}
+        </EstCell>
+      )}
+      costPrice={(
+        <EstCell textAlign={'right'}>
+          {`${costPrice.toLocaleString()} 円`}
+        </EstCell>
+      )}
+      quantity={(
+        <EstCell>
+          {`${quantity.toLocaleString()} ${unit}`}
+        </EstCell>
+      )}
+      profitRate={(
+        <EstCell>
+          {`${materialProfRate} %`}
+        </EstCell>
+      )}
+      taxType={(
+        <EstCell>
+          {`${taxable ? '課税' : '非課税'}`}
+        </EstCell>
+      )}
+      unitPrice={(
+        <EstCell textAlign={'right'}>
+          {`${unitPrice.toLocaleString()} 円`}
+        </EstCell>
+      )}
+      rowUnitPrice={(
+        <EstCell textAlign={'right'}>
+          {`${rowUnitPriceAfterTax.toLocaleString()} 円`}
+        </EstCell>
+      )}
+      rowDetails={(
+        <EstCell>
+          {rowDetails}
+        </EstCell>
+      )}
+    />
+  );
+};


### PR DESCRIPTION
## 変更

- 見積は契約があると、Textfieldをdisabledになっていましたが、閲覧のみのデータを表示するようになりました。
- ![image](https://user-images.githubusercontent.com/2501255/211130684-323764fd-1dc5-4591-a2c7-873d16f31ab7.png)

## 変更理由

- レンダリングがより軽くするために。これで、要らないハンドラーやコンポーネントを処理しないので、早くなります。