### PR TITLE
工事情報画面：編集か登録でタイトルを生成する

### DIFF
--- a/packages/kokoas-client/src/pages/projRegister/FormConstruction.tsx
+++ b/packages/kokoas-client/src/pages/projRegister/FormConstruction.tsx
@@ -12,7 +12,6 @@ import { ProjectShortCuts } from './parts/ProjectShortCuts';
 import { UneditableInfo } from 'kokoas-client/src/components/ui/information/UneditableInfo';
 import { RecordSelect } from './sections/RecordSelect/RecordSelect';
 
-
 export const FormConstruction  = () => {
 
   const {
@@ -41,7 +40,7 @@ export const FormConstruction  = () => {
 
       <MainContainer>
         <PageTitle
-          label="工事情報登録"
+          label={`工事情報${projId ? '編集' : '登録'}`}
           color="#60498C"
           textColor='#FFF'
           secondaryLabel={projDataId}


### PR DESCRIPTION
## 変更

- 工事情報画面：編集か登録でタイトルを生成する

## 理由

- 工事情報が関わるタスクがあり、当PRで修正をしました。