### PR TITLE
見積：実行予算の出力の修正

### DIFF
--- a/packages/kokoas-server/src/handleRequest/reqDownloadEstimateAsAndpad/conversions/estimateToAndpadJson.ts
+++ b/packages/kokoas-server/src/handleRequest/reqDownloadEstimateAsAndpad/conversions/estimateToAndpadJson.ts
@@ -16,6 +16,7 @@ export const estimateToAndpadJson = ({
     rows: rows.value.map(({ value: {
       部材名,
       大項目,
+      中項目,
       部材備考,
       単価,
       原価,
@@ -26,6 +27,7 @@ export const estimateToAndpadJson = ({
       return {
         ...initialRow,
         フォルダ１: 大項目.value,
+        フォルダ２: 中項目.value,
         明細名: 部材名.value,
         工事種類: 大項目.value,
         備考: 部材備考.value,
@@ -33,7 +35,7 @@ export const estimateToAndpadJson = ({
         見積原価単価: +原価.value,
         数量: +数量.value,
         単位: 単位.value,
-        実行予算単価: 0,
+        実行予算単価: +原価.value,
         メモ: 備考.value,
       };
     }), 

--- a/packages/kokoas-server/src/handleRequest/reqDownloadEstimateAsAndpad/conversions/initialRow.ts
+++ b/packages/kokoas-server/src/handleRequest/reqDownloadEstimateAsAndpad/conversions/initialRow.ts
@@ -1,4 +1,7 @@
 
+// 当面、必須になっているので固定
+const transactionPartnerId = '207075';
+
 export const initialRow = {
   フォルダ１: '',
   フォルダ２: '',
@@ -8,7 +11,7 @@ export const initialRow = {
   工事場所: '',
   工事種類: '',
   備考: '',
-  取引先ID: '',
+  取引先ID: transactionPartnerId,
   取引先名: '',
   定価: 0,
   見積金額単価: 0,

--- a/packages/kokoas-server/src/handleRequest/reqDownloadEstimateAsAndpad/convertEstimateToAndpadById.test.ts
+++ b/packages/kokoas-server/src/handleRequest/reqDownloadEstimateAsAndpad/convertEstimateToAndpadById.test.ts
@@ -1,5 +1,6 @@
+import path from 'path';
 import { convertEstimateToAndpadById } from './convertEstimateToAndpadById';
-
+import fs from 'fs/promises';
 
 describe('convertEstimateByIdToAndpad', () => {
   const testEstimateId = 'fc8f798a-a73f-4447-b4bb-99d51da2f198';
@@ -15,6 +16,10 @@ describe('convertEstimateByIdToAndpad', () => {
     // excel to base64
     const base64 = Buffer.from(await result.xlsx.writeBuffer())
       .toString('base64');
+
+    const savePath = path.join(__dirname, '../__TEST__', '実行予算.xlsx');
+
+    await fs.writeFile(savePath, Buffer.from(base64, 'base64'));
 
     console.log('base64: ', base64);
     expect(base64).toBeTruthy();


### PR DESCRIPTION
## 変更

- Andpadへ実行予算の添付をテストして、内容の修正を行いました。

## 理由

- https://trello.com/c/2T2aN58N