### PR TITLE
fix-88-円マークがバックスラッシュで表示されてしまう

### DIFF
--- a/packages/kokoas-client/src/components/ui/upload/daikokuEstimate/uploadDialog/stepCheckItems/ItemRow.tsx
+++ b/packages/kokoas-client/src/components/ui/upload/daikokuEstimate/uploadDialog/stepCheckItems/ItemRow.tsx
@@ -90,7 +90,7 @@ export const ItemRow = ({
       )}
       rowDetails={(
         <ItemCell>
-          {rowDetails}
+          {rowDetails.replace('\\', '￥')}
         </ItemCell>
       )}
     />

--- a/packages/kokoas-client/src/components/ui/upload/daikokuEstimate/uploadDialog/stepCheckItems/ItemRow.tsx
+++ b/packages/kokoas-client/src/components/ui/upload/daikokuEstimate/uploadDialog/stepCheckItems/ItemRow.tsx
@@ -90,7 +90,7 @@ export const ItemRow = ({
       )}
       rowDetails={(
         <ItemCell>
-          {rowDetails.replace('\\', '￥')}
+          {rowDetails.replaceAll('\\', '￥')}
         </ItemCell>
       )}
     />


### PR DESCRIPTION
## 変更

- 表示の際、`\` を　`￥` に変換

## 変更理由

- #88 

## 備考

- 解決案ですが、`&yen;`は　`innerHTML` ※１　を利用する時、いい方法ですが、今までの文字列操作 ※２はJavascriptでやっているので、統一化させるために `replaceAll` にしました。でも、日本特有の課題なので、私が気づいていないことがあれば、教えてください。


※１ Reactで、HTML entity を表示するには、JSXの中にそのままに入れます。よって、備考の各バックスラッシュを取り出して `<>{備考部分} &yen; {備考部分}</>` に書き換えるか、`dangerouslySetInnerHTML ` を 利用することになります。  
※２ `toLocaleString()` や `split()` や `format() `など

