### PR TITLE
hotfix-住所選択は正常に作動しない

### DIFF
--- a/packages/kokoas-client/package.json
+++ b/packages/kokoas-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kokoas-client",
-  "version": "20230221.4",
+  "version": "20230221.5",
   "devDependencies": {},
   "scripts": {
     "dev": "npm run build -- --watch --mode development",

--- a/packages/kokoas-client/src/pages/customer/register/FormikIndividualCustomer.tsx
+++ b/packages/kokoas-client/src/pages/customer/register/FormikIndividualCustomer.tsx
@@ -12,13 +12,10 @@ import { formToDBCustGroup } from './helper/formToDBCustGroup';
 import { useEmployees } from '../../../hooksQuery';
 import { useResolveParam } from './hooks/useResolveParam';
 import { validationSchema } from './validationSchema';
-import { useIsFetching } from '@tanstack/react-query';
-import { LinearProgress } from '@mui/material';
 
 
 
 export const FormikIndividualCustomer = () => {
-  const isFetching = !!useIsFetching();
   const { mutateAsync: saveCustGroupMutation } = useSaveCustGroup();
   const { data: employees } = useEmployees();
 
@@ -45,10 +42,6 @@ export const FormikIndividualCustomer = () => {
       });
     }
   };
-
-  if (isFetching) {
-    return <LinearProgress />;
-  }
 
 
   return (


### PR DESCRIPTION
## 変更

- ローディング確認と表示を一旦外しました。

## 理由

- ローディング中に、フォームをローディングコンポーネントに変えていますが、ローディング中の確認は、react-query全体のものさしていてるので、react-queryで住所取得のローディングも含まれてしまいます。

## テスト

- 後ほど追加します。
- https://rdmuhwtt6gx7.cybozu.com/k/149/#/custgroup/register
