### PR TITLE
hotfix-139-bug-契約が開けないものがあります

### DIFF
--- a/packages/kokoas-client/package.json
+++ b/packages/kokoas-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kokoas-client",
-  "version": "20230221.1",
+  "version": "20230221.2",
   "devDependencies": {},
   "scripts": {
     "dev": "npm run build -- --watch --mode development",

--- a/packages/kokoas-client/src/pages/projContracts/hooks/useContractPreview.tsx
+++ b/packages/kokoas-client/src/pages/projContracts/hooks/useContractPreview.tsx
@@ -18,6 +18,7 @@ import { TypeOfForm } from '../form';
 export const useContractPreview = () => {
   const { status, values, setValues } = useFormikContext<TypeOfForm>();
   const [previewUrl, setPreviewUrl] = useState('');
+  const [selectedDoc, setSelectedDoc] = useState('');
   const [previewLoading, setPreviewLoading] = useState(false);
   const { setSnackState } = useSnackBar();
 
@@ -51,6 +52,7 @@ export const useContractPreview = () => {
           URL.revokeObjectURL(prev); // Free memory
           return url;
         });
+        setSelectedDoc(fileKey);
       } else {
         setPreviewUrl('');
       }
@@ -88,5 +90,6 @@ export const useContractPreview = () => {
     previewUrl,
     setValues,
     handleRefetch,
+    selectedDoc,
   };
 };

--- a/packages/kokoas-client/src/pages/projContracts/parts/ContractFormActions.tsx
+++ b/packages/kokoas-client/src/pages/projContracts/parts/ContractFormActions.tsx
@@ -31,6 +31,7 @@ export const ContractFormActions = () => {
     handlePreview,
     handleRefetch,
     formLoading,
+    selectedDoc,
   } = useContractPreview();
 
   const setOpenPreview = (isOpen: boolean) => {
@@ -96,6 +97,7 @@ export const ContractFormActions = () => {
       <ContractDialog
         open={isPreviewOpen}
         formLoading={formLoading}
+        selectedDoc={selectedDoc}
         handleRefetch={handleRefetch}
         handlePreview={handlePreview}
         previewUrl={previewUrl}

--- a/packages/kokoas-client/src/pages/projContracts/parts/ContractFormActions.tsx
+++ b/packages/kokoas-client/src/pages/projContracts/parts/ContractFormActions.tsx
@@ -20,6 +20,7 @@ export const ContractFormActions = () => {
     isValid,
     errors,
     touched,
+    dirty,
     values: {
       envelopeStatus,
     },
@@ -59,7 +60,8 @@ export const ContractFormActions = () => {
   const isFormikBusy = isSubmitting || isValidating;
 
   const isPreviewDisabled = isFormikBusy
-    || (!isValid && !envelopeStatus); // 検証ロジックが異なる既存契約の後方互換性を処理するためのものです。
+    || (!isValid && !envelopeStatus) // 検証ロジックが異なる既存契約の後方互換性を処理するためのものです。
+    || dirty;
 
   const isSaveDisabled = isFormikBusy || !!envelopeStatus;
 
@@ -99,12 +101,23 @@ export const ContractFormActions = () => {
         previewUrl={previewUrl}
         handleClose={() => setOpenPreview(false)}
       />
-      {isPreviewDisabled && isFormikBusy && '処理中です。'}
+      <Typography variant='caption' color={'error'} align="center"
+        component={'div'}
+      >
 
-      {isPreviewDisabled && !isValid && !envelopeStatus && (
-      <Typography variant='caption' color={'error'} align="center">
-        {'フォームにエラーがあります。保存ボタンを押すと、エラー箇所が分かります。'}
-      </Typography>)}
+        {isPreviewDisabled && isFormikBusy && <div>
+          処理中です。
+        </div>}
+
+        {isPreviewDisabled && !isValid && !envelopeStatus && <div>
+          フォームにエラーがあります。保存ボタンを押すと、エラー箇所が分かります。
+        </div>}
+
+        {isPreviewDisabled && dirty && <div>
+          保存されていない変更があります。保存してください。
+        </div>}
+
+      </Typography>
     </Stack>
   );
 };

--- a/packages/kokoas-client/src/pages/projContracts/parts/Preview/ContractDialog.tsx
+++ b/packages/kokoas-client/src/pages/projContracts/parts/Preview/ContractDialog.tsx
@@ -10,6 +10,7 @@ export const ContractDialog = ({
   open,
   formLoading,
   previewUrl,
+  selectedDoc,
   handleRefetch,
   handleClose,
   handlePreview,
@@ -17,11 +18,11 @@ export const ContractDialog = ({
   open: boolean,
   formLoading: boolean,
   previewUrl: string,
+  selectedDoc: string,
   handleRefetch: () => void,
   handleClose: () => void,
   handlePreview: (fileKey: string) => void,
 }) => {
-
 
   return (
     <Dialog
@@ -71,7 +72,10 @@ export const ContractDialog = ({
 
       {!formLoading && (
       <PreviewFooter >
-        <SelectDocuments handlePreview={handlePreview} />
+        <SelectDocuments
+          handlePreview={handlePreview}
+          selectedDoc={selectedDoc}
+        />
       </PreviewFooter>
       )}
     </Dialog>

--- a/packages/kokoas-client/src/pages/projContracts/parts/Preview/SelectDocuments.tsx
+++ b/packages/kokoas-client/src/pages/projContracts/parts/Preview/SelectDocuments.tsx
@@ -1,26 +1,29 @@
 import {  Chip, Stack } from '@mui/material';
 import { useFormikContext } from 'formik';
-import { getFieldName, TypeOfForm } from '../../form';
+import { TypeOfForm } from '../../form';
 import AttachmentIcon from '@mui/icons-material/Attachment';
 
 
 export const SelectDocuments = ({
   handlePreview,
+  selectedDoc,
 }: {
-  handlePreview: (fileKey: string) => void
+  handlePreview: (fileKey: string) => void,
+  selectedDoc: string,
 }) => {
 
   const {
     values: {
-      envDocFileKeys, envSelectedDoc,
-    }, setFieldValue } = useFormikContext<TypeOfForm>();
+      envDocFileKeys,
+    } } = useFormikContext<TypeOfForm>();
+
 
   return (
     <Stack p={0} spacing={1} direction={'row'}
       alignItems={'center'}
     >
       {envDocFileKeys.map(file => {
-        const isSelected = envSelectedDoc === file.fileKey;
+        const isSelected = selectedDoc === file.fileKey;
 
         return (
           <Chip
@@ -30,7 +33,6 @@ export const SelectDocuments = ({
             label={file.name}
             size={isSelected ? 'medium' : 'small'}
             onClick={()=>{
-              setFieldValue(getFieldName('envSelectedDoc'), file.fileKey);
               handlePreview(file.fileKey);
             }}
           />

--- a/packages/kokoas-server/src/api/docusign/contracts/construction/generateContractPdf.ts
+++ b/packages/kokoas-server/src/api/docusign/contracts/construction/generateContractPdf.ts
@@ -379,7 +379,7 @@ export const generateContractPdf = async (
   if (payMethod === '振込') {
     drawText(
       firstPage,
-      payDestination,
+      payDestination || '豊田信用金庫　朝日支店', // 当面、固定。頻繁に変わるなら、マスター設定に移行。
       {
         x: 380,
         y: 367,


### PR DESCRIPTION
## 変更

- 完了または進行中の契約がある場合、検証エラーがあっても、プレビューは開けるようになりました。
- プレビューボタンの下に開けない理由を追加しました。
- 支払い方法は`振込`で、振込先が指定しなかった場合、`豊田信用金庫　朝日支店`になるよう修正しました。

## 理由

- fix #139 
- 網羅的ではないかもしれませんが、見落としたケースがある場合、教えてください。
- 前の仕組みは、プレビューでも保存処理をしましたが、今回はプレビューだと保存しないので、バックエンドで振込先が空の場合、`豊田信用金庫　朝日支店` になります。

## 備考

- 緊急修正なので、直接マスターへ派生させました。
- 開発環境で次のリンクで確認出来ます。他プロジェクトにもOKです。https://rdmuhwtt6gx7.cybozu.com/k/176/#/project/contract/preview?projEstimateId=d6572e8d-22b2-4575-b6ac-6af91bd6128b
- 契約内容に問題がありましたが、別PRで最優先に修正します。