### PR TITLE
hotfix-契約ページにandpadのシステムIDを追加しました

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32906,7 +32906,7 @@
       "devDependencies": {}
     },
     "packages/kokoas-client": {
-      "version": "20230508.2",
+      "version": "20230508.3",
       "dependencies": {
         "api-kintone": "*",
         "auto-kintone": "*",

--- a/packages/kokoas-client/package.json
+++ b/packages/kokoas-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kokoas-client",
-  "version": "20230508.2",
+  "version": "20230508.3",
   "devDependencies": {},
   "scripts": {
     "dev": "npm run build -- --watch --mode development",

--- a/packages/kokoas-client/src/pages/projContractV2/parts/Info.tsx
+++ b/packages/kokoas-client/src/pages/projContractV2/parts/Info.tsx
@@ -1,11 +1,12 @@
 import { Stack, Typography } from '@mui/material';
+import { ReactNode } from 'react';
 
 export const Info = ({
   label,
   value,
 }: {
   label: string,
-  value: string,
+  value: ReactNode,
 }) => (
   <Stack 
     direction={'row'}

--- a/packages/kokoas-client/src/pages/projContractV2/parts/StaticContents.tsx
+++ b/packages/kokoas-client/src/pages/projContractV2/parts/StaticContents.tsx
@@ -7,6 +7,7 @@ import { pages } from '../../Router';
 import { generateParams } from 'kokoas-client/src/helpers/url';
 import { useFormContext } from 'react-hook-form';
 import { TypeOfForm } from '../schema';
+import { ReactNode } from 'react';
 
 export const StaticContents = ({
   data,
@@ -16,7 +17,7 @@ export const StaticContents = ({
 }: {
   data: Array<{
     label: string,
-    value: string,
+    value: ReactNode,
   }>
   buttonLabel: string,
   isLoading?: boolean,

--- a/packages/kokoas-client/src/pages/projContractV2/sections/ProjectSummary.tsx
+++ b/packages/kokoas-client/src/pages/projContractV2/sections/ProjectSummary.tsx
@@ -2,11 +2,12 @@
 import { useWatch } from 'react-hook-form';
 import { StaticContents } from '../parts/StaticContents';
 import { TypeOfForm } from '../schema';
-import { useProjById } from 'kokoas-client/src/hooksQuery';
+import { useAndpadOrderByProjId, useProjById } from 'kokoas-client/src/hooksQuery';
 import { ComponentProps, useMemo } from 'react';
 import { addressBuilder } from 'libs';
 import { TAgents } from 'types';
 import { pages } from '../../Router';
+import { Link } from '@mui/material';
 
 export const ProjectSummary = () => {
   const projId = useWatch<TypeOfForm>({
@@ -14,6 +15,11 @@ export const ProjectSummary = () => {
   });
 
   const { data, isLoading } = useProjById(projId as string);
+  const { data: andPadData } = useAndpadOrderByProjId(projId as string);
+
+  const {
+    システムID: systemId,
+  } = andPadData || {};
 
   const parsedData : ComponentProps<typeof StaticContents>['data'] = useMemo(() => {
     if (!data) return [];
@@ -41,10 +47,19 @@ export const ProjectSummary = () => {
       { label: '工事名', value: projName.value },
       { label: '工事担当者', value: cocoConstNames },
       { label: '工事住所', value: address },
+      { label: 'AndpadシステムID', value: systemId 
+        ? ( 
+          <Link href={`https://andpad.jp/my/orders/${systemId}`}>
+            {systemId}
+          </Link> 
+        )
+        : '未登録', 
+      },
     ];
 
   }, [
     data,
+    systemId,
   ]);
     
 


### PR DESCRIPTION
## 変更

- ![image](https://user-images.githubusercontent.com/2501255/236728967-4f7f9729-7af4-4f06-80ef-e67846d5f729.png)


## 理由

- 高橋さんに相談したところ、契約書類に搭載しない代わりに、契約画面に載せます。