### PR TITLE
fix-契約がある工事なのに、警告が出ない

### DIFF
--- a/packages/kokoas-client/src/hooksQuery/useProjHasContract.ts
+++ b/packages/kokoas-client/src/hooksQuery/useProjHasContract.ts
@@ -8,11 +8,11 @@ import { getEstimatesByProjId } from 'api-kintone';
 export const useProjHasContract = (
   projId = '',
 ) => {
+
   return useQuery(
     [AppIds.projEstimates, { projId }],
     () =>  getEstimatesByProjId(projId),
     {
-
       enabled: !!projId,
       select: ({ records }) => {
         return records?.some(({ envStatus }) => !!envStatus.value);

--- a/packages/kokoas-client/src/hooksQuery/useProjHasContract.ts
+++ b/packages/kokoas-client/src/hooksQuery/useProjHasContract.ts
@@ -8,7 +8,6 @@ import { getEstimatesByProjId } from 'api-kintone';
 export const useProjHasContract = (
   projId = '',
 ) => {
-
   return useQuery(
     [AppIds.projEstimates, { projId }],
     () =>  getEstimatesByProjId(projId),

--- a/packages/kokoas-client/src/hooksQuery/useProjHasContract.ts
+++ b/packages/kokoas-client/src/hooksQuery/useProjHasContract.ts
@@ -12,6 +12,7 @@ export const useProjHasContract = (
     [AppIds.projEstimates, { projId }],
     () =>  getEstimatesByProjId(projId),
     {
+
       enabled: !!projId,
       select: ({ records }) => {
         return records?.some(({ envStatus }) => !!envStatus.value);

--- a/packages/kokoas-client/src/pages/projRegister/FormConstruction.tsx
+++ b/packages/kokoas-client/src/pages/projRegister/FormConstruction.tsx
@@ -16,7 +16,6 @@ import { RecordSelect } from './sections/RecordSelect/RecordSelect';
 export const FormConstruction  = () => {
 
   const {
-    status,
     submitForm,
     values,
     dirty,
@@ -29,10 +28,11 @@ export const FormConstruction  = () => {
     projTypeId,
     projDataId,
     custGroupId,
+    hasContract,
   } = values;
 
-  const isEditMode = window.location.href.includes('edit');
-  const isFormDisabled = (status as TFormStatus) === 'disabled';
+  const isEditMode = !!projId;
+  const isFormDisabled = hasContract;
 
   return (
 

--- a/packages/kokoas-client/src/pages/projRegister/form.ts
+++ b/packages/kokoas-client/src/pages/projRegister/form.ts
@@ -1,6 +1,5 @@
 
 import {
-  TEnvelopeStatus,
   Territory,
   RecordStatus,
   RecordCancelStatus,
@@ -39,7 +38,7 @@ export const initialValues = {
   buildingType: '戸建て' as BuildingType,
   isChkAddressKari: false,
   status: '追客中' as RecordStatus,
-  envelopeStatus: '' as TEnvelopeStatus,
+  hasContract: false,
   cancelStatus: [] as RecordCancelStatus[],
 };
 

--- a/packages/kokoas-client/src/pages/projRegister/hooks/useResolveParams.ts
+++ b/packages/kokoas-client/src/pages/projRegister/hooks/useResolveParams.ts
@@ -1,8 +1,10 @@
 
 
 
+import { useIsFetching } from '@tanstack/react-query';
+import { useBackdrop } from 'kokoas-client/src/hooks';
 import { useURLParams } from 'kokoas-client/src/hooks/useURLParams';
-import { useProjById, useCustGroupById } from 'kokoas-client/src/hooksQuery';
+import { useProjById, useCustGroupById, useProjHasContract } from 'kokoas-client/src/hooksQuery';
 import { useEffect, useState } from 'react';
 import { convertCustGroupToForm, convertProjToForm } from '../api/convertToForm';
 import { TypeOfForm, initialValues } from '../form';
@@ -11,8 +13,9 @@ import { TypeOfForm, initialValues } from '../form';
  * URLで渡されたものを処理する
  */
 export const useResolveParams = () => {
+  const { setBackdropState } = useBackdrop();
   const [initForm, setInitForm] = useState<TypeOfForm>(initialValues);
-
+  const isFetching = useIsFetching();
   const {
     projId: projIdFromURL,
     custGroupId: custGroupIdFromURL,
@@ -23,13 +26,20 @@ export const useResolveParams = () => {
 
   const { data: custGroupRec } = useCustGroupById(projRec?.custGroupId.value || custGroupIdFromURL || '');
 
+  const { data: hasContract  = false } = useProjHasContract(projRec?.uuid.value);
 
   useEffect(() => {
+
+    if (isFetching) {
+      setBackdropState({ open: true });
+      return;
+    }
 
     if (projIdFromURL && projRec && custGroupRec) {
 
       setInitForm({
         ...initialValues,
+        hasContract,
         ...convertProjToForm(projRec),
         ...convertCustGroupToForm(custGroupRec),
       });
@@ -44,7 +54,11 @@ export const useResolveParams = () => {
     } else if (!custGroupIdFromURL && !projIdFromURL) {
       setInitForm(initialValues);
     }
-  }, [projRec, custGroupRec, projIdFromURL, custGroupIdFromURL ]);
+
+    // バックドロップを隠す
+    setBackdropState({ open: false });
+
+  }, [projRec, custGroupRec, projIdFromURL, custGroupIdFromURL, hasContract, isFetching, setBackdropState ]);
 
   return initForm;
 };

--- a/packages/kokoas-client/src/pages/projRegister/hooks/useResolveParams.ts
+++ b/packages/kokoas-client/src/pages/projRegister/hooks/useResolveParams.ts
@@ -1,8 +1,6 @@
 
 
 
-import { useIsFetching } from '@tanstack/react-query';
-import { useBackdrop } from 'kokoas-client/src/hooks';
 import { useURLParams } from 'kokoas-client/src/hooks/useURLParams';
 import { useProjById, useCustGroupById, useProjHasContract } from 'kokoas-client/src/hooksQuery';
 import { useEffect, useState } from 'react';
@@ -13,9 +11,7 @@ import { TypeOfForm, initialValues } from '../form';
  * URLで渡されたものを処理する
  */
 export const useResolveParams = () => {
-  const { setBackdropState } = useBackdrop();
   const [initForm, setInitForm] = useState<TypeOfForm>(initialValues);
-  const isFetching = useIsFetching();
   const {
     projId: projIdFromURL,
     custGroupId: custGroupIdFromURL,
@@ -30,13 +26,7 @@ export const useResolveParams = () => {
 
   useEffect(() => {
 
-    if (isFetching) {
-      setBackdropState({ open: true });
-      return;
-    }
-
     if (projIdFromURL && projRec && custGroupRec) {
-
       setInitForm({
         ...initialValues,
         hasContract,
@@ -45,7 +35,6 @@ export const useResolveParams = () => {
       });
 
     } else if (custGroupIdFromURL && !projIdFromURL && custGroupRec) {
-
       setInitForm({
         ...initialValues,
         ...convertCustGroupToForm(custGroupRec),
@@ -53,12 +42,12 @@ export const useResolveParams = () => {
 
     } else if (!custGroupIdFromURL && !projIdFromURL) {
       setInitForm(initialValues);
+
     }
 
-    // バックドロップを隠す
-    setBackdropState({ open: false });
 
-  }, [projRec, custGroupRec, projIdFromURL, custGroupIdFromURL, hasContract, isFetching, setBackdropState ]);
+
+  }, [projRec, custGroupRec, projIdFromURL, custGroupIdFromURL, hasContract ]);
 
   return initForm;
 };

--- a/packages/kokoas-client/src/pages/projRegister/sections/ConstructionInfo/ConstructionInfo.tsx
+++ b/packages/kokoas-client/src/pages/projRegister/sections/ConstructionInfo/ConstructionInfo.tsx
@@ -3,13 +3,12 @@ import { Grid, FormHelperText, Button } from '@mui/material';
 import { PageSubTitle } from '../../../../components/ui/labels/';
 import { ConstructionAgent } from './ConstructionAgent';
 import { FormikLabeledCheckBox } from '../../../../components/ui/checkboxes';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { FormikSelect } from '../../../../components/ui/selects';
 import { FormikTextFieldV2 as  FormikTextField } from '../../../../components/ui/textfield';
 import { TypeOfForm, getFieldName } from '../../form';
 import { useFormikContext } from 'formik';
-import { useProjHasContract, useProjTypes } from 'kokoas-client/src/hooksQuery/';
-import { useBackdrop } from 'kokoas-client/src/hooks';
+import { useProjTypes } from 'kokoas-client/src/hooksQuery/';
 import { ContractDetails } from './ContractDetails';
 import { Territory } from 'types';
 
@@ -25,18 +24,13 @@ export const ConstructionInfo = (
   const { storeId, territory } = props;
 
   const {
-    status,
     values: {
       cocoConst1,
       projId,
+      hasContract,
     },
     setValues,
   } = useFormikContext<TypeOfForm>();
-
-  const isReadOnly = (status as TFormStatus) === 'disabled';
-
-  const { setBackdropState } = useBackdrop();
-  const { data, isFetching } = useProjHasContract(projId);
 
   const { data: projTypeOptions } = useProjTypes<Options>({
     select: (d) => d
@@ -60,9 +54,6 @@ export const ConstructionInfo = (
     setOpen(false);
   };
 
-  useEffect(() => {
-    setBackdropState({ open: isFetching });
-  }, [isFetching, setBackdropState]);
 
   return (
     <>
@@ -74,7 +65,7 @@ export const ConstructionInfo = (
         <Grid item xs={12} md={8}>
           {projTypeOptions &&
           <FormikSelect name={getFieldName('projTypeId')} label={'工事種別'}
-            disabled={isReadOnly || data}
+            disabled={hasContract}
             options={projTypeOptions}
             required
             onChange={(_, newTextVal) => {
@@ -88,7 +79,7 @@ export const ConstructionInfo = (
         </Grid>
 
         <Grid item xs={12} md={4}>
-          {data &&
+          {hasContract &&
             <>
               <FormHelperText>
                 契約済みのため編集できません
@@ -106,7 +97,7 @@ export const ConstructionInfo = (
         </Grid>
         <Grid item xs={12}>
           <FormikTextField name={getFieldName('projName')} label="工事名称" placeholder="氏名/会社名様邸　工事種別"
-            disabled={isReadOnly} required
+            disabled={hasContract} required
           />
         </Grid>
       </Grid>
@@ -121,7 +112,7 @@ export const ConstructionInfo = (
             >
               <ConstructionAgent
                 number={num}
-                disabled={(!cocoConst1 && num === 2) || isReadOnly}
+                disabled={(!cocoConst1 && num === 2) || hasContract}
                 storeId={storeId}
                 territory={territory}
               />
@@ -131,7 +122,7 @@ export const ConstructionInfo = (
 
         <Grid item xs={12} md={4}>
           <FormikLabeledCheckBox name={getFieldName('isAgentConfirmed')} label="工事担当者を確定する" helperText='※工事担当者が未定の場合はチェックしないでください。'
-            disabled={isReadOnly}
+            disabled={hasContract}
           />
 
         </Grid>


### PR DESCRIPTION
## 変更

- 契約あるかどうかの判定はフォームの初期化フックへ移動しました。
- Formikのstatusを利用していましたが、削除しました。

## 理由

- プロジェクトの見積もりの中に一つでも契約になったら、警告が出るはずですが、出なくなりました。react-queryの移行の時、見落としました。
- Formikのstatusの利用目的が無くなっようです。認識違いなら教えてください。