### PR TITLE
サーバ側のエンドポイントの型定義をリファクタリングしました

### DIFF
--- a/packages/libs/src/endpoints.ts
+++ b/packages/libs/src/endpoints.ts
@@ -1,16 +1,7 @@
-import { KokoasApiNodes } from 'types';
-
-export const getKokoasEndpoint = (k: KokoasApiNodes) => k;
-
-export type TKokoasEnpoint =
-| 'uploadEstimates'
-| 'uploadGenka'
-| 'saveProjectToAndpad';
 
 
 
-/** リファクタリングが必要　 ~ ras */
-export const kokoasEndpoints : Record<TKokoasEnpoint, KokoasApiNodes> = {
+export const kokoasEndpoints = {
   /** 大黒さんの見積をアップロードし、変換する */
   uploadEstimates : 'upload/daikoku/estimate',
 
@@ -19,4 +10,12 @@ export const kokoasEndpoints : Record<TKokoasEnpoint, KokoasApiNodes> = {
 
   /** 案件をAndpadへ登録 */
   saveProjectToAndpad: 'andpad/register',
-};
+
+  /** 見積をAndpadの実行予算の形式でダウンロード */
+  downloadEstimateAsAndpad: 'download/estimate/andpad',
+} as const;
+
+export type TKokoasEndpointKey = keyof typeof kokoasEndpoints;
+export type TKokoasEndpoint = typeof kokoasEndpoints[keyof typeof kokoasEndpoints];
+
+export const getKokoasEndpoint = (k: TKokoasEndpoint) => k;

--- a/packages/types/src/common/server.ts
+++ b/packages/types/src/common/server.ts
@@ -135,8 +135,3 @@ export interface IRequestJWTUserTokenResponse {
 export type ApiNodes =
 | 'docusign'
 | 'kokoas';
-
-export type KokoasApiNodes =
-| 'upload/daikoku/estimate'
-| 'upload/daikoku/genka'
-| 'andpad/register';


### PR DESCRIPTION
## 変更

- エンドポイントの型はオブジェクトから派生させるようにしました。

## 理由

- エンドポイントの加減の際、変更点を減らすため。

## 備考

- 当変更よりいい整理の仕方があれば、ぜひお願いします。