### PR TITLE
hotfix-契約が進行中の場合、無効にする

### DIFF
--- a/packages/kokoas-client/src/pages/projContractV2/FormInput.tsx
+++ b/packages/kokoas-client/src/pages/projContractV2/FormInput.tsx
@@ -3,8 +3,17 @@ import { PageSubTitle } from 'kokoas-client/src/components';
 import { TotalAmount } from './sections/TotalAmount';
 import { PaymentSchedule } from './sections/PaymentSchedule';
 import { ConstructionPeriods } from './sections/ConstructionPeriods';
+import { useWatch } from 'react-hook-form';
+import { TypeOfForm } from './schema';
 
 export const FormInput = () => {
+
+  const envelopeStatus = useWatch<TypeOfForm>({
+    name: 'envelopeStatus',
+  });
+
+  const hasContract = !!envelopeStatus;
+
   return (
     <Grid 
       container 
@@ -13,17 +22,17 @@ export const FormInput = () => {
     >
       <PageSubTitle label={'合計金額'} />
       <Grid item xs={12}>
-        <TotalAmount />
+        <TotalAmount disabled={hasContract} />
       </Grid>
 
       <PageSubTitle label={'支払い予定'} />
       <Grid item xs={12}>
-        <PaymentSchedule />
+        <PaymentSchedule disabled={hasContract} />
       </Grid>
 
       <PageSubTitle label={'工期'} />
       <Grid item xs={12}>
-        <ConstructionPeriods />
+        <ConstructionPeriods disabled={hasContract} />
       </Grid>
 
       <Grid item xs={12}>

--- a/packages/kokoas-client/src/pages/projContractV2/parts/ConstructionDates.tsx
+++ b/packages/kokoas-client/src/pages/projContractV2/parts/ConstructionDates.tsx
@@ -8,10 +8,12 @@ export const ConstructionDates = ({
   label,
   dateFldName,
   daysFldName,
+  disabled,
 }: {
   label: string
   dateFldName: KeyOfForm
   daysFldName: KeyOfForm
+  disabled?: boolean,
 }) => {
   const {
     register,
@@ -32,7 +34,7 @@ export const ConstructionDates = ({
         {label}
       </FormLabel>
       <Stack direction={'row'} spacing={2}> 
-        <ControlledDatePicker name={dateFldName} width='50%' />
+        <ControlledDatePicker disabled={disabled} name={dateFldName} width='50%' />
         <TextField 
           {...register(daysFldName, { setValueAs(value) {
             return Number(value);
@@ -58,6 +60,7 @@ export const ConstructionDates = ({
           }}
           error={!!daysFldNameErr}
           helperText={daysFldNameErr?.message}
+          disabled={disabled}
         />
       </Stack>
     </FormControl>

--- a/packages/kokoas-client/src/pages/projContractV2/parts/PaymentFieldGroup.tsx
+++ b/packages/kokoas-client/src/pages/projContractV2/parts/PaymentFieldGroup.tsx
@@ -10,6 +10,7 @@ export const PaymentFieldGroup = (
   {
     fieldNames,
     label,
+    disabled = false,
   }: {
     label: string,
     fieldNames: {
@@ -17,6 +18,7 @@ export const PaymentFieldGroup = (
       amtFldName: KeyOfForm,
       dateFldName: KeyOfForm,
     }
+    disabled?: boolean,
   },
 ) => {
 
@@ -45,6 +47,7 @@ export const PaymentFieldGroup = (
       <FormControlLabel
         label={label}
         name={chkFldName}
+        disabled={disabled}
         control={(
           <Checkbox
             checked={isChecked as boolean}
@@ -92,11 +95,11 @@ export const PaymentFieldGroup = (
       <ControlledCurrencyInput 
         name={amtFldName} 
         variant='standard'
-        disabled={!isChecked}
+        disabled={!isChecked || disabled}
       />
       <ControlledDatePicker 
         name={dateFldName}
-        disabled={!isChecked}
+        disabled={!isChecked || disabled}
       />
     </Stack>
   );

--- a/packages/kokoas-client/src/pages/projContractV2/parts/PaymentMethod.tsx
+++ b/packages/kokoas-client/src/pages/projContractV2/parts/PaymentMethod.tsx
@@ -79,6 +79,7 @@ export const PaymentMethod = ({
                 placeholder='豊田信用金庫　朝日支店'
                 error={!!payDestinationErr}
                 helperText={payDestinationErr?.message}
+                disabled={disabled}
               />
               
               

--- a/packages/kokoas-client/src/pages/projContractV2/sections/ConstructionPeriods.tsx
+++ b/packages/kokoas-client/src/pages/projContractV2/sections/ConstructionPeriods.tsx
@@ -2,16 +2,22 @@ import { Stack } from '@mui/material';
 import { ConstructionDates } from '../parts/ConstructionDates';
 import { ControlledDatePicker } from '../fields/ControlledDatePicker';
 
-export const ConstructionPeriods = () => {
+export const ConstructionPeriods = ({
+  disabled,
+}: {
+  disabled: boolean,
+}) => {
 
   return (
     <Stack spacing={4} maxWidth={600}>
       <ConstructionDates
+        disabled={disabled}
         label='着手'
         dateFldName='startDate'
         daysFldName='startDaysAfterContractDate'
       />
       <ConstructionDates 
+        disabled={disabled}
         label='完成'
         dateFldName='finishDate'
         daysFldName='finishDaysAfterContractDate'
@@ -19,6 +25,7 @@ export const ConstructionPeriods = () => {
       <ControlledDatePicker label='引き渡し日' name={'deliveryDate'} variant='outlined' />
 
       <ControlledDatePicker 
+        disabled={disabled}
         label='契約日(必須)' 
         name={'contractDate'} 
         variant='outlined'

--- a/packages/kokoas-client/src/pages/projContractV2/sections/PaymentSchedule.tsx
+++ b/packages/kokoas-client/src/pages/projContractV2/sections/PaymentSchedule.tsx
@@ -5,7 +5,11 @@ import { SubsidyAmount } from '../parts/SubsidyAmount';
 import { blue } from '@mui/material/colors';
 import { PaymentMethod } from '../parts/PaymentMethod';
 
-export const PaymentSchedule = () => {
+export const PaymentSchedule = ({
+  disabled,
+}: {
+  disabled: boolean
+}) => {
   return (
     <Stack 
       spacing={2} 
@@ -14,6 +18,7 @@ export const PaymentSchedule = () => {
       maxWidth={600}
     >
       <PaymentFieldGroup
+        disabled={disabled}
         fieldNames={{
           chkFldName: 'hasContractAmt',
           amtFldName: 'contractAmt',
@@ -22,6 +27,7 @@ export const PaymentSchedule = () => {
         label='契約金'
       />
       <PaymentFieldGroup
+        disabled={disabled}
         fieldNames={{
           chkFldName: 'hasInitialAmt',
           amtFldName: 'initialAmt',
@@ -30,6 +36,7 @@ export const PaymentSchedule = () => {
         label='着手金'
       />
       <PaymentFieldGroup
+        disabled={disabled}
         fieldNames={{
           chkFldName: 'hasInterimAmt',
           amtFldName: 'interimAmt',
@@ -38,6 +45,7 @@ export const PaymentSchedule = () => {
         label='中間金'
       />
       <PaymentFieldGroup
+        disabled={disabled}
         fieldNames={{
           chkFldName: 'hasFinalAmt',
           amtFldName: 'finalAmt',
@@ -63,7 +71,7 @@ export const PaymentSchedule = () => {
  
       </Stack>
       
-      <PaymentMethod />
+      <PaymentMethod disabled={disabled} />
 
     </Stack>
   );

--- a/packages/kokoas-client/src/pages/projContractV2/sections/TotalAmount.tsx
+++ b/packages/kokoas-client/src/pages/projContractV2/sections/TotalAmount.tsx
@@ -5,14 +5,18 @@ import { ControlledCurrencyInput } from '../fields/ControlledCurrencyInput';
  * 合計金額
  * @returns 
  */
-export const TotalAmount = () => {
+export const TotalAmount = ({
+  disabled,
+}: {
+  disabled: boolean
+}) => {
 
   return (
     <Stack maxWidth={450} width={'100%'} spacing={2}
       my={2}
     >
-      <ControlledCurrencyInput name="totalContractAmt" label="契約合計金額" />
-      <ControlledCurrencyInput name="totalProfit" label="粗利額" />
+      <ControlledCurrencyInput disabled={disabled} name="totalContractAmt" label="契約合計金額" />
+      <ControlledCurrencyInput disabled={disabled} name="totalProfit" label="粗利額" />
     </Stack>
   );
 };


### PR DESCRIPTION
## 変更

- 契約が進行中の場合、無効にする機能を再現しました。

## 理由

- 高橋さんに確認したところ以下のフィールドが編集出来るままにする：
  - 引き渡し日
  - 返金
  - 補助金 