### PR TITLE
hotfix-completedまたはvoidedの状態取り下げボタンを無効にする

### DIFF
--- a/packages/kokoas-client/src/pages/projContractV2/parts/preview/menu/void/MenuVoidContract.tsx
+++ b/packages/kokoas-client/src/pages/projContractV2/parts/preview/menu/void/MenuVoidContract.tsx
@@ -8,7 +8,8 @@ import { TEnvelopeStatus } from 'types';
 
 /**
  * 無効化（取り下げ）出来ない状態
- * @see 
+ * @see https://support.docusign.com/s/articles/FAQs-related-to-Voiding-Envelopes-in-DocuSign?language=en_US
+ * @see https://support.docusign.com/s/document-item?language=en_US&bundleId=oeq1643226594604&topicId=vks1578456426150.html&_LANG=enus
  */
 const terminalStates: TEnvelopeStatus[] = ['voided', 'voiding', 'completed'];
 

--- a/packages/kokoas-client/src/pages/projContractV2/parts/preview/menu/void/MenuVoidContract.tsx
+++ b/packages/kokoas-client/src/pages/projContractV2/parts/preview/menu/void/MenuVoidContract.tsx
@@ -1,23 +1,39 @@
-import { ListItemText, MenuItem  } from '@mui/material';
+import { MenuItem, Tooltip  } from '@mui/material';
 
 import { VoidContractDialog } from './VoidContractDialog';
 import { useState } from 'react';
+import { useWatch } from 'react-hook-form';
+import { TypeOfForm } from 'kokoas-client/src/pages/projContractV2/schema';
+import { TEnvelopeStatus } from 'types';
 
-
+/**
+ * 無効化（取り下げ）出来ない状態
+ * @see 
+ */
+const terminalStates: TEnvelopeStatus[] = ['voided', 'voiding', 'completed'];
 
 export const MenuVoidContract = () => {
   const [open, setOpen] = useState(false);
+  const envelopeStatus = useWatch<TypeOfForm>({
+    name: 'envelopeStatus',
+  }) as TEnvelopeStatus;
+
+  const isTerminalState = terminalStates.includes(envelopeStatus);
 
   return (
     <>
-      <MenuItem onClick={() => {
-        setOpen(true);
-      }}
-      >
-        <ListItemText>
-          取り下げ
-        </ListItemText>
-      </MenuItem>
+      <Tooltip title={isTerminalState ? '進捗中の契約は取り下げできません' : ''}>
+        <div>
+          <MenuItem 
+            disabled={isTerminalState}
+            onClick={() => {
+              setOpen(true);
+            }}
+          >
+            取り下げ
+          </MenuItem>
+        </div>
+      </Tooltip>
       <VoidContractDialog 
         handleClose={()=> setOpen(false)} 
         open={open}


### PR DESCRIPTION
## 変更

- エンベロープはcompletedまたはvoidedの状態取り下げボタンを無効にする

## 理由

- docusignの仕様
https://support.docusign.com/s/document-item?language=en_US&bundleId=oeq1643226594604&topicId=vks1578456426150.html&_LANG=enus