### PR TITLE
T305-2 - バリデーション

### DIFF
--- a/packages/kokoas-client/src/components/ui/textfield/NumberCommaField.tsx
+++ b/packages/kokoas-client/src/components/ui/textfield/NumberCommaField.tsx
@@ -5,7 +5,7 @@ import { forwardRef } from 'react';
 
 
 
-export type NumberCommaFieldProps = Omit<TextFieldProps, 'onChange' | 'onBlur' | 'value' | 'type'> & UseNumberCommaFieldProps;
+export type NumberCommaFieldProps = Omit<TextFieldProps, 'onChange' | 'onBlur' | 'type'> & UseNumberCommaFieldProps;
 
 
 /**

--- a/packages/kokoas-client/src/lib/zodErrorMapJA.ts
+++ b/packages/kokoas-client/src/lib/zodErrorMapJA.ts
@@ -57,7 +57,7 @@ export const zodErrorMapJA =
           };
         case z.ZodIssueCode.invalid_date:
           return {
-            message: 'Invalid date',
+            message: '日付が無効です。',
           };
         case z.ZodIssueCode.invalid_string:
           if (issue.validation !== 'regex') {

--- a/packages/kokoas-client/src/lib/zodErrorMapJA.ts
+++ b/packages/kokoas-client/src/lib/zodErrorMapJA.ts
@@ -4,6 +4,7 @@ import { z } from 'zod';
 const types : Record<string, string> = {
   number: '数値',
   string: '文字列',
+  nan: '数字ではないもの',
 };
 
 export const zodErrorMapJA =

--- a/packages/kokoas-client/src/pages/projContractV2/FormContract.tsx
+++ b/packages/kokoas-client/src/pages/projContractV2/FormContract.tsx
@@ -27,12 +27,14 @@ export const FormContract = () => {
   const { 
     control, 
     reset,
+    watch,
   } = formReturn;
 
   useEffect(() => {
     reset({ ...newFormVal });
   }, [reset, newFormVal]);
 
+  console.log(watch());
 
   return (
     <FormProvider {...formReturn}>

--- a/packages/kokoas-client/src/pages/projContractV2/FormContract.tsx
+++ b/packages/kokoas-client/src/pages/projContractV2/FormContract.tsx
@@ -20,6 +20,7 @@ export const FormContract = () => {
   const formReturn = useForm<TypeOfForm>({
     defaultValues: newFormVal,
     resolver: zodResolver(schema),
+    
   });
 
   const { contractId, projId } = newFormVal;
@@ -27,14 +28,12 @@ export const FormContract = () => {
   const { 
     control, 
     reset,
-    watch,
   } = formReturn;
 
   useEffect(() => {
     reset({ ...newFormVal });
   }, [reset, newFormVal]);
 
-  console.log(watch());
 
   return (
     <FormProvider {...formReturn}>

--- a/packages/kokoas-client/src/pages/projContractV2/fields/ControlledCurrencyInput.tsx
+++ b/packages/kokoas-client/src/pages/projContractV2/fields/ControlledCurrencyInput.tsx
@@ -33,24 +33,24 @@ export const ControlledCurrencyInput = ({
         },
         fieldState: {
           error,
-          isDirty,
         },
         
       }) => {
 
         return (
           <NumberCommaField
-            value={value as number}
             label={label}
             inputRef={ref}
+            value={value as string}
             defaultValue={typeof value === 'number' ? (value as number).toLocaleString() : value}
             name={name}
             variant={variant}
             onChange={(v) => {
-              onChange(v);
+              const parsedValue = +v;
+              onChange(isNaN(parsedValue) ? v : parsedValue);
             }}
             onBlur={onBlur}
-            error={!!error && isDirty}
+            error={!!error}
             disabled={disabled}
             placeholder={placeholder}
             helperText={error?.message}

--- a/packages/kokoas-client/src/pages/projContractV2/fields/ControlledDatePicker.tsx
+++ b/packages/kokoas-client/src/pages/projContractV2/fields/ControlledDatePicker.tsx
@@ -10,6 +10,7 @@ export const ControlledDatePicker = ({
   width,
   variant = 'standard',
   emphasized = false,
+  inputRef,
 }: {
   name: keyof TypeOfForm
   label?: string,
@@ -17,6 +18,7 @@ export const ControlledDatePicker = ({
   width?: string,
   variant?: TextFieldProps['variant'],
   emphasized?: boolean,
+  inputRef?: React.Ref<HTMLInputElement>,
 }) => {
 
 
@@ -44,8 +46,8 @@ export const ControlledDatePicker = ({
         return (
           <JADatePicker
             onChange={onChange}
-            ref={ref}
             value={value || null}
+            ref={ref}
             disablePast
             views={['year', 'month', 'day']}
             disabled={disabled}

--- a/packages/kokoas-client/src/pages/projContractV2/fields/ControlledDatePicker.tsx
+++ b/packages/kokoas-client/src/pages/projContractV2/fields/ControlledDatePicker.tsx
@@ -10,7 +10,7 @@ export const ControlledDatePicker = ({
   width,
   variant = 'standard',
   emphasized = false,
-  inputRef,
+
 }: {
   name: keyof TypeOfForm
   label?: string,
@@ -18,7 +18,6 @@ export const ControlledDatePicker = ({
   width?: string,
   variant?: TextFieldProps['variant'],
   emphasized?: boolean,
-  inputRef?: React.Ref<HTMLInputElement>,
 }) => {
 
 

--- a/packages/kokoas-client/src/pages/projContractV2/form.ts
+++ b/packages/kokoas-client/src/pages/projContractV2/form.ts
@@ -4,7 +4,7 @@ export const initialForm : TypeOfForm = {
   projId: '',
   projName: '',
 
-  contractId: undefined,
+  contractId: null,
 
   totalContractAmt: 0,
   projectCost: 0,

--- a/packages/kokoas-client/src/pages/projContractV2/form.ts
+++ b/packages/kokoas-client/src/pages/projContractV2/form.ts
@@ -10,26 +10,26 @@ export const initialForm : TypeOfForm = {
   projectCost: 0,
   
   hasContractAmt: false,
-  contractAmt: null,
+  contractAmt: 0,
   contractAmtDate: null,
   
   hasStartAmt: false,
-  startAmt: null,
+  startAmt: 0,
   startAmtDate: null,
 
   hasInterimAmt: false,
-  interimAmt: null,
+  interimAmt: 0,
   interimAmtDate: null,
 
   hasFinalAmt: false,
-  finalAmt: null,
+  finalAmt: 0,
   finalAmtDate: null,
   
   hasRefund: false,
-  refundAmt: null,
+  refundAmt: 0,
 
   hasSubsidy: false,
-  subsidyAmt: null,
+  subsidyAmt: 0,
   subsidyType: '顧客に返金',
   
   payMethod: '振込',

--- a/packages/kokoas-client/src/pages/projContractV2/hooks/useSubmitHandler.ts
+++ b/packages/kokoas-client/src/pages/projContractV2/hooks/useSubmitHandler.ts
@@ -14,7 +14,7 @@ export const useSubmitHandler = () => {
       // 成功の時
       setSnackState({
         open: true,
-        message: '保存しました',
+        message: '成功しました。（保存処理は開発中です）',
         severity: 'success',
       });
       

--- a/packages/kokoas-client/src/pages/projContractV2/parts/ConstructionDates.tsx
+++ b/packages/kokoas-client/src/pages/projContractV2/parts/ConstructionDates.tsx
@@ -1,7 +1,7 @@
 import { FormControl, FormLabel, InputAdornment, Stack, TextField } from '@mui/material';
 import { ControlledDatePicker } from '../fields/ControlledDatePicker';
 import { KeyOfForm } from '../form';
-import { useFormContext } from 'react-hook-form';
+import { useFormContext, useFormState } from 'react-hook-form';
 import { TypeOfForm } from '../schema';
 
 export const ConstructionDates = ({
@@ -15,7 +15,15 @@ export const ConstructionDates = ({
 }) => {
   const {
     register,
+    control,
   } = useFormContext<TypeOfForm>();
+
+  const { errors: {
+    [daysFldName]: daysFldNameErr,
+  } } = useFormState({
+    name: daysFldName,
+    control,
+  });
 
 
   return (
@@ -26,9 +34,10 @@ export const ConstructionDates = ({
       <Stack direction={'row'} spacing={2}> 
         <ControlledDatePicker name={dateFldName} width='50%' />
         <TextField 
-          {...register(daysFldName)}
+          {...register(daysFldName, { valueAsNumber: true })}
           sx={{ width: '50%' }} 
           fullWidth
+          type='number'
           variant='standard'
           InputProps={{
             startAdornment: (
@@ -45,6 +54,8 @@ export const ConstructionDates = ({
               textAlign: 'right',
             },
           }}
+          error={!!daysFldNameErr}
+          helperText={daysFldNameErr?.message}
         />
       </Stack>
     </FormControl>

--- a/packages/kokoas-client/src/pages/projContractV2/parts/PaymentFieldGroup.tsx
+++ b/packages/kokoas-client/src/pages/projContractV2/parts/PaymentFieldGroup.tsx
@@ -30,6 +30,7 @@ export const PaymentFieldGroup = (
     control, 
     register, 
     setValue, 
+    resetField,
     getFieldState,
     getValues,
   } = useFormContext<TypeOfForm>();
@@ -50,12 +51,12 @@ export const PaymentFieldGroup = (
                 if (!e.target.checked) { // チェックを外したら、
                  
                   // 金額をクリアする
-                  setValue(amtFldName, null, { shouldValidate: true });
+                  resetField(amtFldName);
 
                   // エラーがあれば、日付をクリアする
                   const { error: dateFldErr } = getFieldState(dateFldName);
                   if (dateFldErr) {
-                    setValue(dateFldName, null, { shouldValidate: true });
+                    resetField(dateFldName);
                   }
                 } else {
 

--- a/packages/kokoas-client/src/pages/projContractV2/parts/PaymentFieldGroup.tsx
+++ b/packages/kokoas-client/src/pages/projContractV2/parts/PaymentFieldGroup.tsx
@@ -26,7 +26,7 @@ export const PaymentFieldGroup = (
     dateFldName, 
   } = fieldNames;
 
-  const { register, control } = useFormContext<TypeOfForm>();
+  const { register, control, setValue, getFieldState } = useFormContext<TypeOfForm>();
   const isChecked = useWatch({
     control,
     name: chkFldName,
@@ -39,7 +39,21 @@ export const PaymentFieldGroup = (
         name={chkFldName}
         control={(
           <Checkbox
-            {...register(chkFldName)}
+            {...register(chkFldName, {
+              onChange: (e) => {
+                if (!e.target.checked) {
+                  // チェックを外したら、エラーがあればクリアする
+                  const { error: amtFldErr } = getFieldState(amtFldName);
+                  const { error: dateFldErr } = getFieldState(dateFldName);
+                  if (amtFldErr) {
+                    setValue(amtFldName, null, { shouldValidate: true });
+                  }
+                  if (dateFldErr) {
+                    setValue(dateFldName, null, { shouldValidate: true });
+                  }
+                }
+              },
+            })}
             sx={{
               transform: 'scale(1.5)',
             }}

--- a/packages/kokoas-client/src/pages/projContractV2/parts/PaymentFieldGroup.tsx
+++ b/packages/kokoas-client/src/pages/projContractV2/parts/PaymentFieldGroup.tsx
@@ -26,7 +26,13 @@ export const PaymentFieldGroup = (
     dateFldName, 
   } = fieldNames;
 
-  const { register, control, setValue, getFieldState } = useFormContext<TypeOfForm>();
+  const { 
+    control, 
+    register, 
+    setValue, 
+    getFieldState,
+    getValues,
+  } = useFormContext<TypeOfForm>();
   const isChecked = useWatch({
     control,
     name: chkFldName,
@@ -41,16 +47,37 @@ export const PaymentFieldGroup = (
           <Checkbox
             {...register(chkFldName, {
               onChange: (e) => {
-                if (!e.target.checked) {
-                  // チェックを外したら、エラーがあればクリアする
-                  const { error: amtFldErr } = getFieldState(amtFldName);
+                if (!e.target.checked) { // チェックを外したら、
+                 
+                  // 金額をクリアする
+                  setValue(amtFldName, null, { shouldValidate: true });
+
+                  // エラーがあれば、日付をクリアする
                   const { error: dateFldErr } = getFieldState(dateFldName);
-                  if (amtFldErr) {
-                    setValue(amtFldName, null, { shouldValidate: true });
-                  }
                   if (dateFldErr) {
                     setValue(dateFldName, null, { shouldValidate: true });
                   }
+                } else {
+
+                  // チェックを入れたら、残額を計算して、金額にセットする
+                  const [
+                    startAmt,
+                    interimAmt,
+                    contractAmt,
+                    finalAmt,
+                    totalContractAmt,
+                  ] = getValues([
+                    'startAmt', 
+                    'interimAmt', 
+                    'contractAmt', 
+                    'finalAmt', 
+                    'totalContractAmt',
+                  ]);
+
+                  const amt = (startAmt ?? 0) + (interimAmt ?? 0) + (contractAmt ?? 0) + (finalAmt ?? 0);
+                  const remainingAmt = totalContractAmt - amt;
+
+                  setValue(amtFldName, remainingAmt, { shouldValidate: true });
                 }
               },
             })}

--- a/packages/kokoas-client/src/pages/projContractV2/parts/PaymentMethod.tsx
+++ b/packages/kokoas-client/src/pages/projContractV2/parts/PaymentMethod.tsx
@@ -1,6 +1,6 @@
 import { FormControl, FormControlLabel, FormHelperText, FormLabel, Radio, RadioGroup, TextField } from '@mui/material';
 import { TypeOfForm, payMethods } from '../schema';
-import { Controller, useFormContext } from 'react-hook-form';
+import { Controller, useFormContext, useFormState  } from 'react-hook-form';
 
 
 export const PaymentMethod = ({
@@ -10,7 +10,15 @@ export const PaymentMethod = ({
 }) => {
 
   const { control, register } = useFormContext<TypeOfForm>();
-  
+
+  const {
+    errors: {
+      payDestination: payDestinationErr,
+    },
+  } = useFormState({
+    control,
+    name: 'payDestination',
+  });  
 
   return (
 
@@ -69,6 +77,8 @@ export const PaymentMethod = ({
                   mt: 2,
                 }}
                 placeholder='豊田信用金庫　朝日支店'
+                error={!!payDestinationErr}
+                helperText={payDestinationErr?.message}
               />
               
               

--- a/packages/kokoas-client/src/pages/projContractV2/parts/RefundAmount.tsx
+++ b/packages/kokoas-client/src/pages/projContractV2/parts/RefundAmount.tsx
@@ -4,7 +4,7 @@ import { useFormContext, useWatch } from 'react-hook-form';
 import { ControlledCurrencyInput } from '../fields/ControlledCurrencyInput';
 
 export const RefundAmount = () => {
-  const { register, control } = useFormContext<TypeOfForm>();
+  const { register, control, setValue, getFieldState } = useFormContext<TypeOfForm>();
 
   const isChecked = useWatch({
     control,
@@ -17,7 +17,17 @@ export const RefundAmount = () => {
         label={'返金額'}
         control={(
           <Checkbox
-            {...register('hasRefund')}
+            {...register('hasRefund', {
+              onChange: (e) => {
+                if (!e.target.checked) {
+                  // チェックを外したら、エラーがあればクリアする
+                  const { error } = getFieldState('refundAmt');
+                  if (error) {
+                    setValue('refundAmt', null, { shouldValidate: true });
+                  }
+                }
+              },
+            })}
             sx={{
               transform: 'scale(1.5)',
             }}

--- a/packages/kokoas-client/src/pages/projContractV2/parts/RefundAmount.tsx
+++ b/packages/kokoas-client/src/pages/projContractV2/parts/RefundAmount.tsx
@@ -4,7 +4,12 @@ import { useFormContext, useWatch } from 'react-hook-form';
 import { ControlledCurrencyInput } from '../fields/ControlledCurrencyInput';
 
 export const RefundAmount = () => {
-  const { register, control, setValue, getFieldState } = useFormContext<TypeOfForm>();
+  const { 
+    control, 
+    register,  
+    resetField,
+    getFieldState, 
+  } = useFormContext<TypeOfForm>();
 
   const isChecked = useWatch({
     control,
@@ -23,7 +28,7 @@ export const RefundAmount = () => {
                   // チェックを外したら、エラーがあればクリアする
                   const { error } = getFieldState('refundAmt');
                   if (error) {
-                    setValue('refundAmt', null, { shouldValidate: true });
+                    resetField('refundAmt');
                   }
                 }
               },

--- a/packages/kokoas-client/src/pages/projContractV2/parts/SubsidyAmount.tsx
+++ b/packages/kokoas-client/src/pages/projContractV2/parts/SubsidyAmount.tsx
@@ -22,7 +22,7 @@ export const SubsidyAmount = () => {
                   // チェックを外したら、エラーがあればクリアする
                   const { error } = getFieldState('subsidyAmt');
                   if (error) {
-                    setValue('subsidyAmt', null, { shouldValidate: true });
+                    setValue('subsidyAmt', 0, { shouldValidate: true });
                   }
                 }
               },

--- a/packages/kokoas-client/src/pages/projContractV2/parts/SubsidyAmount.tsx
+++ b/packages/kokoas-client/src/pages/projContractV2/parts/SubsidyAmount.tsx
@@ -4,7 +4,7 @@ import { TypeOfForm, subsidyTypes } from '../schema';
 import { ControlledCurrencyInput } from '../fields/ControlledCurrencyInput';
 
 export const SubsidyAmount = () => {
-  const { register, control } = useFormContext<TypeOfForm>();
+  const { register, control, setValue, getFieldState } = useFormContext<TypeOfForm>();
 
   const isChecked = useWatch({
     control,
@@ -16,7 +16,17 @@ export const SubsidyAmount = () => {
         label={'補助金'}
         control={(
           <Checkbox
-            {...register('hasSubsidy')}
+            {...register('hasSubsidy', {
+              onChange: (e) => {
+                if (!e.target.checked) {
+                  // チェックを外したら、エラーがあればクリアする
+                  const { error } = getFieldState('subsidyAmt');
+                  if (error) {
+                    setValue('subsidyAmt', null, { shouldValidate: true });
+                  }
+                }
+              },
+            })}
             sx={{
               transform: 'scale(1.5)',
             }}

--- a/packages/kokoas-client/src/pages/projContractV2/schema.tsx
+++ b/packages/kokoas-client/src/pages/projContractV2/schema.tsx
@@ -18,7 +18,7 @@ const schema = z.object({
 
   /** 契約のuuid */
   contractId: z.string().uuid()
-    .optional(),
+    .nullable(),
 
   /** 契約合計金額 */
   totalContractAmt: z.number(),
@@ -101,7 +101,53 @@ const schema = z.object({
   }, {
     path: ['contractAmt'],
     message: '契約金を入力してください。',
+  })
+  .refine(({ hasStartAmt, startAmt }) => {
+    if (hasStartAmt && !startAmt) {
+      return false;
+    }
+    return true;
+  }, {
+    path: ['startAmt'],
+    message: '着手金を入力してください。',
+  })
+  .refine(({ hasInterimAmt, interimAmt }) => {
+    if (hasInterimAmt && !interimAmt) {
+      return false;
+    }
+    return true;
+  }, {
+    path: ['interimAmt'],
+    message: '中間金を入力してください。',
+  })
+  .refine(({ hasFinalAmt, finalAmt }) => {
+    if (hasFinalAmt && !finalAmt) {
+      return false;
+    }
+    return true;
+  }, {
+    path: ['finalAmt'],
+    message: '最終金を入力してください。',
+  })
+  .refine(({ hasRefund, refundAmt }) => {
+    if (hasRefund && !refundAmt) {
+      return false;
+    }
+    return true;
+  }, {
+    path: ['refundAmt'],
+    message: '返金額を入力してください。',
+  })
+  .refine(({ hasSubsidy, subsidyAmt }) => {
+    if (hasSubsidy && !subsidyAmt) {
+      return false;
+    }
+    return true;
+  }, {
+    path: ['subsidyAmt'],
+    message: '補助金を入力してください。',
   });
+  
 
 
 export type TypeOfForm = z.infer<typeof schema>;

--- a/packages/kokoas-client/src/pages/projContractV2/schema.tsx
+++ b/packages/kokoas-client/src/pages/projContractV2/schema.tsx
@@ -146,7 +146,23 @@ const schema = z.object({
   }, {
     path: ['subsidyAmt'],
     message: '補助金を入力してください。',
+  })
+  .refine(({
+    totalContractAmt,
+    contractAmt,
+    startAmt,
+    interimAmt,
+    finalAmt,
+  }) => {
+    if (totalContractAmt !== (contractAmt ?? 0) + (startAmt ?? 0) + (interimAmt ?? 0) + (finalAmt ?? 0)) {
+      return false;
+    }
+    return true;
+  }, {
+    path: ['totalContractAmt'],
+    message: '契約合計金額と契約金、着手金、中間金、最終金の合計が一致しません。',  
   });
+  
   
 
 

--- a/packages/kokoas-client/src/pages/projContractV2/schema.tsx
+++ b/packages/kokoas-client/src/pages/projContractV2/schema.tsx
@@ -28,35 +28,35 @@ const schema = z.object({
 
   /** 契約金 */
   hasContractAmt: z.boolean(),
-  contractAmt: z.number().nullable(),
+  contractAmt: z.number(),
   contractAmtDate: z.date().nullable(),
 
   /** 着手金 */
   hasStartAmt: z.boolean(),
-  startAmt: z.number().nullable(),
+  startAmt: z.number(),
   startAmtDate: z.date().nullable(),
 
   /** 中間金 */
   hasInterimAmt: z.boolean(),
-  interimAmt: z.number().nullable(),
+  interimAmt: z.number(),
   interimAmtDate: z.date().nullable(),
 
   /** 最終金 */
   hasFinalAmt: z.boolean(),
-  finalAmt: z.number().nullable(),
+  finalAmt: z.number(),
   finalAmtDate: z.date().nullable(),
   
   /** 返金有無 */
   hasRefund: z.boolean(),
   
   /** 返金額 */
-  refundAmt: z.number().nullable(),
+  refundAmt: z.number(),
 
   /** 補助金有無 */
   hasSubsidy: z.boolean(),
 
   /** 補助金 */
-  subsidyAmt: z.number().nullable(),
+  subsidyAmt: z.number(),
   
   /** 補助種類 */
   subsidyType: z.enum(subsidyTypes),

--- a/packages/kokoas-client/src/pages/projContractV2/schema.tsx
+++ b/packages/kokoas-client/src/pages/projContractV2/schema.tsx
@@ -83,15 +83,25 @@ const schema = z.object({
   /** 契約日 */
   contractDate: z.date(),
   
-}).refine((data) => {
-  // Check if payMethod is 振込 and payDestination is not provided
-  if (data.payMethod === '振込' && !data.payDestination) {
-    return false;
-  }
-  return true;
-}, {
-  message: '振込先を入力してください。',
-});
+})
+  .refine(({ payMethod, payDestination }) => {
+    if (payMethod === '振込' && !payDestination) {
+      return false;
+    }
+    return true;
+  }, {
+    path: ['payDestination'],
+    message: '振込先を入力してください。',
+  })
+  .refine(({ hasContractAmt, contractAmt }) => {
+    if (hasContractAmt && !contractAmt) {
+      return false;
+    }
+    return true;
+  }, {
+    path: ['contractAmt'],
+    message: '契約金を入力してください。',
+  });
 
 
 export type TypeOfForm = z.infer<typeof schema>;

--- a/packages/kokoas-client/src/pages/projContractV2/schema.tsx
+++ b/packages/kokoas-client/src/pages/projContractV2/schema.tsx
@@ -108,7 +108,7 @@ const schema = z.object({
     }
     return true;
   }, {
-    path: ['startAmt'],
+    path: ['initialAmt'],
     message: '着手金を入力してください。',
   })
   .refine(({ hasInterimAmt, interimAmt }) => {

--- a/packages/kokoas-client/src/pages/projContractV2/sections/PaymentSchedule.tsx
+++ b/packages/kokoas-client/src/pages/projContractV2/sections/PaymentSchedule.tsx
@@ -17,7 +17,7 @@ export const PaymentSchedule = () => {
         fieldNames={{
           chkFldName: 'hasContractAmt',
           amtFldName: 'contractAmt',
-          dateFldName: 'contractDate',
+          dateFldName: 'contractAmtDate',
         }}
         label='契約金'
       />


### PR DESCRIPTION
## 派生元

- #198 

## 変更

- バリデーションを追加しました。

## 理由

- https://trello.com/c/ugm2xd3a

## 課題

- zod には依存フィールドの場合、yupのwhen()と同様な機能がなく、refine を 使います。refine は yupのtestという機能のほうが近いです [[1]](https://github.com/colinhacks/zod/issues/890) 。ただ、複数のrefine フィールド時、その一つにエラーがある場合、その他のrefineは実行されません [[2]](https://github.com/colinhacks/zod/issues/479)。