### PR TITLE
請求入力：請求する見積りのIDをURLに追加する

### DIFF
--- a/packages/kokoas-client/src/pages/projInvoice/api/convertInvoiceToForm.ts
+++ b/packages/kokoas-client/src/pages/projInvoice/api/convertInvoiceToForm.ts
@@ -7,6 +7,7 @@ export const convertInvoiceToForm = (
   recInvoice: DBInvoices.SavedData,
   estimates: TMaterials[],
   datInvoicesTotal: EstimateList[],
+  estimateIdArray: string[],
 ): Partial<TypeOfForm> => {
   const {
     uuid,
@@ -43,6 +44,8 @@ export const convertInvoiceToForm = (
       return dataIdOfInvoice === dataId;
     })?.billedAmount ?? '0';
 
+    const isForPaymentFromURL = estimateIdArray.some((id) => id === estimateId);
+
     acc.push({
       estimateIndex: String(idx),
       projId: projId,
@@ -53,7 +56,7 @@ export const convertInvoiceToForm = (
       billedAmount: Number(Big(tgtBilledAmount).minus(tgtBillingAmount)),
       billingAmount: Number(tgtBillingAmount),
       amountType: amountType,
-      isForPayment: tgtBillingAmount === '0' ? false : true,
+      isForPayment: ((tgtBillingAmount === '0') && !isForPaymentFromURL) ? false : true,
       estimateId: estimateId,
     });
 

--- a/packages/kokoas-client/src/pages/projInvoice/api/convertInvoiceToForm.ts
+++ b/packages/kokoas-client/src/pages/projInvoice/api/convertInvoiceToForm.ts
@@ -56,7 +56,7 @@ export const convertInvoiceToForm = (
       billedAmount: Number(Big(tgtBilledAmount).minus(tgtBillingAmount)),
       billingAmount: Number(tgtBillingAmount),
       amountType: amountType,
-      isForPayment: ((tgtBillingAmount === '0') && !isForPaymentFromURL) ? false : true,
+      isForPayment: tgtBillingAmount !== '0' || isForPaymentFromURL,
       estimateId: estimateId,
     });
 

--- a/packages/kokoas-client/src/pages/projInvoice/fieldComponents/EstimatesTableBody.tsx
+++ b/packages/kokoas-client/src/pages/projInvoice/fieldComponents/EstimatesTableBody.tsx
@@ -1,6 +1,9 @@
 import { TableCell, TableRow, Typography } from '@mui/material';
 import { FormikLabeledCheckBox } from 'kokoas-client/src/components';
+import { generateParams } from 'kokoas-client/src/helpers/url';
 import { roundTo } from 'libs';
+import { useNavigate } from 'react-router-dom';
+import { pages } from '../../Router';
 import { getEstimatesFieldName, TMaterials } from '../form';
 
 const CellContent = ({
@@ -25,6 +28,8 @@ export const EstimateTableBody = ({
 }: {
   estimateRow: TMaterials
 }) => {
+
+  const navigate = useNavigate();
 
   const {
     contractAmount,
@@ -70,6 +75,7 @@ export const EstimateTableBody = ({
         {/* 請求に使用する */}
         <FormikLabeledCheckBox
           name={getEstimatesFieldName(+estimateRow.estimateIndex, 'isForPayment')}
+          onChange={(_, val) => navigate(`${pages.projInvoice}?${generateParams({ projEstimateId: val?. })}`)}
           disabled={disabled}
         />
       </TableCell>

--- a/packages/kokoas-client/src/pages/projInvoice/fieldComponents/EstimatesTableBody.tsx
+++ b/packages/kokoas-client/src/pages/projInvoice/fieldComponents/EstimatesTableBody.tsx
@@ -5,6 +5,7 @@ import { roundTo } from 'libs';
 import { useNavigate } from 'react-router-dom';
 import { pages } from '../../Router';
 import { getEstimatesFieldName, TMaterials } from '../form';
+import { useURLParams } from '../../../hooks/useURLParams';
 
 const CellContent = ({
   content,
@@ -32,9 +33,44 @@ export const EstimateTableBody = ({
   const navigate = useNavigate();
 
   const {
+    invoiceId: projInvoiceIdFromURL,
+    custGroupId: custGroupIdFromURL,
+    projEstimateId: estimateIdFromURL,
+  } = useURLParams();
+
+
+  const {
     contractAmount,
     billedAmount,
+    estimateId,
   } = estimateRow;
+
+  const handleChange = (_: any, val: boolean | null) => {
+    let newEstimateId = (estimateIdFromURL)?.split(', ');
+    if (val) { // チェックが入った時は、estimateIdをURLに追加する
+      if (newEstimateId) {
+        newEstimateId?.push(estimateId);
+      } else {
+        newEstimateId = [estimateId];
+      }
+    } else {
+      newEstimateId = newEstimateId?.filter((item) => {
+        return item !== estimateId;
+      });
+    }
+
+    const urlParams = (projInvoiceIdFromURL) ?
+      generateParams({
+        invoiceId: projInvoiceIdFromURL,
+        projEstimateId: newEstimateId?.join(', '),
+      }) :
+      generateParams({
+        custGroupId: custGroupIdFromURL,
+        projEstimateId: newEstimateId?.join(', '),
+      });
+
+    navigate(`${pages.projInvoice}?${urlParams}`);
+  };
 
   const isRefund = contractAmount < 0;
   const disabled = !isRefund ? contractAmount <= billedAmount : contractAmount >= billedAmount;
@@ -75,7 +111,7 @@ export const EstimateTableBody = ({
         {/* 請求に使用する */}
         <FormikLabeledCheckBox
           name={getEstimatesFieldName(+estimateRow.estimateIndex, 'isForPayment')}
-          onChange={(_, val) => navigate(`${pages.projInvoice}?${generateParams({ projEstimateId: val?. })}`)}
+          onChange={handleChange}
           disabled={disabled}
         />
       </TableCell>

--- a/packages/kokoas-client/src/pages/projInvoice/fieldComponents/EstimatesTableBody.tsx
+++ b/packages/kokoas-client/src/pages/projInvoice/fieldComponents/EstimatesTableBody.tsx
@@ -45,28 +45,20 @@ export const EstimateTableBody = ({
     estimateId,
   } = estimateRow;
 
-  const handleChange = (_: any, val: boolean | null) => {
-    let newEstimateId = (estimateIdFromURL)?.split(', ');
-    if (val) { // チェックが入った時は、estimateIdをURLに追加する
-      if (newEstimateId) {
-        newEstimateId?.push(estimateId);
-      } else {
-        newEstimateId = [estimateId];
-      }
-    } else {
-      newEstimateId = newEstimateId?.filter((item) => {
-        return item !== estimateId;
-      });
-    }
+  const handleChange = (checked: boolean) => {
+    const estimateIdArray = (estimateIdFromURL)?.split(', ') ?? [];
+    const newEstimateIdArray = checked
+      ? [...estimateIdArray, estimateId]
+      : estimateIdArray.filter((id) => id !== estimateId);
 
     const urlParams = (projInvoiceIdFromURL) ?
       generateParams({
         invoiceId: projInvoiceIdFromURL,
-        projEstimateId: newEstimateId?.join(', '),
+        projEstimateId: newEstimateIdArray?.join(', '),
       }) :
       generateParams({
         custGroupId: custGroupIdFromURL,
-        projEstimateId: newEstimateId?.join(', '),
+        projEstimateId: newEstimateIdArray?.join(', '),
       });
 
     navigate(`${pages.projInvoice}?${urlParams}`);
@@ -111,7 +103,7 @@ export const EstimateTableBody = ({
         {/* 請求に使用する */}
         <FormikLabeledCheckBox
           name={getEstimatesFieldName(+estimateRow.estimateIndex, 'isForPayment')}
-          onChange={handleChange}
+          onChange={(_, checked) => handleChange(checked)}
           disabled={disabled}
         />
       </TableCell>

--- a/packages/kokoas-client/src/pages/projInvoice/fieldComponents/EstimatesTableBody.tsx
+++ b/packages/kokoas-client/src/pages/projInvoice/fieldComponents/EstimatesTableBody.tsx
@@ -46,20 +46,16 @@ export const EstimateTableBody = ({
   } = estimateRow;
 
   const handleChange = (checked: boolean) => {
-    const estimateIdArray = (estimateIdFromURL)?.split(', ') ?? [];
+    const estimateIdArray = (estimateIdFromURL)?.split(',') ?? [];
     const newEstimateIdArray = checked
       ? [...estimateIdArray, estimateId]
       : estimateIdArray.filter((id) => id !== estimateId);
 
-    const urlParams = (projInvoiceIdFromURL) ?
-      generateParams({
-        invoiceId: projInvoiceIdFromURL,
-        projEstimateId: newEstimateIdArray?.join(', '),
-      }) :
-      generateParams({
-        custGroupId: custGroupIdFromURL,
-        projEstimateId: newEstimateIdArray?.join(', '),
-      });
+    const urlParams = generateParams({
+      invoiceId: projInvoiceIdFromURL,
+      custGroupId: custGroupIdFromURL,
+      projEstimateId: newEstimateIdArray?.join(','),
+    });
 
     navigate(`${pages.projInvoice}?${urlParams}`);
   };

--- a/packages/kokoas-client/src/pages/projInvoice/hooks/useResolveParams.ts
+++ b/packages/kokoas-client/src/pages/projInvoice/hooks/useResolveParams.ts
@@ -15,6 +15,7 @@ export const useResolveParams = () => {
   const {
     invoiceId: projInvoiceIdFromURL,
     custGroupId: custGroupIdFromURL,
+    projEstimateId: estimateIdFromURL,
   } = useURLParams();
 
   const {
@@ -50,6 +51,8 @@ export const useResolveParams = () => {
         draft.custName = custData.custNames.value;
         newEstimates?.forEach((data, idx) => {
           const tgtBilledAmount = datInvoicesTotal?.find(({ dataId }) => dataId === data.dataId)?.billedAmount ?? '0';
+          const newIsForPayment = estimateIdFromURL?.split(', ').some((item) => item === data.estimateId) ?? false;
+
 
           draft.estimates[idx] = {
             estimateIndex: String(idx),
@@ -61,7 +64,7 @@ export const useResolveParams = () => {
             billedAmount: Number(tgtBilledAmount),
             billingAmount: data.billingAmount,
             amountType: '',
-            isForPayment: data.isForPayment,
+            isForPayment: data.isForPayment || newIsForPayment,
             estimateId: data.estimateId,
           };
         });

--- a/packages/kokoas-client/src/pages/projInvoice/hooks/useResolveParams.ts
+++ b/packages/kokoas-client/src/pages/projInvoice/hooks/useResolveParams.ts
@@ -51,8 +51,7 @@ export const useResolveParams = () => {
         draft.custName = custData.custNames.value;
         newEstimates?.forEach((data, idx) => {
           const tgtBilledAmount = datInvoicesTotal?.find(({ dataId }) => dataId === data.dataId)?.billedAmount ?? '0';
-          const newIsForPayment = estimateIdFromURL?.split(',').some((item) => item === data.estimateId) ?? false;
-
+          const newIsForPayment = (estimateIdFromURL || '').split(',').includes(data.estimateId);
 
           draft.estimates[idx] = {
             estimateIndex: String(idx),

--- a/packages/kokoas-client/src/pages/projInvoice/hooks/useResolveParams.ts
+++ b/packages/kokoas-client/src/pages/projInvoice/hooks/useResolveParams.ts
@@ -39,7 +39,7 @@ export const useResolveParams = () => {
       setValues((prev) => ({
         ...prev,
         ...convertCustDataToForm(custData),
-        ...convertInvoiceToForm(recInvoice.record, newEstimates, datInvoicesTotal),
+        ...convertInvoiceToForm(recInvoice.record, newEstimates, datInvoicesTotal, estimateIdFromURL?.split(',') ?? []),
         invoiceId: projInvoiceIdFromURL,
       }));
     } else if (custGroupIdFromURL && custData && recContracts) {
@@ -51,7 +51,7 @@ export const useResolveParams = () => {
         draft.custName = custData.custNames.value;
         newEstimates?.forEach((data, idx) => {
           const tgtBilledAmount = datInvoicesTotal?.find(({ dataId }) => dataId === data.dataId)?.billedAmount ?? '0';
-          const newIsForPayment = estimateIdFromURL?.split(', ').some((item) => item === data.estimateId) ?? false;
+          const newIsForPayment = estimateIdFromURL?.split(',').some((item) => item === data.estimateId) ?? false;
 
 
           draft.estimates[idx] = {
@@ -84,6 +84,7 @@ export const useResolveParams = () => {
     recContracts,
     datInvoicesTotal,
     recInvoice,
+    estimateIdFromURL,
   ]);
 
 };


### PR DESCRIPTION
**変更**
---

 - 請求入力画面に置いて、「請求に使用する」にチェックを入れた際、チェックした見積もりのIDをURLに追加します。
 - 同様に、チェックを外した際には見積もりのIDをURLから削除します。


**変更理由**
---

 - https://trello.com/c/qJ4VmnR9