### PR TITLE
Andpadへ格納するデータを表示する

### DIFF
--- a/packages/api-kintone/src/estimates/getContractByProjId.test.ts
+++ b/packages/api-kintone/src/estimates/getContractByProjId.test.ts
@@ -1,0 +1,9 @@
+import { getContractByProjId } from './getContractByProjId';
+
+describe('getContractByProjId', () => {
+  it('should get the main contract', async () => {
+    const result = await getContractByProjId('8aa54bb3-10e7-45fa-adde-df7776082c77');
+
+    console.log(result);
+  });
+});

--- a/packages/api-kintone/src/estimates/getContractByProjId.ts
+++ b/packages/api-kintone/src/estimates/getContractByProjId.ts
@@ -40,7 +40,6 @@ export const getContractByProjId = async (projId: string) => {
 
           const calculated = calculateEstimateRecord({ record: estimate });
 
-          console.log(calculated.summary.totalAmountAfterTax, mainContract?.calculated.summary.totalAmountAfterTax);
           if (!mainContract || calculated.summary.totalAmountAfterTax > mainContract.calculated.summary.totalAmountAfterTax) {
             return {
               record: estimate,

--- a/packages/api-kintone/src/estimates/getContractByProjId.ts
+++ b/packages/api-kintone/src/estimates/getContractByProjId.ts
@@ -1,0 +1,57 @@
+import { KProjestimates, TEnvelopeStatus } from 'types';
+import { getRecords } from '../common';
+import { calculateEstimateRecord, CalculateEstimateRecordReturn } from './calculation';
+import { RecordType, appId } from './config';
+
+type GetContractByProjIdResult =  {
+  record: RecordType,
+  calculated: CalculateEstimateRecordReturn
+} | undefined;
+
+/**
+ * 主な契約（一番高い金額）を取得する
+ */
+export const getContractByProjId = async (projId: string) => {
+  if (!projId) throw new Error('Invalid project id.');
+
+  const projIdKey : KProjestimates  = 'projId';
+  const envStatusKey : KProjestimates = 'envStatus';
+
+  const envStatusVal : TEnvelopeStatus = 'completed';
+
+  const mainQuery = [
+    `${projIdKey} = "${projId}"`,
+    `${envStatusKey} = "${envStatusVal}"`,
+  ]
+    .join(' and ');
+
+  console.log(mainQuery);
+  const result = getRecords<RecordType>({
+    app: appId,
+    query: `${mainQuery}`,
+  })
+    .then(({ records }) => {
+
+      return records
+        .reduce((mainContract, estimate) => {
+          if (estimate.projId.value !== projId) {
+            return mainContract;
+          }
+
+          const calculated = calculateEstimateRecord({ record: estimate });
+
+          console.log(calculated.summary.totalAmountAfterTax, mainContract?.calculated.summary.totalAmountAfterTax);
+          if (!mainContract || calculated.summary.totalAmountAfterTax > mainContract.calculated.summary.totalAmountAfterTax) {
+            return {
+              record: estimate,
+              calculated,
+            };
+          }
+          return mainContract;
+
+        }, undefined as GetContractByProjIdResult);
+    });
+
+
+  return result;
+};

--- a/packages/api-kintone/src/estimates/index.ts
+++ b/packages/api-kintone/src/estimates/index.ts
@@ -2,6 +2,7 @@ export * from './calculation';
 export * from './createPaymentList';
 export * from './generateEstimateDataIdSeqNum';
 export * from './getAllEstimates';
+export * from './getContractByProjId';
 export * from './getContracts';
 export * from './getEstimateByEnvId';
 export * from './getEstimateById';

--- a/packages/kokoas-client/src/api/andpad/convertProjToAndpad.test.ts
+++ b/packages/kokoas-client/src/api/andpad/convertProjToAndpad.test.ts
@@ -10,5 +10,7 @@ describe('convertProjToAndpad', () => {
     const result = await convertProjToAndpad('8aa54bb3-10e7-45fa-adde-df7776082c77');
 
     console.log(result);
+
+    expect(result).toBeDefined();
   });
 });

--- a/packages/kokoas-client/src/api/andpad/convertProjToAndpad.test.ts
+++ b/packages/kokoas-client/src/api/andpad/convertProjToAndpad.test.ts
@@ -1,0 +1,14 @@
+/**
+ * @jest-environment node
+ */
+
+
+import { convertProjToAndpad } from './convertProjToAndpad';
+
+describe('convertProjToAndpad', () => {
+  it('should convert project to andpand　案件', async () => {
+    const result = await convertProjToAndpad('8aa54bb3-10e7-45fa-adde-df7776082c77');
+
+    console.log(result);
+  });
+});

--- a/packages/kokoas-client/src/api/andpad/convertProjToAndpad.ts
+++ b/packages/kokoas-client/src/api/andpad/convertProjToAndpad.ts
@@ -1,4 +1,9 @@
+import { buildingTypesAndpad, projectTypesAndpad, SaveProjectData, storeNamesAndpad } from 'api-andpad';
 import { getContractByProjId, getCustGroupById, getCustomersByIds, getProjById } from 'api-kintone';
+import format from 'date-fns/format';
+import parseISO from 'date-fns/parseISO';
+import { bestStringMatch } from 'kokoas-client/src/lib';
+import { TAgents, TContact } from 'types';
 import { getAddressByPostal } from '../others';
 
 export const convertProjToAndpad = async (projId: string) => {
@@ -7,10 +12,17 @@ export const convertProjToAndpad = async (projId: string) => {
     getProjById(projId),
     getContractByProjId(projId),
   ]);
+  if (!projRec) throw new Error('工事情報の取得が失敗しました。');
+  if (!estData) throw new Error('契約情報の取得が失敗しました。');
+
 
   const custGroupRec = await getCustGroupById(projRec?.custGroupId.value);
+  if (!custGroupRec) throw new Error('顧客グループ情報の取得が失敗しました。');
+
   const firstCustId = custGroupRec?.members.value[0].value.custId.value;
   const firstCust = (await getCustomersByIds([firstCustId]))[0];
+  if (!firstCust) throw new Error('顧客情報の取得が失敗しました。');
+
 
   const {
     prefecture: projPrefecture,
@@ -19,5 +31,56 @@ export const convertProjToAndpad = async (projId: string) => {
   const {
     prefecture: custPrefecture,
   } = await getAddressByPostal(firstCust?.postalCode.value || '') ?? {};
+
+  if (!projPrefecture) throw new Error('物件の都道府県の取得が失敗しました。');
+  if (!custPrefecture) throw new Error('顧客の都道府県の取得が失敗しました。');
+
+
+  const { record: estRec } = estData;
+
+
+  const firstAgent = custGroupRec
+    .agents
+    .value
+    .find((row) => (row.value.agentType.value as TAgents) === 'cocoAG')
+    ?.value;
+
+
+  const [firstCustTel1, firstCustTel2] = firstCust.contacts.value.filter((row) => (row.value.contactType.value as TContact) === 'tel');
+  const firstCustEmail = firstCust.contacts.value.find((row) => (row.value.contactType.value as TContact) === 'email');
+  const saveResult: SaveProjectData = {
+    '顧客管理ID': custGroupRec.uuid.value,
+    '顧客名': firstCust.fullName.value,
+    '顧客名（カナ）': firstCust.fullNameReading.value,
+    '顧客郵便番号': firstCust.postalCode.value,
+    '顧客現住所': [firstCust.address1.value.trim(), firstCust.address2.value.trim()].join(','),
+    '顧客担当者名': firstAgent?.employeeName.value,
+    '顧客電話番号1': firstCustTel1.value.contactValue.value,
+    '顧客電話番号2': firstCustTel2.value.contactValue.value,
+    '顧客メールアドレス': firstCustEmail?.value.contactValue.value,
+
+    '物件管理ID': projRec.uuid.value,
+    '物件種別': bestStringMatch(projRec.buildingType.value, buildingTypesAndpad, { valueIfNoMatch: 'その他' }),
+    '物件名': `${firstCust.fullName.value}様邸`,
+    '物件住所種別': '新しい住所を入力する',
+    '物件郵便番号': projRec.postal.value,
+    '物件住所': `${projRec.address1.value}${projRec.address2.value}`,
+
+    '案件管理ID': projRec.uuid.value,
+    '案件名': `${custGroupRec.storeName.value}　${projRec.projName.value}`,
+    '案件種別': projRec.projTypeName.value === '新築工事' ? '新築' : 'リフォーム',
+    '案件フロー': '契約前',
+
+    // andpadのAPIの保存仕様ではyyyy-MM-ddですが、取得の際、yyyy/MM/dd
+    '契約日(実績)': estRec.contractDate.value ? format(parseISO(estRec.contractDate.value), 'yyyy/MM/dd') : '',
+
+    'ラベル:工事内容': bestStringMatch(projRec.projTypeName.value, projectTypesAndpad, { valueIfNoMatch: 'その他' }),
+    'ラベル:店舗': bestStringMatch(custGroupRec.storeName.value, storeNamesAndpad, { ignore: '店' }),
+
+    '顧客都道府県': custPrefecture,
+    '物件都道府県': projPrefecture,
+  };
+
+  return saveResult;
 
 };

--- a/packages/kokoas-client/src/api/andpad/convertProjToAndpad.ts
+++ b/packages/kokoas-client/src/api/andpad/convertProjToAndpad.ts
@@ -1,0 +1,23 @@
+import { getContractByProjId, getCustGroupById, getCustomersByIds, getProjById } from 'api-kintone';
+import { getAddressByPostal } from '../others';
+
+export const convertProjToAndpad = async (projId: string) => {
+
+  const [projRec, estData] = await Promise.all([
+    getProjById(projId),
+    getContractByProjId(projId),
+  ]);
+
+  const custGroupRec = await getCustGroupById(projRec?.custGroupId.value);
+  const firstCustId = custGroupRec?.members.value[0].value.custId.value;
+  const firstCust = (await getCustomersByIds([firstCustId]))[0];
+
+  const {
+    prefecture: projPrefecture,
+  } = await getAddressByPostal(projRec?.postal.value || '') ?? {};
+
+  const {
+    prefecture: custPrefecture,
+  } = await getAddressByPostal(firstCust?.postalCode.value || '') ?? {};
+
+};

--- a/packages/kokoas-client/src/api/others/getAddressByPostal.ts
+++ b/packages/kokoas-client/src/api/others/getAddressByPostal.ts
@@ -10,6 +10,10 @@ interface PostalAPIResponse {
   }[] | null
 }
 
+/**
+ * 郵便番号で取得します。
+ *
+ */
 export const getAddressByPostal = async (
   postal: string,
 ) : Promise<{
@@ -35,6 +39,7 @@ export const getAddressByPostal = async (
       });
   } catch (e) {
     if (e instanceof ReferenceError) {
+      // Kintone上でない時, 利用した場合
       const { results }: PostalAPIResponse = (await axios.get(endpoint)).data;
       if (results) {
         const { address1, address2, address3 } = results[0];

--- a/packages/kokoas-client/src/components/ui/buttons/AndpadButton.tsx
+++ b/packages/kokoas-client/src/components/ui/buttons/AndpadButton.tsx
@@ -20,6 +20,10 @@ export const AndpadButton = styled(Button)<ButtonProps>(({ theme }) => ({
     borderColor: hoverColor,
     boxShadow: theme.shadows[6],
   },
+  '&:disabled': {
+    backgroundColor: red[50],
+    borderColor: 'unset',
+  },
   '&:active': {
     backgroundColor: hoverColor,
     borderColor: hoverColor,

--- a/packages/kokoas-client/src/hooksQuery/index.ts
+++ b/packages/kokoas-client/src/hooksQuery/index.ts
@@ -8,6 +8,7 @@ export * from './useContractByProjId';
 export * from './useContracts';
 export * from './useContractsByCustGroupId';
 export * from './useContractsByProjId';
+export * from './useConvertToAndpadByProjId';
 export * from './useCustGroupById';
 export * from './useCustGroupByProjId';
 export * from './useCustGroups';

--- a/packages/kokoas-client/src/hooksQuery/useConvertToAndpadByProjId.ts
+++ b/packages/kokoas-client/src/hooksQuery/useConvertToAndpadByProjId.ts
@@ -1,33 +1,13 @@
 import { useQuery } from '@tanstack/react-query';
-import { getCustGroupById, getCustomersByIds, getProjById } from 'api-kintone';
-import { getContractByProjId } from 'api-kintone/src/estimates/getContractByProjId';
 import { AppIds } from 'config';
-import { getAddressByPostal } from '../api';
+import { convertProjToAndpad } from '../api/andpad/convertProjToAndpad';
 
 
 export const useConvertToAndpadByProjId = (projId = '') => {
 
   return useQuery(
     ['andpad', AppIds.projects, projId],
-    async () => {
-
-      const [projRec, estData] = await Promise.all([
-        getProjById(projId),
-        getContractByProjId(projId),
-      ]);
-
-      const custGroupRec = await getCustGroupById(projRec?.custGroupId.value);
-      const firstCustId = custGroupRec?.members.value[0].value.custId.value;
-      const firstCustRec = (await getCustomersByIds([firstCustId]))[0];
-
-      const {
-        prefecture: projPrefecture,
-      } = await getAddressByPostal(projRec?.postal.value || '') ?? {};
-
-      const {
-        prefecture: custPrefecture,
-      } = getAddressByPostal(firstCust?.postalCode.value || '') ?? {};
-    },
+    () => convertProjToAndpad(projId),
     {
       enabled: !!projId,
     },

--- a/packages/kokoas-client/src/hooksQuery/useConvertToAndpadByProjId.ts
+++ b/packages/kokoas-client/src/hooksQuery/useConvertToAndpadByProjId.ts
@@ -1,0 +1,35 @@
+import { useQuery } from '@tanstack/react-query';
+import { getCustGroupById, getCustomersByIds, getProjById } from 'api-kintone';
+import { getContractByProjId } from 'api-kintone/src/estimates/getContractByProjId';
+import { AppIds } from 'config';
+import { getAddressByPostal } from '../api';
+
+
+export const useConvertToAndpadByProjId = (projId = '') => {
+
+  return useQuery(
+    ['andpad', AppIds.projects, projId],
+    async () => {
+
+      const [projRec, estData] = await Promise.all([
+        getProjById(projId),
+        getContractByProjId(projId),
+      ]);
+
+      const custGroupRec = await getCustGroupById(projRec?.custGroupId.value);
+      const firstCustId = custGroupRec?.members.value[0].value.custId.value;
+      const firstCustRec = (await getCustomersByIds([firstCustId]))[0];
+
+      const {
+        prefecture: projPrefecture,
+      } = await getAddressByPostal(projRec?.postal.value || '') ?? {};
+
+      const {
+        prefecture: custPrefecture,
+      } = getAddressByPostal(firstCust?.postalCode.value || '') ?? {};
+    },
+    {
+      enabled: !!projId,
+    },
+  );
+};

--- a/packages/kokoas-client/src/hooksQuery/useSaveAndpadProject.ts
+++ b/packages/kokoas-client/src/hooksQuery/useSaveAndpadProject.ts
@@ -1,92 +1,16 @@
 import { useMutation } from '@tanstack/react-query';
-import { TAgents, TContact } from 'types';
 import { saveAndpadProject } from '../api/andpad/saveAndpadProject';
-
 import { useCommonOptions } from './useCommonOptions';
-import { useCustGroupById } from './useCustGroupById';
-import { useCustomersById } from './useCustomersById';
-import { useProjById } from './useProjById';
-import { buildingTypesAndpad, projectTypesAndpad, storeNamesAndpad } from 'api-andpad';
-import { bestStringMatch } from '../lib';
-import { useContractByProjId } from './useContractByProjId';
-import { useAddressPostalCode } from './useAddressPostalCode';
 import { useSnackBar } from '../hooks/useSnackBar';
 
 
 
-export const useSaveAndpadProject = (projId: string | undefined) => {
+export const useSaveAndpadProject = () => {
   const commonOptions = useCommonOptions();
   const { setSnackState } = useSnackBar();
-  const { data: projRec } = useProjById(projId ?? '');
-  const { data: custGroupRec } = useCustGroupById(projRec?.custGroupId.value ?? '');
-  const { data: estData } = useContractByProjId(projId);
-
-  const firstCustId = custGroupRec?.members.value[0].value.custId.value;
-
-  const { data: firstCust } = useCustomersById(firstCustId);
-
-  const { data: {
-    prefecture: projPrefecture,
-  } = {} } = useAddressPostalCode(projRec?.postal.value || '', { enabled: !!projRec?.postal.value });
-
-  const { data: {
-    prefecture: custPrefecture,
-  } = {} } = useAddressPostalCode(firstCust?.postalCode.value || '', { enabled: !!firstCust?.postalCode.value });
 
   return useMutation(
-    async () => {
-
-      if (!projRec) throw new Error('工事情報の取得が失敗しました。');
-      if (!custGroupRec) throw new Error('顧客グループ情報の取得が失敗しました。');
-      if (!firstCust) throw new Error('顧客情報の取得が失敗しました。');
-      if (!estData) throw new Error('契約情報の取得が失敗しました。');
-      if (!projPrefecture) throw new Error('物件の都道府県の取得が失敗しました。');
-      if (!custPrefecture) throw new Error('顧客の都道府県の取得が失敗しました。');
-
-      const { record: estRec } = estData;
-
-      const firstAgent = custGroupRec
-        .agents
-        .value
-        .find((row) => (row.value.agentType.value as TAgents) === 'cocoAG')
-        ?.value;
-
-
-      const [firstCustTel1, firstCustTel2] = firstCust.contacts.value.filter((row) => (row.value.contactType.value as TContact) === 'tel');
-      const firstCustEmail = firstCust.contacts.value.find((row) => (row.value.contactType.value as TContact) === 'email');
-      const saveResult = await saveAndpadProject({
-        '顧客管理ID': custGroupRec.uuid.value,
-        '顧客名': firstCust.fullName.value,
-        '顧客名（カナ）': firstCust.fullNameReading.value,
-        '顧客郵便番号': firstCust.postalCode.value,
-        '顧客現住所': [firstCust.address1.value.trim(), firstCust.address2.value.trim()].join(','),
-        '顧客担当者名': firstAgent?.employeeName.value,
-        '顧客電話番号1': firstCustTel1.value.contactValue.value,
-        '顧客電話番号2': firstCustTel2.value.contactValue.value,
-        '顧客メールアドレス': firstCustEmail?.value.contactValue.value,
-
-        '物件管理ID': projRec.uuid.value,
-        '物件種別': bestStringMatch(projRec.buildingType.value, buildingTypesAndpad, { valueIfNoMatch: 'その他' }),
-        '物件名': `${firstCust.fullName.value}様邸`,
-        '物件住所種別': '新しい住所を入力する',
-        '物件郵便番号': projRec.postal.value,
-        '物件住所': `${projRec.address1.value}${projRec.address2.value}`,
-
-        '案件管理ID': projRec.uuid.value,
-        '案件名': `${custGroupRec.storeName.value}　${projRec.projName.value}`,
-        '案件種別': projRec.projTypeName.value === '新築工事' ? '新築' : 'リフォーム',
-        '案件フロー': '契約前',
-
-        '契約日(実績)': estRec.contractDate.value || '',
-        'ラベル:工事内容': bestStringMatch(projRec.projTypeName.value, projectTypesAndpad, { valueIfNoMatch: 'その他' }),
-        'ラベル:店舗': bestStringMatch(custGroupRec.storeName.value, storeNamesAndpad, { ignore: '店' }),
-
-        '顧客都道府県': custPrefecture,
-        '物件都道府県': projPrefecture,
-      });
-
-      return saveResult;
-    },
+    saveAndpadProject,
     {
       ...commonOptions,
       onSuccess: ({ data }) => {

--- a/packages/kokoas-client/src/pages/projRegister/sections/RecordSelect/SaveToAndpadDialog.tsx
+++ b/packages/kokoas-client/src/pages/projRegister/sections/RecordSelect/SaveToAndpadDialog.tsx
@@ -2,7 +2,7 @@ import { Button, Dialog, DialogActions, DialogTitle } from '@mui/material';
 import { AndpadButton } from 'kokoas-client/src/components/ui/buttons/AndpadButton';
 import { AndpadLogo } from 'kokoas-client/src/components/ui/icons';
 import { useURLParams } from 'kokoas-client/src/hooks/useURLParams';
-import { useSaveAndpadProject } from 'kokoas-client/src/hooksQuery';
+import { useConvertToAndpadByProjId, useSaveAndpadProject } from 'kokoas-client/src/hooksQuery';
 import { TypeOfForm } from '../../form';
 import { SaveToAndpadDialogContent } from './SaveToAndpadDialogContent';
 
@@ -14,14 +14,17 @@ export const SaveToAndpadDialog = ({
   handleClose: () => void
 }) => {
   const { projId } = useURLParams<TypeOfForm>();
-  const { mutate: mutateAndpad } = useSaveAndpadProject(projId || '');
+  const { data, isLoading } = useConvertToAndpadByProjId(open ? projId : '');
+
+  const { mutate: mutateAndpad } = useSaveAndpadProject();
 
 
   const handleClick = () => {
-    mutateAndpad();
+    if (data) {
+      mutateAndpad(data);
+    }
     handleClose();
   };
-
 
   return (
     <Dialog
@@ -29,11 +32,12 @@ export const SaveToAndpadDialog = ({
       onClose={handleClose}
       keepMounted={false}
       maxWidth={'xs'}
+      fullWidth
     >
       <DialogTitle>
         アンドパッドへ登録しますか。
       </DialogTitle>
-      <SaveToAndpadDialogContent />
+      <SaveToAndpadDialogContent isLoading={isLoading} convertedData={data} />
       <DialogActions>
         <Button onClick={handleClose}>
           キャンセル
@@ -41,6 +45,7 @@ export const SaveToAndpadDialog = ({
         <AndpadButton
           onClick={handleClick}
           startIcon={<AndpadLogo />}
+          disabled={isLoading}
         >
           はい
         </AndpadButton>

--- a/packages/kokoas-client/src/pages/projRegister/sections/RecordSelect/SaveToAndpadDialogContent.tsx
+++ b/packages/kokoas-client/src/pages/projRegister/sections/RecordSelect/SaveToAndpadDialogContent.tsx
@@ -1,12 +1,24 @@
 import { DialogContent, DialogContentText } from '@mui/material';
+import { SaveProjectData } from 'api-andpad';
+import { Loading } from 'kokoas-client/src/components/ui/loading/Loading';
+import { SaveToAndpadDialogData } from './SaveToAndpadDialogData';
 
-export const SaveToAndpadDialogContent = () => {
+export const SaveToAndpadDialogContent = ({
+  convertedData,
+  isLoading,
+
+}:{
+  isLoading: boolean
+  convertedData?: SaveProjectData
+}) => {
 
   return (
-    <DialogContent>
+    <DialogContent sx={{ height: '90vh' }}>
       <DialogContentText>
-        Andpadへ格納します。
+        {isLoading ?  '少々お待ちください。' : '以下の内容でAndpadへ保存されます。'}
       </DialogContentText>
+      {isLoading && <Loading /> }
+      {!!convertedData && <SaveToAndpadDialogData convertedData={convertedData} />}
     </DialogContent>
   );
 };

--- a/packages/kokoas-client/src/pages/projRegister/sections/RecordSelect/SaveToAndpadDialogData.tsx
+++ b/packages/kokoas-client/src/pages/projRegister/sections/RecordSelect/SaveToAndpadDialogData.tsx
@@ -1,0 +1,32 @@
+import { Table, TableBody, TableCell, TableContainer, TableRow } from '@mui/material';
+import { SaveProjectData } from 'api-andpad';
+
+
+
+export const SaveToAndpadDialogData = ({
+  convertedData,
+} : {
+  convertedData: SaveProjectData
+}) => {
+  return (
+    <TableContainer>
+      <Table>
+        <TableBody>
+
+          {Object.entries(convertedData).map(([key, val]) => (
+            <TableRow
+              key={key}
+              sx={{ '&:last-child td, &:last-child th': { border: 0 } }}
+            >
+              <TableCell align="right">
+                {key}
+              </TableCell>
+              <TableCell align="left">
+                {val}
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </TableContainer>);
+};


### PR DESCRIPTION
## 変更

- Andpadへ保存する前に、データを確認出来るようになりました。
- キャッシュから取得していましたが、直接KintoneのAPIから取得することになりました。

## 理由

- https://trello.com/c/5pz0i3x0
- 取得情報が多いので、利用端末に負担をかけていました。GraphQLに移行したら、また改修します。

## テスト

- 以下でテスト出来ます。
　https://rdmuhwtt6gx7.cybozu.com/k/176/#/project/edit?projId=8aa54bb3-10e7-45fa-adde-df7776082c77