### PR TITLE
T260 - 見積もり：課税スイッチの表示設定を追加する

### DIFF
--- a/packages/kokoas-client/src/pages/projEstimate/tables/estimatesVirtual/EstRowFormat.tsx
+++ b/packages/kokoas-client/src/pages/projEstimate/tables/estimatesVirtual/EstRowFormat.tsx
@@ -93,10 +93,10 @@ export const EstRowFormat = forwardRef<HTMLElement, EstRowFormatProps>((props, r
           </Stack>
           )}
 
-          <Stack width={'auto'}>
+          <Stack width={'30%'}>
             {unitPrice}
           </Stack>
-          <Stack width={'auto'}>
+          <Stack width={showTaxType ? '33%' : '45%'}>
             {rowUnitPrice}
           </Stack>
         </Stack>

--- a/packages/kokoas-client/src/pages/projEstimate/tables/estimatesVirtual/EstRowFormat.tsx
+++ b/packages/kokoas-client/src/pages/projEstimate/tables/estimatesVirtual/EstRowFormat.tsx
@@ -93,10 +93,10 @@ export const EstRowFormat = forwardRef<HTMLElement, EstRowFormatProps>((props, r
           </Stack>
           )}
 
-          <Stack width={'30%'}>
+          <Stack width={'auto'}>
             {unitPrice}
           </Stack>
-          <Stack width={'33%'}>
+          <Stack width={'auto'}>
             {rowUnitPrice}
           </Stack>
         </Stack>

--- a/packages/kokoas-client/src/pages/projEstimate/tables/estimatesVirtual/EstRowFormat.tsx
+++ b/packages/kokoas-client/src/pages/projEstimate/tables/estimatesVirtual/EstRowFormat.tsx
@@ -1,5 +1,7 @@
 import { Stack, StackProps } from '@mui/material';
 import { forwardRef, ReactNode } from 'react';
+import { useFormContext, useWatch } from 'react-hook-form';
+import { TypeOfForm } from '../../form';
 
 export interface EstRowFormatProps {
   stackProps?: StackProps,
@@ -17,6 +19,13 @@ export interface EstRowFormatProps {
 }
 
 export const EstRowFormat = forwardRef<HTMLElement, EstRowFormatProps>((props, ref ) => {
+  const { control } = useFormContext<TypeOfForm>();
+  const status = useWatch({
+    name: 'status',
+    control,
+  });
+
+  const showTaxType = status === '工事実行';
 
   const {
     stackProps,
@@ -32,6 +41,8 @@ export const EstRowFormat = forwardRef<HTMLElement, EstRowFormatProps>((props, r
     rowUnitPrice,
     rowDetails,
   } = props;
+
+
 
   return (
 
@@ -76,9 +87,12 @@ export const EstRowFormat = forwardRef<HTMLElement, EstRowFormatProps>((props, r
           <Stack width={'25%'}>
             {profitRate}
           </Stack>
+          {showTaxType && (
           <Stack width={'12%'}>
             {taxType}
           </Stack>
+          )}
+
           <Stack width={'30%'}>
             {unitPrice}
           </Stack>


### PR DESCRIPTION
## 変更

- statusは工事実行のみ、行ごとの課税・非家財のチェックを表示されます。

## 理由

https://trello.com/c/z4Tk43cQ