### PR TITLE
fix-T273-エリア担当者選択機能を修正

### DIFF
--- a/packages/api-kintone/src/employees/helpers/filterEmployees.test.ts
+++ b/packages/api-kintone/src/employees/helpers/filterEmployees.test.ts
@@ -1,0 +1,117 @@
+import { EmpAffiliations, IEmployees, Territory } from 'types';
+import { getEmployees } from '../getEmployees';
+import { filterEmployees } from './filterEmployees';
+
+describe('filterEmployees', () => {
+  let employees: IEmployees[] = [];
+
+  beforeAll(async () => {
+    employees = await getEmployees(true);
+  });
+
+  it('should return all cocoAG when territory and store is not defined.', () => {
+    const result = filterEmployees(
+      employees,
+      {
+        agentType: 'cocoAG',
+      });
+
+    const isMatch = result
+      .every(({ affiliation }) => (affiliation.value as EmpAffiliations) === 'ここすも' );
+
+    console.log(`cocoAG Length: ${result.length}`);
+    expect(isMatch).toBe(true);
+  });
+
+  it('should return all yumeAG when territory and store is not defined.', () => {
+    const result = filterEmployees(
+      employees,
+      {
+        agentType: 'yumeAG',
+      });
+
+    const isMatch = result
+      .every(({ affiliation }) => (affiliation.value as EmpAffiliations) === 'ゆめてつ' );
+
+    console.log(`yumeAG Length: ${result.length}`);
+    expect(isMatch).toBe(true);
+  });
+
+  it('should return cocoAG of 東 territory', () => {
+    const result = filterEmployees(employees, {
+      agentType: 'cocoAG',
+      territory: '東',
+    });
+
+    console.log(`[cocoAG, 東] Length: ${result.length}`);
+
+    const isMatch = result
+      .every(({
+        territory_v2: territory,
+        affiliation,
+      }) => (territory.value as Territory) === '東'  && (affiliation.value as EmpAffiliations) === 'ここすも');
+
+    expect(isMatch).toBe(true);
+  });
+
+  it('should return yumeAG of 東 territory with specified storeId', () => {
+    const toyokawaStoreId = '83128853-98af-47af-9e5a-9d711bee4a43'; // https://rdmuhwtt6gx7.cybozu.com/k/19/show#record=12
+    const result = filterEmployees(employees, {
+      agentType: 'yumeAG',
+      territory: '東',
+      storeId: toyokawaStoreId,
+    });
+
+    console.log(`[yumeAG, 東] Length: ${result.length}`);
+
+    console.log(result);
+
+    const isMatch = result
+      .every(({
+        mainStoreId_v2: mainStoreId,
+        affStores,
+        territory_v2: territory,
+        affiliation,
+      }) => (territory.value as Territory) === '東'
+        && (affiliation.value as EmpAffiliations) === 'ゆめてつ'
+        && ( mainStoreId.value === toyokawaStoreId || affStores.value.some(({ value: { affStoreId } }) => affStoreId.value === toyokawaStoreId) ),
+      );
+
+    expect(isMatch).toBe(true);
+  });
+
+  it('should return yumeAG of 西 territory with that matches any of storeId[]', () => {
+    const storeIds = [
+      '83128853-98af-47af-9e5a-9d711bee4a43', // 豊川中央店 https://rdmuhwtt6gx7.cybozu.com/k/19/show#record=12
+      'df176cb7-b731-466b-a354-a1cd5cc8f748', // 豊田中央店 https://rdmuhwtt6gx7.cybozu.com/k/19/show#record=13
+    ];
+    const result = filterEmployees(employees, {
+      agentType: 'yumeAG',
+      territory: '西',
+      storeId: storeIds,
+    });
+
+    console.log(`[yumeAG, 西] Length: ${result.length}`);
+
+    console.log(result);
+
+    const isMatch = result
+      .every(({
+        mainStoreId_v2: mainStoreId,
+        affStores,
+        territory_v2: territory,
+        affiliation,
+      }) => (territory.value as Territory) === '西'
+        && (affiliation.value as EmpAffiliations) === 'ゆめてつ'
+        && (storeIds
+          .some((storeId) => (
+            mainStoreId.value === storeId
+              || affStores.value
+                .some(({ value: { affStoreId: _storeId } }) => _storeId.value === storeId )
+          ))
+        ),
+      );
+
+    expect(isMatch).toBe(true);
+  });
+});

--- a/packages/api-kintone/src/employees/helpers/filterEmployees.test.ts
+++ b/packages/api-kintone/src/employees/helpers/filterEmployees.test.ts
@@ -1,6 +1,27 @@
+/**
+ * @jest-environment node
+ */
+
 import { EmpAffiliations, IEmployees, Territory } from 'types';
 import { getEmployees } from '../getEmployees';
 import { filterEmployees } from './filterEmployees';
+
+
+const flatenResult = ({
+  mainStoreId_v2: mainStoreId,
+  affStores,
+  territory_v2: territory,
+  affiliation,
+  文字列＿氏名: empName,
+  mainStore_v2: mainStore,
+} : IEmployees) => ({
+  mainStoreId: mainStoreId.value,
+  affStores: affStores.value.map((row) => row.value.affStoreName.value),
+  territory: territory.value,
+  affiliation: affiliation.value,
+  empName: empName.value,
+  mainStore: mainStore.value,
+});
 
 describe('filterEmployees', () => {
   let employees: IEmployees[] = [];
@@ -62,9 +83,7 @@ describe('filterEmployees', () => {
       storeId: toyokawaStoreId,
     });
 
-    console.log(`[yumeAG, 東] Length: ${result.length}`);
-
-    console.log(result);
+    console.log(`[yumeAG, 東, ${toyokawaStoreId}] Length: ${result.length}`);
 
     const isMatch = result
       .every(({
@@ -85,15 +104,17 @@ describe('filterEmployees', () => {
       '83128853-98af-47af-9e5a-9d711bee4a43', // 豊川中央店 https://rdmuhwtt6gx7.cybozu.com/k/19/show#record=12
       'df176cb7-b731-466b-a354-a1cd5cc8f748', // 豊田中央店 https://rdmuhwtt6gx7.cybozu.com/k/19/show#record=13
     ];
+
     const result = filterEmployees(employees, {
       agentType: 'yumeAG',
       territory: '西',
       storeId: storeIds,
     });
 
-    console.log(`[yumeAG, 西] Length: ${result.length}`);
+    const flatResults = result.map(flatenResult);
 
-    console.log(result);
+    console.log(`[yumeAG, 西, ${storeIds}] Length: ${result.length}`);
+    console.log(flatResults);
 
     const isMatch = result
       .every(({

--- a/packages/api-kintone/src/employees/helpers/filterEmployees.test.ts
+++ b/packages/api-kintone/src/employees/helpers/filterEmployees.test.ts
@@ -8,7 +8,7 @@ import { filterEmployees } from './filterEmployees';
 
 /**
  * 「IEmployees」を含む入力オブジェクトから指定されたプロパティと値を持つフラットなオブジェクトを返します。
- * テスト自体が合っているかどうか、目で簡単に確認するため。
+ * @remarks テスト自体が合っているかどうか、目で簡単に確認するために用いられます。
  */
 const flatenResult = ({
   mainStoreId_v2: mainStoreId,

--- a/packages/api-kintone/src/employees/helpers/filterEmployees.test.ts
+++ b/packages/api-kintone/src/employees/helpers/filterEmployees.test.ts
@@ -6,7 +6,10 @@ import { EmpAffiliations, IEmployees, Territory } from 'types';
 import { getEmployees } from '../getEmployees';
 import { filterEmployees } from './filterEmployees';
 
-
+/**
+ * 「IEmployees」を含む入力オブジェクトから指定されたプロパティと値を持つフラットなオブジェクトを返します。
+ * テスト自体が合っているかどうか、目で簡単に確認するため。
+ */
 const flatenResult = ({
   mainStoreId_v2: mainStoreId,
   affStores,
@@ -99,7 +102,7 @@ describe('filterEmployees', () => {
     expect(isMatch).toBe(true);
   });
 
-  it('should return yumeAG of 西 territory with that matches any of storeId[]', () => {
+  it('should return yumeAG of 西 territory that matches any of specified storeId[]', () => {
     const storeIds = [
       '83128853-98af-47af-9e5a-9d711bee4a43', // 豊川中央店 https://rdmuhwtt6gx7.cybozu.com/k/19/show#record=12
       'df176cb7-b731-466b-a354-a1cd5cc8f748', // 豊田中央店 https://rdmuhwtt6gx7.cybozu.com/k/19/show#record=13

--- a/packages/api-kintone/src/employees/helpers/filterEmployees.ts
+++ b/packages/api-kintone/src/employees/helpers/filterEmployees.ts
@@ -1,0 +1,78 @@
+import { TAgents, Territory } from 'types';
+import { RecordType } from '../config';
+import { resolveAffiliations } from './resolveAffiliations';
+import { resolveRoles } from './resolveRoles';
+
+
+/**
+ * フィルタ条件に基づいて社員を返します。
+ *
+ * 注意：本関数は、混乱を招く仕組みがあるため、以下の点に注意してください。
+ *
+ * mainStoreId_v2 と mainStore の存在について
+ * どちらも、店舗リストに紐づく社員名簿のフィールドです。
+ * 前バージョンでは mainStore は店舗リストのレコード番号で紐づいていましたが、
+ * テスト環境に移行すると、同じレコード番号にはなりませんでした。
+ * そこで、ココアスに関わる全アプリに uuid を実装することにしました。
+ * ただし、店舗リストに紐づいているアプリがあるため、それらアプリを特定して、
+ * 更新するまで、旧 mainStore や territory などを残しています。
+ *
+ * 旧フィールド：mainStoreId, affiliateStores, mainStore
+ * 新フィールド: mainStoreId_v2, affStores, mainStore_v2
+ *
+ * 社員名簿：
+ * https://rdmuhwtt6gx7.cybozu.com/k/34/
+ */
+export const filterEmployees = (
+  employees: RecordType[],
+  condition: {
+    storeId?: string | string[],
+    agentType?: TAgents | TAgents[],
+    territory?: Territory
+  }) => {
+
+  let affiliations: string[] = [];
+  let roles: string[] = [];
+
+
+  const storeIds = ([] as string[]).concat(condition.storeId ?? []).filter(Boolean);
+
+  if (condition.agentType) {
+    affiliations = resolveAffiliations(condition.agentType);
+    roles = resolveRoles(condition.agentType);
+  }
+
+  return employees
+    .filter(({
+      mainStoreId_v2: mainStore,
+      affStores,
+      affiliation,
+      役職: empRole,
+      territory_v2: territory,
+    }) => {
+
+      const isStoreSelected = !!storeIds.length;
+
+      const isInStore = storeIds
+        .some((s) => (mainStore.value === s
+          || affStores
+            .value
+            .some(({ value: { affStoreId: _storeId } }) => _storeId.value === s )
+        ));
+
+      const isAffiliated = !affiliations.length || affiliations.includes(affiliation.value);
+      const isInRole = !roles.length || roles.includes(empRole.value);
+      const isInTerritory = !condition.territory || condition.territory === territory.value;
+
+      const shouldInclude = isAffiliated
+        && isInRole
+        && (
+          isStoreSelected
+            ? (isInStore && isInTerritory)
+            : isInTerritory
+        );
+
+      return shouldInclude;
+    });
+
+};

--- a/packages/api-kintone/src/employees/helpers/index.ts
+++ b/packages/api-kintone/src/employees/helpers/index.ts
@@ -1,2 +1,3 @@
+export * from './filterEmployees';
 export * from './resolveAffiliations';
 export * from './resolveRoles';

--- a/packages/api-kintone/src/employees/helpers/resolveAffiliations.test.ts
+++ b/packages/api-kintone/src/employees/helpers/resolveAffiliations.test.ts
@@ -2,5 +2,6 @@ import { resolveAffiliations } from '.';
 
 test('resolve', () => {
   expect(resolveAffiliations('cocoConst').length).toBeTruthy();
-  expect(resolveAffiliations(['yumeAG', 'cocoAG', 'cocoConst']).length).toBeTruthy();
+  const affiliations = resolveAffiliations(['yumeAG', 'cocoAG', 'cocoConst']);
+  expect(affiliations).toBeTruthy();
 });

--- a/packages/api-kintone/src/employees/helpers/resolveAffiliations.test.ts
+++ b/packages/api-kintone/src/employees/helpers/resolveAffiliations.test.ts
@@ -1,7 +1,16 @@
 import { resolveAffiliations } from '.';
 
-test('resolve', () => {
-  expect(resolveAffiliations('cocoConst').length).toBeTruthy();
-  const affiliations = resolveAffiliations(['yumeAG', 'cocoAG', 'cocoConst']);
-  expect(affiliations).toBeTruthy();
+describe('resolveAffiliations', () => {
+  it('should resolve affiliation of a single agent', () => {
+    expect(resolveAffiliations('cocoConst')).toMatchObject(['ここすも']);
+  });
+
+  it('should resolve affiliations of an array of agents', () => {
+    expect(resolveAffiliations(['yumeAG', 'cocoAG', 'cocoConst'])).toMatchObject(['ゆめてつ', 'ここすも']);
+  });
+
+  it('should resolve unique affiliations of an array of agents with duplicates', () => {
+    expect(resolveAffiliations(['yumeAG', 'cocoAG', 'cocoConst', 'cocoAG', 'cocoAG', 'cocoAG'])).toMatchObject(['ゆめてつ', 'ここすも']);
+  });
 });
+

--- a/packages/api-kintone/src/employees/helpers/resolveAffiliations.ts
+++ b/packages/api-kintone/src/employees/helpers/resolveAffiliations.ts
@@ -1,23 +1,25 @@
 import { EmpAffiliations, TAgents } from 'types';
 
-
-
+/**
+ * 与えられた TAgents または TAgents[] 型のパラメータから、関連会社を解決します。
+ *
+ * @param {TAgents | TAgents[]} dirtyType - string または string[] で表されたエージェントのタイプ
+ * @returns {EmpAffiliations[]} 関連する会社の EmpAffiliations[] 配列
+ */
 export const resolveAffiliations = (dirtyType: TAgents | TAgents[]) => {
+  const agentType = dirtyType instanceof Array ? dirtyType : [dirtyType];
 
-  return ([] as string[])
-    .concat(dirtyType)
-    .reduce((acc, curr)=>{
-
-      if (curr.includes('yume') && !acc.includes('ゆめてつ')) {
-        return [...new Set([...acc, 'ゆめてつ'])];
-      }
-      if (curr.includes('coco') && !acc.includes('ここすも')) {
-        return [...new Set([...acc, 'ここすも'])];
-      }
-      if (curr.includes('sutekura') && !acc.includes('すてくら')) {
-        return [...new Set([...acc, 'すてくら'])];
-      }
-
+  const result : EmpAffiliations[] = agentType.reduce((acc, curr) => {
+    if (curr.includes('yume') && !acc.includes('ゆめてつ')) {
+      return [...acc, 'ゆめてつ'];
+    } else if (curr.includes('coco') && !acc.includes('ここすも')) {
+      return [...acc, 'ここすも'];
+    } else if (curr.includes('sutekura') && !acc.includes('すてくら')) {
+      return [...acc, 'すてくら'];
+    } else {
       return acc;
-    }, [] as EmpAffiliations[]);
+    }
+  }, [] as EmpAffiliations[]);
+
+  return result;
 };

--- a/packages/api-kintone/src/employees/helpers/resolveAffiliations.ts
+++ b/packages/api-kintone/src/employees/helpers/resolveAffiliations.ts
@@ -9,7 +9,7 @@ import { EmpAffiliations, TAgents } from 'types';
 export const resolveAffiliations = (dirtyType: TAgents | TAgents[]) => {
   const agentType = dirtyType instanceof Array ? dirtyType : [dirtyType];
 
-  const result : EmpAffiliations[] = agentType.reduce((acc, curr) => {
+  return agentType.reduce<EmpAffiliations[]>((acc, curr) => {
     if (curr.includes('yume') && !acc.includes('ゆめてつ')) {
       return [...acc, 'ゆめてつ'];
     } else if (curr.includes('coco') && !acc.includes('ここすも')) {
@@ -19,7 +19,5 @@ export const resolveAffiliations = (dirtyType: TAgents | TAgents[]) => {
     } else {
       return acc;
     }
-  }, [] as EmpAffiliations[]);
-
-  return result;
+  }, []);
 };

--- a/packages/api-kintone/src/employees/helpers/resolveAffiliations.ts
+++ b/packages/api-kintone/src/employees/helpers/resolveAffiliations.ts
@@ -2,9 +2,6 @@ import { EmpAffiliations, TAgents } from 'types';
 
 /**
  * 与えられた TAgents または TAgents[] 型のパラメータから、関連会社を解決します。
- *
- * @param {TAgents | TAgents[]} dirtyType - string または string[] で表されたエージェントのタイプ
- * @returns {EmpAffiliations[]} 関連する会社の EmpAffiliations[] 配列
  */
 export const resolveAffiliations = (dirtyType: TAgents | TAgents[]) => {
   const agentType = dirtyType instanceof Array ? dirtyType : [dirtyType];

--- a/packages/api-kintone/src/employees/helpers/resolveRoles.test.ts
+++ b/packages/api-kintone/src/employees/helpers/resolveRoles.test.ts
@@ -1,0 +1,18 @@
+import { resolveRoles, rolesMap } from './resolveRoles';
+
+describe('resolveRoles', () => {
+  it('should return role of a single agent types', () => {
+    expect(resolveRoles('cocoAG')).toMatchObject(rolesMap.cocoAG);
+  });
+
+  it('should return roles of agent types', () => {
+    console.log(resolveRoles(['cocoAG', 'cocoConst']));
+    expect(resolveRoles(['cocoAG', 'cocoConst'])).toStrictEqual(rolesMap.cocoAG);
+  });
+
+
+  it('should return unique roles of agent types with duplicates', () => {
+    console.log(resolveRoles(['cocoAG', 'cocoConst']));
+    expect(resolveRoles(['cocoAG', 'cocoConst', 'cocoAG', 'cocoAG'])).toStrictEqual(rolesMap.cocoAG);
+  });
+});

--- a/packages/api-kintone/src/employees/helpers/resolveRoles.ts
+++ b/packages/api-kintone/src/employees/helpers/resolveRoles.ts
@@ -7,7 +7,7 @@ type RolesMap = {
 export const rolesMap: RolesMap = {
   'yumeAG': ['主任', '営業', '店長'],
   'cocoAG': ['営業', '店長', '工務', '主任'],
-  'cocoConst': ['営業', '店長', '工務', '主任'], // 当面、cocoAG 一緒ですが、変わるかもしれません。
+  'cocoConst': ['営業', '店長', '工務', '主任'], // 当面、cocoAGと一緒ですが、変わるかもしれませんので、残しておきます。
   'sutekura': ['主任', '営業', '店長', '工務'],
 };
 

--- a/packages/api-kintone/src/employees/helpers/resolveRoles.ts
+++ b/packages/api-kintone/src/employees/helpers/resolveRoles.ts
@@ -15,7 +15,7 @@ const rolesMap: RolesMap = {
 export const resolveRoles = (dirtyType: TAgents | TAgents[]) => {
   const types =  dirtyType instanceof Array ? dirtyType : [dirtyType];
 
-  const roles = types.reduce((acc: EmpRoles[], type: TAgents) => {
+  const roles = types.reduce<EmpRoles[]>((acc, type: TAgents) => {
     const typeRoles = rolesMap[type];
     if (typeRoles) {
       return [...acc, ...typeRoles];

--- a/packages/api-kintone/src/employees/helpers/resolveRoles.ts
+++ b/packages/api-kintone/src/employees/helpers/resolveRoles.ts
@@ -1,19 +1,27 @@
 import { TAgents, EmpRoles } from 'types';
 
+type RolesMap = {
+  [key in TAgents]: EmpRoles[];
+};
 
-export const resolveRoles = (dirtyType: TAgents | TAgents[])  => {
-  return ([] as TAgents[])
-    .concat(dirtyType)
-    .reduce((acc, curr) => {
-      switch (curr) {
-        case 'yumeAG':
-          return [...new Set([...acc, ...['主任', '営業', '店長'] as EmpRoles[]])];
-        case 'cocoAG':
-          return [...new Set([...acc, ...['主任', '営業', '店長', '工務'] as EmpRoles[]])];
-        case 'cocoConst':
-          return [...new Set([...acc, ...['工務', '営業', '店長', '主任'] as EmpRoles[]])];
-        case 'sutekura':
-          return [...new Set([...acc, ...['主任', '営業', '店長', '工務'] as EmpRoles[]])];
-      }
-    }, [] as EmpRoles[]);
+const rolesMap: RolesMap = {
+  'yumeAG': ['主任', '営業', '店長'],
+  'cocoAG': ['主任', '営業', '店長', '工務'],
+  'cocoConst': ['工務', '営業', '店長', '主任'],
+  'sutekura': ['主任', '営業', '店長', '工務'],
+};
+
+
+export const resolveRoles = (dirtyType: TAgents | TAgents[]) => {
+  const types =  dirtyType instanceof Array ? dirtyType : [dirtyType];
+
+  const roles = types.reduce((acc: EmpRoles[], type: TAgents) => {
+    const typeRoles = rolesMap[type];
+    if (typeRoles) {
+      return [...acc, ...typeRoles];
+    }
+    return acc;
+  }, []);
+
+  return [...new Set(roles)];
 };

--- a/packages/api-kintone/src/employees/helpers/resolveRoles.ts
+++ b/packages/api-kintone/src/employees/helpers/resolveRoles.ts
@@ -4,18 +4,17 @@ type RolesMap = {
   [key in TAgents]: EmpRoles[];
 };
 
-const rolesMap: RolesMap = {
+export const rolesMap: RolesMap = {
   'yumeAG': ['主任', '営業', '店長'],
-  'cocoAG': ['主任', '営業', '店長', '工務'],
-  'cocoConst': ['工務', '営業', '店長', '主任'],
+  'cocoAG': ['営業', '店長', '工務', '主任'],
+  'cocoConst': ['営業', '店長', '工務', '主任'], // 当面、cocoAG 一緒ですが、変わるかもしれません。
   'sutekura': ['主任', '営業', '店長', '工務'],
 };
 
-
 export const resolveRoles = (dirtyType: TAgents | TAgents[]) => {
-  const types =  dirtyType instanceof Array ? dirtyType : [dirtyType];
+  const agentTypes =  dirtyType instanceof Array ? dirtyType : [dirtyType];
 
-  const roles = types.reduce<EmpRoles[]>((acc, type: TAgents) => {
+  const roles = agentTypes.reduce<EmpRoles[]>((acc, type: TAgents) => {
     const typeRoles = rolesMap[type];
     if (typeRoles) {
       return [...acc, ...typeRoles];

--- a/packages/kokoas-client/package.json
+++ b/packages/kokoas-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kokoas-client",
-  "version": "20230221.2",
+  "version": "20230221.3",
   "devDependencies": {},
   "scripts": {
     "dev": "npm run build -- --watch --mode development",

--- a/packages/kokoas-client/src/hooksQuery/useFilteredEmployees.ts
+++ b/packages/kokoas-client/src/hooksQuery/useFilteredEmployees.ts
@@ -4,9 +4,23 @@ import { useEmployees } from './useEmployees';
 import { useCallback } from 'react';
 
 
+
+
 /**
- * Return employees based on filter conditions
+ * フィルタ条件に基づいて社員を返します。
  *
+ * 注意：本関数は、混乱を招く仕組みがあるため、以下の点に注意してください。
+ *
+ * mainStoreId_v2 と mainStore の存在について
+ * どちらも、店舗リストに紐づく社員名簿のフィールドです。
+ * 前バージョンでは mainStore は店舗リストのレコード番号で紐づいていましたが、
+ * テスト環境に移行すると、同じレコード番号にはなりませんでした。
+ * そこで、ココアスに関わる全アプリに uuid を実装することにしました。
+ * ただし、店舗リストに紐づいているアプリがあるため、それらアプリを特定して、
+ * 更新するまで、旧 mainStore や territory などを残しています。
+ *
+ * 社員名簿：
+ * https://rdmuhwtt6gx7.cybozu.com/k/34/
  */
 export const useFilteredEmployees = ({
   storeId = [],
@@ -33,28 +47,29 @@ export const useFilteredEmployees = ({
 
         return data
           .filter(({
-            mainStoreId_v2,
+            mainStoreId_v2: mainStore,
             affStores,
             affiliation,
             役職: empRole,
             territory_v2: _territory,
           }) => {
 
-            const isInStore = storeIds.some((s) => (mainStoreId_v2.value === s
+            const isInStore = storeIds
+              .some((s) => (mainStore.value === s
               || affStores
                 .value
                 .some(({ value: { affStoreId: _storeId } }) => _storeId.value === s )
-            )); 
+              ));
 
             const isAffiliated = !affiliations.length || affiliations.includes(affiliation.value);
             const isInRole = !roles.length || roles.includes(empRole.value);
             const isInTerritory = !territory || territory === _territory.value;
 
             return (
-              isInStore
+              (isInStore
               && isAffiliated
-              && isInRole
-              && isInTerritory
+              && isInRole)
+              || isInTerritory
             );
 
           });

--- a/packages/kokoas-client/src/hooksQuery/useFilteredEmployees.ts
+++ b/packages/kokoas-client/src/hooksQuery/useFilteredEmployees.ts
@@ -54,6 +54,8 @@ export const useFilteredEmployees = ({
             territory_v2: _territory,
           }) => {
 
+            const isStoreSelected = !!storeIds.length;
+
             const isInStore = storeIds
               .some((s) => (mainStore.value === s
               || affStores
@@ -65,13 +67,15 @@ export const useFilteredEmployees = ({
             const isInRole = !roles.length || roles.includes(empRole.value);
             const isInTerritory = !territory || territory === _territory.value;
 
-            return (
-              (isInStore
-              && isAffiliated
-              && isInRole)
-              || isInTerritory
+            const shouldInclude = isAffiliated
+            && isInRole
+            && (
+              isStoreSelected
+                ? (isInStore && isInTerritory)
+                : isInTerritory
             );
 
+            return shouldInclude;
           });
       },
       [agentType, storeId, territory],

--- a/packages/kokoas-client/src/hooksQuery/useFilteredEmployees.ts
+++ b/packages/kokoas-client/src/hooksQuery/useFilteredEmployees.ts
@@ -1,84 +1,12 @@
-import { TAgents, Territory } from 'types';
-import {  resolveRoles, resolveAffiliations } from 'api-kintone';
+import { filterEmployees } from 'api-kintone';
 import { useEmployees } from './useEmployees';
 import { useCallback } from 'react';
 
-
-
-
-/**
- * フィルタ条件に基づいて社員を返します。
- *
- * 注意：本関数は、混乱を招く仕組みがあるため、以下の点に注意してください。
- *
- * mainStoreId_v2 と mainStore の存在について
- * どちらも、店舗リストに紐づく社員名簿のフィールドです。
- * 前バージョンでは mainStore は店舗リストのレコード番号で紐づいていましたが、
- * テスト環境に移行すると、同じレコード番号にはなりませんでした。
- * そこで、ココアスに関わる全アプリに uuid を実装することにしました。
- * ただし、店舗リストに紐づいているアプリがあるため、それらアプリを特定して、
- * 更新するまで、旧 mainStore や territory などを残しています。
- *
- * 社員名簿：
- * https://rdmuhwtt6gx7.cybozu.com/k/34/
- */
-export const useFilteredEmployees = ({
-  storeId = [],
-  agentType,
-  territory,
-} : {
-  storeId?: string | string[],
-  agentType?: TAgents | TAgents[],
-  territory?: Territory
-}) => {
-
-
+export const useFilteredEmployees = (conditions: Parameters<typeof filterEmployees>[1]) => {
   return useEmployees({
     select: useCallback(
-      (data) => {
-        let affiliations: string[] = [];
-        let roles: string[] = [];
-        const storeIds = ([] as string[]).concat(storeId).filter(Boolean);
-
-        if (agentType) {
-          affiliations = resolveAffiliations(agentType);
-          roles = resolveRoles(agentType);
-        }
-
-        return data
-          .filter(({
-            mainStoreId_v2: mainStore,
-            affStores,
-            affiliation,
-            役職: empRole,
-            territory_v2: _territory,
-          }) => {
-
-            const isStoreSelected = !!storeIds.length;
-
-            const isInStore = storeIds
-              .some((s) => (mainStore.value === s
-              || affStores
-                .value
-                .some(({ value: { affStoreId: _storeId } }) => _storeId.value === s )
-              ));
-
-            const isAffiliated = !affiliations.length || affiliations.includes(affiliation.value);
-            const isInRole = !roles.length || roles.includes(empRole.value);
-            const isInTerritory = !territory || territory === _territory.value;
-
-            const shouldInclude = isAffiliated
-            && isInRole
-            && (
-              isStoreSelected
-                ? (isInStore && isInTerritory)
-                : isInTerritory
-            );
-
-            return shouldInclude;
-          });
-      },
-      [agentType, storeId, territory],
+      (data) => filterEmployees(data, conditions ),
+      [conditions],
     ),
   });
 };


### PR DESCRIPTION
## 変更

- 社員検索関数の日本語ドキュメンテーションを修正しました。
- テストの追加
- 領域を選択⇒そのエリア（東、西）の担当者を選択できるようになりました。

## 理由

- 廃止するフィールドについてのドキュメントを残し忘れたため、修正しました。
- 当要件のテストを重視しています。不具合が発生した場合は、新たにテストケースを追加していきます。これによって、修正時に他の要件が影響を受けないか、素早く確認できます。
- https://trello.com/c/lvZRvVC3

## 備考

- バグ修正なので、PR確認が終わったら、masterに直接マージされます。マージしたら、master を developmentにマージします。