### PR TITLE
請求入力：請求書発行、再発行、破棄の3ボタンを追加する

### DIFF
--- a/packages/kokoas-client/src/pages/projInvoice/FormInvoice.tsx
+++ b/packages/kokoas-client/src/pages/projInvoice/FormInvoice.tsx
@@ -3,7 +3,7 @@ import { MainContainer } from '../../components/ui/containers';
 import { PageTitle } from '../../components/ui/labels';
 import { getFieldName, TypeOfForm } from './form';
 import { ScrollToFieldError } from '../../components/utils/ScrollToFieldError';
-import { Divider, Grid, Stack, Typography } from '@mui/material';
+import { Alert, Divider, Grid, Stack, Typography } from '@mui/material';
 import { PlannedPaymentDate } from './fieldComponents/PlannedPaymentDate';
 import { SearchCustGroup } from 'kokoas-client/src/components/ui/textfield';
 import { useNavigate } from 'react-router-dom';
@@ -45,6 +45,7 @@ export const FormInvoice = () => {
   });
 
   const isBilled = (invoiceStatus !== 'created') && (invoiceStatus !== '');
+  const isVoided = invoiceStatus === 'voided';
 
 
   useEffect(() => {
@@ -91,7 +92,7 @@ export const FormInvoice = () => {
         <Grid item md={6} />
 
 
-        {custGroupId &&
+        {custGroupId && !isVoided &&
           <>
             {/* 契約済み見積り情報の表示 */}
             <Grid item xs={12} md={12}>
@@ -157,6 +158,13 @@ export const FormInvoice = () => {
             <EmptyBox>
               顧客を選択してください
             </EmptyBox>
+          </Grid>}
+
+        {isVoided &&
+          <Grid item xs={12} md={6}>
+            <Alert severity="error">
+              破棄した請求書のため、参照できません
+            </Alert>
           </Grid>}
 
       </MainContainer>

--- a/packages/kokoas-client/src/pages/projInvoice/FormInvoice.tsx
+++ b/packages/kokoas-client/src/pages/projInvoice/FormInvoice.tsx
@@ -3,7 +3,7 @@ import { MainContainer } from '../../components/ui/containers';
 import { PageTitle } from '../../components/ui/labels';
 import { getFieldName, TypeOfForm } from './form';
 import { ScrollToFieldError } from '../../components/utils/ScrollToFieldError';
-import { Button, Divider, Grid, Stack, Typography } from '@mui/material';
+import { Divider, Grid, Stack, Typography } from '@mui/material';
 import { PlannedPaymentDate } from './fieldComponents/PlannedPaymentDate';
 import { useResolveParams } from './hooks/useResolveParams';
 import { SearchCustGroup } from 'kokoas-client/src/components/ui/textfield';
@@ -17,6 +17,7 @@ import { EstimatesTable } from './fieldComponents/EstimatesTable';
 import { BillingEntryTable } from './fieldComponents/BillingEntryTable';
 import { EmptyBox } from 'kokoas-client/src/components/ui/information/EmptyBox';
 import { BillingTotal } from './fieldComponents/BillingTotal';
+import { ActionButtons } from './fieldComponents/ActionButtons';
 
 
 
@@ -24,7 +25,7 @@ export const FormInvoice = () => {
   const navigate = useNavigate();
   const { setSnackState } = useSnackBar();
 
-  const { values, submitForm, setValues, errors, submitCount } = useFormikContext<TypeOfForm>();
+  const { values, setValues, errors, submitCount } = useFormikContext<TypeOfForm>();
   const submitCountRef = useRef(0);
 
   const {
@@ -140,16 +141,10 @@ export const FormInvoice = () => {
             </Grid>
 
 
-            {/* 請求書発行ボタン */}
-            <Grid item xs={12} md={6}>
-              <Button
-                variant="contained"
-                onClick={submitForm}
-              >
-                請求書発行
-              </Button>
+            {/* 各種ボタン */}
+            <Grid item xs={12} md={12}>
+              <ActionButtons />
             </Grid>
-            <Grid item md={6} />
           </>}
 
         {!custGroupId &&

--- a/packages/kokoas-client/src/pages/projInvoice/FormikInvoice.tsx
+++ b/packages/kokoas-client/src/pages/projInvoice/FormikInvoice.tsx
@@ -26,7 +26,7 @@ export const FormikInvoice = () => {
 
 
         const handleSave = async () => {
-          const record = convertToKintone(values, 'created');
+          const record = convertToKintone(values);
 
           const { id } = await mutateAsync({
             recordId: invoiceId,

--- a/packages/kokoas-client/src/pages/projInvoice/api/convertToKintone.ts
+++ b/packages/kokoas-client/src/pages/projInvoice/api/convertToKintone.ts
@@ -1,14 +1,14 @@
 import { toKintoneDateStr } from 'kokoas-client/src/lib';
 import { IInvoices } from 'types';
-import { TInvoiceStatus, TypeOfForm } from '../form';
+import { TypeOfForm } from '../form';
 
 export const convertToKintone = ({
   custGroupId,
   estimates,
   plannedPaymentDate,
   exceedChecked,
+  invoiceStatus,
 }: TypeOfForm,
-invoiceStatus: TInvoiceStatus,
 ) => {
 
   const billingAmount = estimates.reduce((acc, cur) => {

--- a/packages/kokoas-client/src/pages/projInvoice/fieldComponents/ActionButtons.tsx
+++ b/packages/kokoas-client/src/pages/projInvoice/fieldComponents/ActionButtons.tsx
@@ -1,17 +1,62 @@
-import { Button } from '@mui/material';
+import { Button, Stack } from '@mui/material';
 import { useFormikContext } from 'formik';
+import { useSnackBar } from 'kokoas-client/src/hooks';
 import { TypeOfForm } from '../form';
 
 export const ActionButtons = () => {
 
-  const { submitForm } = useFormikContext<TypeOfForm>();
+  const { submitForm, values } = useFormikContext<TypeOfForm>();
+  const { invoiceStatus } = values;
+  const { setSnackState } = useSnackBar();
+  const isCreating = invoiceStatus === 'created' || invoiceStatus === '';
+  const isSent = invoiceStatus === 'sent';
+
+
+  const handlesubmit = () => {
+    setSnackState({
+      open: true,
+      severity: 'warning',
+      message: '開発中です',
+    });
+  };
 
   return (
-    <Button
-      variant="contained"
-      onClick={submitForm}
+    <Stack
+      direction="row"
+      justifyContent="flex-start"
+      spacing={2}
     >
-      請求書発行
-    </Button>
+      <Button
+        variant="contained"
+        onClick={submitForm}
+        disabled={isSent}
+      >
+        保存
+      </Button>
+      
+      <Button
+        variant="contained"
+        onClick={handlesubmit}
+        disabled={isSent}
+      >
+        請求書発行
+      </Button>
+      
+      {!isCreating && 
+      <Button
+        variant="contained"
+        onClick={handlesubmit}
+      >
+        再発行
+      </Button>}
+      
+      {!isCreating && 
+      <Button
+        variant="contained"
+        onClick={handlesubmit}
+      >
+        破棄
+      </Button>}
+    </Stack>
   );
 };

--- a/packages/kokoas-client/src/pages/projInvoice/fieldComponents/ActionButtons.tsx
+++ b/packages/kokoas-client/src/pages/projInvoice/fieldComponents/ActionButtons.tsx
@@ -1,0 +1,17 @@
+import { Button } from '@mui/material';
+import { useFormikContext } from 'formik';
+import { TypeOfForm } from '../form';
+
+export const ActionButtons = () => {
+
+  const { submitForm } = useFormikContext<TypeOfForm>();
+
+  return (
+    <Button
+      variant="contained"
+      onClick={submitForm}
+    >
+      請求書発行
+    </Button>
+  );
+};

--- a/packages/kokoas-client/src/pages/projInvoice/fieldComponents/ActionButtons.tsx
+++ b/packages/kokoas-client/src/pages/projInvoice/fieldComponents/ActionButtons.tsx
@@ -1,24 +1,22 @@
 import { Button, Stack } from '@mui/material';
 import { useFormikContext } from 'formik';
-import { useSnackBar } from 'kokoas-client/src/hooks';
 import { TypeOfForm } from '../form';
+import { useSubmitInvoice } from '../hooks/useSubmitInvoice';
 
 export const ActionButtons = () => {
 
-  const { submitForm, values } = useFormikContext<TypeOfForm>();
+  const { values } = useFormikContext<TypeOfForm>();
   const { invoiceStatus } = values;
-  const { setSnackState } = useSnackBar();
+
   const isCreating = invoiceStatus === 'created' || invoiceStatus === '';
   const isSent = invoiceStatus === 'sent';
 
-
-  const handlesubmit = () => {
-    setSnackState({
-      open: true,
-      severity: 'warning',
-      message: '開発中です',
-    });
-  };
+  const {
+    handleSave,
+    handleIssue,
+    handleReissue,
+    handleVoided,
+  } = useSubmitInvoice();
 
   return (
     <Stack
@@ -28,35 +26,35 @@ export const ActionButtons = () => {
     >
       <Button
         variant="contained"
-        onClick={submitForm}
+        onClick={handleSave}
         disabled={isSent}
       >
         保存
       </Button>
-      
+
       <Button
         variant="contained"
-        onClick={handlesubmit}
+        onClick={handleIssue}
         disabled={isSent}
       >
         請求書発行
       </Button>
-      
-      {!isCreating && 
-      <Button
-        variant="contained"
-        onClick={handlesubmit}
-      >
-        再発行
-      </Button>}
-      
-      {!isCreating && 
-      <Button
-        variant="contained"
-        onClick={handlesubmit}
-      >
-        破棄
-      </Button>}
+
+      {!isCreating &&
+        <Button
+          variant="contained"
+          onClick={handleReissue}
+        >
+          再発行
+        </Button>}
+
+      {!isCreating &&
+        <Button
+          variant="contained"
+          onClick={handleVoided}
+        >
+          破棄
+        </Button>}
     </Stack>
   );
 };

--- a/packages/kokoas-client/src/pages/projInvoice/hooks/useSubmitInvoice.ts
+++ b/packages/kokoas-client/src/pages/projInvoice/hooks/useSubmitInvoice.ts
@@ -1,64 +1,59 @@
-/* 請求書発行ボタンを押したときの保存処理 */
+import { useFormikContext } from 'formik';
+import { useSnackBar } from 'kokoas-client/src/hooks';
+import { TInvoiceStatus, TypeOfForm } from '../form';
 
-import { Formik } from 'formik';
-import { useSaveInvoice } from 'kokoas-client/src/hooksQuery';
-import { ComponentProps, useEffect } from 'react';
-import { useBackdrop, useSnackBar } from '../../../hooks';
-import { convertToKintone } from '../api/convertToKintone';
-import { TypeOfForm } from '../form';
 
 export const useSubmitInvoice = () => {
 
-  const { mutateAsync, isPaused } = useSaveInvoice();
-
-  const { setBackdropState } = useBackdrop();
   const { setSnackState } = useSnackBar();
+  const { submitForm, setValues, values } = useFormikContext<TypeOfForm>();
 
+  const { invoiceStatus } = values;
 
-  useEffect(() => {
-    if (isPaused) {
-      setSnackState({
-        open: true,
-        severity: 'error',
-        message: '保存に失敗しました。ネットワークエラーです。',
+  const handleSubmit = (newInvoiceStatus: TInvoiceStatus) => {
+
+    setValues((prev) => {
+      return ({
+        ...prev,
+        invoiceStatus: newInvoiceStatus,
       });
-      setBackdropState({ open: false });
-    }
+    });
 
-  }, [isPaused, setSnackState, setBackdropState]);
+    submitForm();
+  };
 
-  const onSubmit: ComponentProps<typeof Formik<TypeOfForm>>['onSubmit'] = async (
-    values,
-    {
-      resetForm,
-    },
-  ) => {
+  const handlePreview = () => {
 
-    const kintoneRecord = convertToKintone(values, 'created');
-    await mutateAsync({
-      record: kintoneRecord,
-      recordId: values.invoiceId,
-    }).then((res) => {
-      setSnackState({
-        open: true,
-        severity: 'success',
-        message: '保存しました。',
-      });
-      console.log('res', res);
-      resetForm({
-        values: { ...values, invoiceId: res.id },
-      });
-    }).catch((err) => {
-      setSnackState({
-        open: true,
-        severity: 'error',
-        message: `保存が失敗しました。${err.message}`,
-      });
+    setSnackState({
+      open: true,
+      severity: 'warning',
+      message: '開発中です',
     });
   };
 
-  return {
-    onSubmit,
+  const handleSave = () => {
+    handleSubmit('created');
   };
 
+  const handleIssue = () => {
+    handleSubmit('sent');
+    handlePreview();
+  };
+
+  const handleReissue = () => {
+    // handleSubmit(invoiceStatus); // 予定が未定かつ、請求書の日付を更新する場合のみ
+    handlePreview();
+  };
+
+  const handleVoided = () => {
+    handleSubmit('voided');
+  };
+
+
+  return {
+    handleSave,
+    handleIssue,
+    handleReissue,
+    handleVoided,
+  };
 };


### PR DESCRIPTION
**変更**
---

 - 請求書発行、再発行、破棄の3ボタンを追加で配置します
 - まずはボタンの配置と、請求ステータスの設定のみ実装します。
 - その他の処理は別PRにて対応します。

**変更理由**
---

 - 要件によります。
 - https://trello.com/c/iA8l57hS