### PR TITLE
請求入力：契約金額と符号の異なる請求金額は入力不可にする

### DIFF
--- a/packages/kokoas-client/src/pages/projInvoice/FormInvoice.tsx
+++ b/packages/kokoas-client/src/pages/projInvoice/FormInvoice.tsx
@@ -36,7 +36,7 @@ export const FormInvoice = () => {
   useResolveParams();
 
 
-  const exceeded = estimates.some(({ contractAmount, billedAmount, billingAmount, isForPayment }) => {
+  const totalAmountExceeded = estimates.some(({ contractAmount, billedAmount, billingAmount, isForPayment }) => {
     const totalBilledAmount = +billedAmount + +billingAmount;
     const isUnderContractAmount = (+contractAmount > 0) && (totalBilledAmount > +contractAmount);
     const isOverContractAmount = (+contractAmount <= 0) && (totalBilledAmount < +contractAmount);
@@ -47,9 +47,9 @@ export const FormInvoice = () => {
   useEffect(() => {
     setValues((prev) => ({
       ...prev,
-      exceededContract: exceeded,
+      exceededContract: totalAmountExceeded,
     }));
-  }, [setValues, exceeded]);
+  }, [setValues, totalAmountExceeded]);
 
   useEffect(() => {
     if (!isEmpty(errors) && submitCount !== submitCountRef.current) {
@@ -114,7 +114,7 @@ export const FormInvoice = () => {
                   {'※請求には課税対象分から使用し、非課税額は最後に使用します'}
                 </Typography>
               </Stack>
-              <BillingEntryTable exceeded={exceeded} />
+              <BillingEntryTable totalAmountExceeded={totalAmountExceeded} />
             </Grid>
 
 

--- a/packages/kokoas-client/src/pages/projInvoice/FormInvoice.tsx
+++ b/packages/kokoas-client/src/pages/projInvoice/FormInvoice.tsx
@@ -38,9 +38,9 @@ export const FormInvoice = () => {
 
   const exceeded = estimates.some(({ contractAmount, billedAmount, billingAmount, isForPayment }) => {
     if (+contractAmount > 0) {
-      return isForPayment && ((+contractAmount < (+billedAmount + +billingAmount)) || +billingAmount < 0);
+      return isForPayment && (+contractAmount < (+billedAmount + +billingAmount));
     }
-    return isForPayment && ((+contractAmount > (+billedAmount + +billingAmount)) || +billingAmount > 0);
+    return isForPayment && (+contractAmount > (+billedAmount + +billingAmount));
 
   });
 

--- a/packages/kokoas-client/src/pages/projInvoice/FormInvoice.tsx
+++ b/packages/kokoas-client/src/pages/projInvoice/FormInvoice.tsx
@@ -37,11 +37,11 @@ export const FormInvoice = () => {
 
 
   const exceeded = estimates.some(({ contractAmount, billedAmount, billingAmount, isForPayment }) => {
-    if (+contractAmount > 0) {
-      return isForPayment && (+contractAmount < (+billedAmount + +billingAmount));
-    }
-    return isForPayment && (+contractAmount > (+billedAmount + +billingAmount));
+    const totalBilledAmount = +billedAmount + +billingAmount;
+    const isUnderContractAmount = (+contractAmount > 0) && (totalBilledAmount > +contractAmount);
+    const isOverContractAmount = (+contractAmount <= 0) && (totalBilledAmount < +contractAmount);
 
+    return isForPayment && (isUnderContractAmount || isOverContractAmount);
   });
 
   useEffect(() => {

--- a/packages/kokoas-client/src/pages/projInvoice/fieldComponents/BillingEntryTable.tsx
+++ b/packages/kokoas-client/src/pages/projInvoice/fieldComponents/BillingEntryTable.tsx
@@ -39,6 +39,7 @@ export const BillingEntryTable = ({
                     estimate={row}
                     idx={idx}
                     paymentList={contracts?.paymentList}
+                    exceeded={exceeded}
                     key={`${row.dataId}_row`}
                   />
                 );

--- a/packages/kokoas-client/src/pages/projInvoice/fieldComponents/BillingEntryTable.tsx
+++ b/packages/kokoas-client/src/pages/projInvoice/fieldComponents/BillingEntryTable.tsx
@@ -39,7 +39,6 @@ export const BillingEntryTable = ({
                     estimate={row}
                     idx={idx}
                     paymentList={contracts?.paymentList}
-                    exceeded={exceeded}
                     key={`${row.dataId}_row`}
                   />
                 );

--- a/packages/kokoas-client/src/pages/projInvoice/fieldComponents/BillingEntryTable.tsx
+++ b/packages/kokoas-client/src/pages/projInvoice/fieldComponents/BillingEntryTable.tsx
@@ -8,9 +8,9 @@ import { BillingEntryTableHead } from './BillingEntryTableHead';
 import { ExceedContractAmount } from './ExceedContractAmount';
 
 export const BillingEntryTable = ({
-  exceeded,
+  totalAmountExceeded,
 }: {
-  exceeded: boolean
+  totalAmountExceeded: boolean
 }) => {
 
   const { values } = useFormikContext<TypeOfForm>();
@@ -46,7 +46,7 @@ export const BillingEntryTable = ({
             </TableBody>
           </Table>
         </TableContainer>}
-      {exceeded && <ExceedContractAmount />}
+      {totalAmountExceeded && <ExceedContractAmount />}
     </>
   );
 };

--- a/packages/kokoas-client/src/pages/projInvoice/fieldComponents/BillingEntryTableRow.tsx
+++ b/packages/kokoas-client/src/pages/projInvoice/fieldComponents/BillingEntryTableRow.tsx
@@ -11,21 +11,22 @@ export const BillingEntryTableRow = ({
   estimate,
   idx,
   paymentList,
-  exceeded,
 }: {
   estimate: TMaterials
   idx: number
   paymentList: ReturnType<typeof createPaymentList>[] | undefined
-  exceeded: boolean
 }) => {
   const {
     setValues,
   } = useFormikContext<TypeOfForm>();
 
-  const { 
+  const {
     projTypeName,
     estimateId,
     dataId,
+    contractAmount,
+    billedAmount,
+    billingAmount,
   } = estimate;
 
   const paymentItem = paymentList?.find(({ uuid }) => uuid === estimateId);
@@ -57,6 +58,14 @@ export const BillingEntryTableRow = ({
       return newVal;
     });
   };
+
+  const newBillingAmount = (+billedAmount + +billingAmount);
+  let exceeded = false;
+  if (+contractAmount >= 0) {
+    exceeded = (+contractAmount < newBillingAmount) || (+billingAmount < 0);
+  } else {
+    exceeded = (+contractAmount > newBillingAmount) || (+billingAmount > 0);
+  }
 
 
   return (

--- a/packages/kokoas-client/src/pages/projInvoice/fieldComponents/BillingEntryTableRow.tsx
+++ b/packages/kokoas-client/src/pages/projInvoice/fieldComponents/BillingEntryTableRow.tsx
@@ -60,11 +60,11 @@ export const BillingEntryTableRow = ({
   };
 
   const newBillingAmount = (+billedAmount + +billingAmount);
-  let exceeded = false;
+  let rowAmountExceeded = false;
   if (+contractAmount >= 0) {
-    exceeded = (+contractAmount < newBillingAmount) || (+billingAmount < 0);
+    rowAmountExceeded = (+contractAmount < newBillingAmount) || (+billingAmount < 0);
   } else {
-    exceeded = (+contractAmount > newBillingAmount) || (+billingAmount > 0);
+    rowAmountExceeded = (+contractAmount > newBillingAmount) || (+billingAmount > 0);
   }
 
 
@@ -93,7 +93,7 @@ export const BillingEntryTableRow = ({
         />
       </TableCell>
       <TableCell>
-        {exceeded && <WarningIcon />}
+        {rowAmountExceeded && <WarningIcon color='warning' />}
       </TableCell>
     </TableRow>
   );

--- a/packages/kokoas-client/src/pages/projInvoice/fieldComponents/BillingEntryTableRow.tsx
+++ b/packages/kokoas-client/src/pages/projInvoice/fieldComponents/BillingEntryTableRow.tsx
@@ -11,10 +11,12 @@ export const BillingEntryTableRow = ({
   estimate,
   idx,
   paymentList,
+  exceeded,
 }: {
   estimate: TMaterials
   idx: number
   paymentList: ReturnType<typeof createPaymentList>[] | undefined
+  exceeded: boolean
 }) => {
   const {
     setValues,
@@ -24,9 +26,6 @@ export const BillingEntryTableRow = ({
     projTypeName,
     estimateId,
     dataId,
-    contractAmount,
-    billedAmount,
-    billingAmount,
   } = estimate;
 
   const paymentItem = paymentList?.find(({ uuid }) => uuid === estimateId);
@@ -58,14 +57,6 @@ export const BillingEntryTableRow = ({
       return newVal;
     });
   };
-
-  const newBillingAmount = (+billedAmount + +billingAmount);
-  let exceeded = false;
-  if (+contractAmount >= 0 ) {
-    exceeded = (+contractAmount < newBillingAmount) || (+billingAmount < 0);
-  } else {
-    exceeded = (+contractAmount > newBillingAmount) || (+billingAmount > 0);
-  }
 
 
   return (

--- a/packages/kokoas-client/src/pages/projInvoice/formValidation.ts
+++ b/packages/kokoas-client/src/pages/projInvoice/formValidation.ts
@@ -20,11 +20,11 @@ const billingAmountValidation = function (this: any) {
     isForPayment,
   } = this.parent;
 
-  if (!isForPayment) return false; // 請求に使用しないときはバリデーションから除外
-  if (!billingAmount) return true; // 未入力もしくは0の場合はエラー
+  if (!isForPayment) return true; // 請求に使用しないときはバリデーションから除外
+  if (!billingAmount) return false; // 未入力もしくは0の場合はエラー
   if ((billingAmount >= 0 && contractAmount >= 0)
-    || (billingAmount < 0 && contractAmount < 0)) return false;
-  return true;
+    || (billingAmount < 0 && contractAmount < 0)) return true;
+  return false;
 };
 
 /* MAIN VALIDATION SCHEMA */

--- a/packages/kokoas-client/src/pages/projInvoice/formValidation.ts
+++ b/packages/kokoas-client/src/pages/projInvoice/formValidation.ts
@@ -25,7 +25,7 @@ export const validationSchema = Yup
         billingAmount: numberValidation
           .when('isForPayment' as TKMaterials, {
             is: true,
-            then: numberValidation.notOneOf([0], '0以外の数値を入力してください'),
+            then: numberValidation.notOneOf([0], '0以外の数値を入力してください'), // 修正
           }),
         billedAmount: numberValidation,
         contractDate: dateValidation,

--- a/packages/kokoas-client/src/pages/projInvoice/formValidation.ts
+++ b/packages/kokoas-client/src/pages/projInvoice/formValidation.ts
@@ -1,5 +1,5 @@
 import * as Yup from 'yup';
-import { getFieldName, KeyOfForm, TKMaterials } from './form';
+import { getFieldName, KeyOfForm } from './form';
 
 
 /* Common validations */
@@ -10,6 +10,22 @@ const dateValidation = Yup
 const numberValidation = Yup
   .number()
   .typeError('数字を入力してください');
+
+
+/* unique validations */
+const billingAmountValidation = function (this: any) {
+  const {
+    contractAmount,
+    billingAmount,
+    isForPayment,
+  } = this.parent;
+
+  if (!isForPayment) return false; // 請求に使用しないときはバリデーションから除外
+  if (!billingAmount) return true; // 未入力もしくは0の場合はエラー
+  if ((billingAmount >= 0 && contractAmount >= 0)
+    || (billingAmount < 0 && contractAmount < 0)) return false;
+  return true;
+};
 
 /* MAIN VALIDATION SCHEMA */
 export const validationSchema = Yup
@@ -23,10 +39,11 @@ export const validationSchema = Yup
         estimateId: Yup.string(),
         contractAmount: numberValidation,
         billingAmount: numberValidation
-          .when('isForPayment' as TKMaterials, {
-            is: true,
-            then: numberValidation.notOneOf([0], '0以外の数値を入力してください'), // 修正
-          }),
+          .test(
+            'with-the-same-plus-or-minus-sign-as-the-contract-amount',
+            '契約金額と同じ符号(+, -)で入力してください',
+            billingAmountValidation,
+          ),
         billedAmount: numberValidation,
         contractDate: dateValidation,
         isForPayment: Yup.boolean(),

--- a/packages/kokoas-client/src/pages/projInvoice/formValidation.ts
+++ b/packages/kokoas-client/src/pages/projInvoice/formValidation.ts
@@ -1,5 +1,5 @@
 import * as Yup from 'yup';
-import { getFieldName, KeyOfForm } from './form';
+import { getFieldName, KeyOfForm, TypeOfForm } from './form';
 
 
 /* Common validations */
@@ -13,7 +13,7 @@ const numberValidation = Yup
 
 
 /* unique validations */
-const billingAmountValidation = function (this: any) {
+const billingAmountValidation = function (this: { parent: TypeOfForm['estimates'][number] }) {
   const {
     contractAmount,
     billingAmount,


### PR DESCRIPTION
**変更**
---

 - 契約書が0円以上の場合、請求金額にも0円以上を入力する
 - 同じく、契約書が0円未満の場合は、請求金額は0円未満を入力する

**変更理由**
---

 - 現状、返金する契約に対して請求を掛けられてしまう。逆も然り。
 - 望ましい形ではないため、バリデーション修正にて対応する
 - https://trello.com/c/wImjgI6D