### PR TITLE
請求入力：会社情報と顧客情報を取得する処理を追加する

### DIFF
--- a/packages/kokoas-server/src/handleRequest/putInvoiceReport/generateInvoicePdf.ts
+++ b/packages/kokoas-server/src/handleRequest/putInvoiceReport/generateInvoicePdf.ts
@@ -1,5 +1,5 @@
 import { getFilePath, getFont } from 'kokoas-server/src/assets';
-import { ParsedInvoiceReport } from 'types';
+import { ParsedCustGroupReport, ParsedInvoiceReport } from 'types';
 import fs from 'fs/promises';
 import fontkit from '@pdf-lib/fontkit';
 import { PDFDocument } from 'pdf-lib';
@@ -11,6 +11,7 @@ import { PDFDocument } from 'pdf-lib';
  */
 export const generateInvoicePdf = async (
   invoiceDat: ParsedInvoiceReport,
+  custGroupDat: ParsedCustGroupReport,
 ) => {
 
   const {
@@ -22,6 +23,11 @@ export const generateInvoicePdf = async (
     // estimateLists,
   } = invoiceDat;
 
+  const {
+    members,
+  } = custGroupDat;
+
+  const custName = members[0].customerName;
 
   const pdfPath = getFilePath({
     fileName: '請求書',
@@ -37,21 +43,32 @@ export const generateInvoicePdf = async (
   const pages = pdfDoc.getPages();
   const firstPage = pages[0];
 
-
   console.log(`Number of pages: ${pdfDoc.getPages().length}`);
   console.log('firstPage', firstPage);
 
 
   // PDF書き込み処理 ここから TODO
 
+  // 顧客氏名
+  firstPage.drawText(
+    custName,
+    {
+      x: 100,
+      y: 522,
+      font: msMinchoFont,
+      size: 18,
+    },
+  );
+
+
   // 請求書番号
   firstPage.drawText(
     slipNumber,
     {
-      x: 10, // dummy値
-      y: 10, // dummy値
+      x: 738,
+      y: 459,
       font: msMinchoFont,
-      size: 10,
+      size: 12,
     },
   );
 

--- a/packages/kokoas-server/src/handleRequest/putInvoiceReport/generateInvoicePdf.ts
+++ b/packages/kokoas-server/src/handleRequest/putInvoiceReport/generateInvoicePdf.ts
@@ -1,5 +1,5 @@
 import { getFilePath, getFont } from 'kokoas-server/src/assets';
-import { ParsedCustGroupReport, ParsedInvoiceReport } from 'types';
+import { ParsedCompanyDetailsDatReport, ParsedCustGroupReport, ParsedInvoiceReport } from 'types';
 import fs from 'fs/promises';
 import fontkit from '@pdf-lib/fontkit';
 import { PDFDocument } from 'pdf-lib';
@@ -12,6 +12,7 @@ import { PDFDocument } from 'pdf-lib';
 export const generateInvoicePdf = async (
   invoiceDat: ParsedInvoiceReport,
   custGroupDat: ParsedCustGroupReport,
+  companyDetailsDat: ParsedCompanyDetailsDatReport,
 ) => {
 
   const {
@@ -26,6 +27,15 @@ export const generateInvoicePdf = async (
   const {
     members,
   } = custGroupDat;
+
+  const {
+    companyName,
+    // companyPostCode,
+    // companyAddress,
+    // kenchikugyoKyoka,
+    // takkengyoNumber,
+    // OfficeRegistration,
+  } = companyDetailsDat;
 
   const custName = members[0].customerName;
 
@@ -72,6 +82,17 @@ export const generateInvoicePdf = async (
     },
   );
 
+
+  // 会社情報の反映  
+  firstPage.drawText(
+    companyName,
+    {
+      x: 477,
+      y: 126,
+      font: msMinchoFont,
+      size: 14,
+    },
+  );
 
   // PDF書き込み処理 ここまで
 

--- a/packages/kokoas-server/src/handleRequest/putInvoiceReport/generateInvoicePdf.ts
+++ b/packages/kokoas-server/src/handleRequest/putInvoiceReport/generateInvoicePdf.ts
@@ -42,7 +42,7 @@ export const generateInvoicePdf = async (
   console.log('firstPage', firstPage);
 
 
-  // PDF書き込み処理 ここから
+  // PDF書き込み処理 ここから TODO
 
   // 請求書番号
   firstPage.drawText(

--- a/packages/kokoas-server/src/handleRequest/putInvoiceReport/parseCocosumoDetails.test.ts
+++ b/packages/kokoas-server/src/handleRequest/putInvoiceReport/parseCocosumoDetails.test.ts
@@ -1,0 +1,13 @@
+import { getCocosumoDetails } from 'api-kintone/src/companyDetails/getCocosumoDetails';
+import { parseCocosumoDetails } from './parseCocosumoDetails';
+
+describe('parsing cocosumoDetails record', () => {
+  it('should validate file', async () => {
+    const recCocosumoDetails = await getCocosumoDetails();
+    const result = await parseCocosumoDetails(recCocosumoDetails);
+    
+    console.log(result);
+
+    expect(result).toHaveProperty('companyName');
+  });
+});

--- a/packages/kokoas-server/src/handleRequest/putInvoiceReport/parseCocosumoDetails.ts
+++ b/packages/kokoas-server/src/handleRequest/putInvoiceReport/parseCocosumoDetails.ts
@@ -1,0 +1,25 @@
+import { ParsedCompanyDetailsDatReport } from 'types';
+
+export const parseCocosumoDetails = async (
+  cocosumoDetailsDat: DBCompanydetails.SavedData,
+): Promise<ParsedCompanyDetailsDatReport> => {
+
+  const {
+    companyName,
+    postCode,
+    companyAddress,
+    kensetsugyoKyoka,
+    takkengyoNumber,
+    kenchikushiJimushoRegister,
+  } = cocosumoDetailsDat;
+
+  return {
+    companyName: companyName.value,
+    companyPostCode: postCode.value,
+    companyAddress: companyAddress.value,
+    kenchikugyoKyoka: kensetsugyoKyoka.value,
+    takkengyoNumber: takkengyoNumber.value,
+    OfficeRegistration: kenchikushiJimushoRegister.value,
+  };
+
+};

--- a/packages/kokoas-server/src/handleRequest/putInvoiceReport/parseCocosumoDetails.ts
+++ b/packages/kokoas-server/src/handleRequest/putInvoiceReport/parseCocosumoDetails.ts
@@ -19,7 +19,7 @@ export const parseCocosumoDetails = async (
     companyAddress: companyAddress.value,
     kenchikugyoKyoka: kensetsugyoKyoka.value,
     takkengyoNumber: takkengyoNumber.value,
-    OfficeRegistration: kenchikushiJimushoRegister.value,
+    officeRegistration: kenchikushiJimushoRegister.value,
   };
 
 };

--- a/packages/kokoas-server/src/handleRequest/putInvoiceReport/parseCustGroupDat.test.ts
+++ b/packages/kokoas-server/src/handleRequest/putInvoiceReport/parseCustGroupDat.test.ts
@@ -1,0 +1,13 @@
+import { getCustGroupById } from 'api-kintone';
+import { parseCustGroupDat } from './parseCustGroupDat';
+
+describe('parsing custGroup record', () => {
+  it('should validate file', async () => {
+    const recCustDat = await getCustGroupById('fe8029b9-4206-4344-a9d4-6d31918e8bb8');
+    const result = await parseCustGroupDat(recCustDat);
+    
+    console.log(result);
+
+    expect(result).toHaveProperty('members');
+  });
+});

--- a/packages/kokoas-server/src/handleRequest/putInvoiceReport/parseCustGroupDat.ts
+++ b/packages/kokoas-server/src/handleRequest/putInvoiceReport/parseCustGroupDat.ts
@@ -1,0 +1,21 @@
+import { ParsedCustGroupReport } from 'types';
+
+export const parseCustGroupDat = async (
+  recCustGroupDat: DBCustgroups.SavedData,
+): Promise<ParsedCustGroupReport> => {
+
+  const {
+    uuid,
+    members:{ value: members },    
+  } = recCustGroupDat;
+
+  return {
+    custGroupId: uuid.value,
+    members: members.map(({ value: member }) => {
+      return {
+        customerName: member.customerName.value,
+      };
+    }),
+  };
+
+};

--- a/packages/kokoas-server/src/handleRequest/putInvoiceReport/reqDownloadInvoice.ts
+++ b/packages/kokoas-server/src/handleRequest/putInvoiceReport/reqDownloadInvoice.ts
@@ -1,8 +1,10 @@
 import { getCustGroupById } from 'api-kintone';
+import { getCocosumoDetails } from 'api-kintone/src/companyDetails/getCocosumoDetails';
 import { getInvoiceById } from 'api-kintone/src/invoice/getInvoiceById';
 import { RequestHandler } from 'express';
 import { DownloadInvoiceResponse } from 'types';
 import { generateInvoicePdf } from './generateInvoicePdf';
+import { parseCocosumoDetails } from './parseCocosumoDetails';
 import { parseCustGroupDat } from './parseCustGroupDat';
 import { parseInvoiceDat } from './parseInvoiceDat';
 
@@ -48,13 +50,20 @@ ReqDownloadInvoice
     const resCustGroup = await parseCustGroupDat(recCustGroup);
 
     // 会社情報の取得
+    const recCocosumoDetails = await getCocosumoDetails();
+    const resCocosumoDetails = await parseCocosumoDetails(recCocosumoDetails);
 
 
     if (update) {
       // TODO 請求書発行日時の更新処理
     }
 
-    const pdfDat = await generateInvoicePdf(resInvoice, resCustGroup); // PDFの作成
+    // PDFの作成
+    const pdfDat = await generateInvoicePdf(
+      resInvoice, 
+      resCustGroup,
+      resCocosumoDetails,
+    );
 
 
     res.status(200).json({

--- a/packages/kokoas-server/src/handleRequest/putInvoiceReport/reqDownloadInvoice.ts
+++ b/packages/kokoas-server/src/handleRequest/putInvoiceReport/reqDownloadInvoice.ts
@@ -1,7 +1,9 @@
+import { getCustGroupById } from 'api-kintone';
 import { getInvoiceById } from 'api-kintone/src/invoice/getInvoiceById';
 import { RequestHandler } from 'express';
 import { DownloadInvoiceResponse } from 'types';
 import { generateInvoicePdf } from './generateInvoicePdf';
+import { parseCustGroupDat } from './parseCustGroupDat';
 import { parseInvoiceDat } from './parseInvoiceDat';
 
 export interface ReqDownloadInvoice {
@@ -37,14 +39,22 @@ ReqDownloadInvoice
       throw new Error('更新用キーが設定されていません。管理者に連絡してください。');
     }
 
+    // 請求書情報の取得
     const recInvoice = await getInvoiceById(invoiceId);
-    const result = await parseInvoiceDat(recInvoice);
+    const resInvoice = await parseInvoiceDat(recInvoice);
+    
+    // 顧客情報の取得
+    const recCustGroup = await getCustGroupById(resInvoice.custGroupId);
+    const resCustGroup = await parseCustGroupDat(recCustGroup);
+
+    // 会社情報の取得
+
 
     if (update) {
       // TODO 請求書発行日時の更新処理
     }
 
-    const pdfDat = await generateInvoicePdf(result); // PDFの作成
+    const pdfDat = await generateInvoicePdf(resInvoice, resCustGroup); // PDFの作成
 
 
     res.status(200).json({

--- a/packages/types/src/common/server.ts
+++ b/packages/types/src/common/server.ts
@@ -115,7 +115,7 @@ export interface ParsedCompanyDetailsDatReport {
   companyAddress: string,
   kenchikugyoKyoka: string,
   takkengyoNumber: string,
-  OfficeRegistration: string,
+  officeRegistration: string,
 }
 
 

--- a/packages/types/src/common/server.ts
+++ b/packages/types/src/common/server.ts
@@ -109,6 +109,15 @@ export interface ParsedCustGroupReport {
   }>;
 }
 
+export interface ParsedCompanyDetailsDatReport {
+  companyName: string,
+  companyPostCode: string,
+  companyAddress: string,
+  kenchikugyoKyoka: string,
+  takkengyoNumber: string,
+  OfficeRegistration: string,
+}
+
 
 export interface ReqSendContract {
   userCode: string,

--- a/packages/types/src/common/server.ts
+++ b/packages/types/src/common/server.ts
@@ -102,6 +102,14 @@ export interface ParsedInvoiceReport {
   }>;
 }
 
+export interface ParsedCustGroupReport {
+  custGroupId: string,
+  members: Array<{
+    customerName: string,
+  }>;
+}
+
+
 export interface ReqSendContract {
   userCode: string,
   projEstimateId: string,
@@ -155,5 +163,5 @@ export interface DownloadInvoiceResponse {
 }
 
 export type ApiNodes =
-| 'docusign'
-| 'kokoas';
+  | 'docusign'
+  | 'kokoas';

--- a/packages/types/src/dtsgen/db.companyDetails.d.ts
+++ b/packages/types/src/dtsgen/db.companyDetails.d.ts
@@ -7,6 +7,7 @@ declare namespace DBCompanydetails {
     companyAddress: kintone.fieldTypes.SingleLineText;
     kenchikushiJimushoRegister: kintone.fieldTypes.SingleLineText;
     takkengyoNumber: kintone.fieldTypes.SingleLineText;
+    postCode: kintone.fieldTypes.SingleLineText;
     invoiceSystemNumber: kintone.fieldTypes.SingleLineText;
     representative: kintone.fieldTypes.SingleLineText;
   }


### PR DESCRIPTION
**依存関係**
---

 - #157 より派生

**変更**
---

 - ~~請求書発行ボタンを押した際に表示されるPDFに、データベースに保存されている内容を転記します~~
 - PDFに引用するデータの準備処理を実装します。追加するDB情報は以下2つです
 - 顧客情報
 - 会社情報

**変更理由**
---

 - 処理の実装漏れのため、PR内容を修正して対応します
 - 要件による
 - https://trello.com/c/iA8l57hS