### PR TITLE
hotfix-未処理の契約の削除機能を追加しました

### DIFF
--- a/packages/api-kintone/src/contracts/deleteContractById.test.ts
+++ b/packages/api-kintone/src/contracts/deleteContractById.test.ts
@@ -1,0 +1,12 @@
+import { deleteContractById } from './deleteContractById';
+
+describe('deleteContractById', () => {
+  it('should succesfully deleted record', async () => {
+    // 未処理の一覧からuuidが取得出来ます。
+    // https://rdmuhwtt6gx7.cybozu.com/k/231/?view=5536753&_saved=1
+    const result = await deleteContractById('7a3f3eae-e25b-4afb-8f94-e82bc6eba6e6');
+    console.log(result);
+    // expect empty object
+    expect(result).toEqual({});
+  });
+});

--- a/packages/api-kintone/src/contracts/deleteContractById.test.ts
+++ b/packages/api-kintone/src/contracts/deleteContractById.test.ts
@@ -1,10 +1,14 @@
 import { deleteContractById } from './deleteContractById';
 
+
+
+
 describe('deleteContractById', () => {
   it('should succesfully deleted record', async () => {
     // 未処理の一覧からuuidが取得出来ます。
     // https://rdmuhwtt6gx7.cybozu.com/k/231/?view=5536753&_saved=1
-    const result = await deleteContractById('7a3f3eae-e25b-4afb-8f94-e82bc6eba6e6');
+    // TODO: モックデータを作成する。
+    const result = await deleteContractById('fe17a8e6-cd39-456d-986c-9259770c2638');
     console.log(result);
     // expect empty object
     expect(result).toEqual({});

--- a/packages/api-kintone/src/contracts/deleteContractById.ts
+++ b/packages/api-kintone/src/contracts/deleteContractById.ts
@@ -13,11 +13,15 @@ export const deleteContractById = async (id: string) => {
   // 本番と開発環境のレコード番号は同等の可能性が高いので、
   // まず、uuidでレコードを取得して、そこからレコード番号を取得する。
   // API呼び出し回数が増えますが、まれに行う処理のようで、整合性を優先します。
+  const data = await getContractById(id);
+
   const {
     $id,
-  } = await getContractById(id) || {};
+    envelopeStatus,
+  } = data || {};
 
   if (!$id) throw new Error('削除するidが見つかりませんでした。');
+  if (envelopeStatus.value !== '') throw new Error(`削除出来る契約書は未処理のみです。状態：${envelopeStatus.value}`);
 
   // DELETE処理は1件であっても複数件であっても同じ記法です。
   return (await ktRecord()).deleteRecords({

--- a/packages/api-kintone/src/contracts/deleteContractById.ts
+++ b/packages/api-kintone/src/contracts/deleteContractById.ts
@@ -1,0 +1,28 @@
+import { ktRecord } from '../client';
+import { appId } from './config';
+import { getContractById } from './getContractById';
+
+/**
+ * 
+ * @param ids 
+ * @see https://github.com/kintone/js-sdk/blob/master/packages/rest-api-client/docs/record.md#deleterecords
+ */
+export const deleteContractById = async (id: string) => {
+  if (!id) throw new Error('削除するidsは必須です。');
+
+  // 本番と開発環境のレコード番号は同等の可能性が高いので、
+  // まず、uuidでレコードを取得して、そこからレコード番号を取得する。
+  // API呼び出し回数が増えますが、まれに行う処理のようで、整合性を優先します。
+  const {
+    $id,
+  } = await getContractById(id) || {};
+
+  if (!$id) throw new Error('削除するidが見つかりませんでした。');
+
+  // DELETE処理は1件であっても複数件であっても同じ記法です。
+  return (await ktRecord()).deleteRecords({
+    app: appId,
+    ids: [$id.value],
+  });
+  
+};

--- a/packages/api-kintone/src/contracts/index.ts
+++ b/packages/api-kintone/src/contracts/index.ts
@@ -1,3 +1,4 @@
+export * from './deleteContractById';
 export * from './getAllContracts';
 export * from './getContractByEnvId';
 export * from './getContractById';

--- a/packages/kokoas-client/src/hooksQuery/index.ts
+++ b/packages/kokoas-client/src/hooksQuery/index.ts
@@ -21,6 +21,7 @@ export * from './useCustomers';
 export * from './useCustomersByCustGroupId';
 export * from './useCustomersById';
 export * from './useCustomersByIds';
+export * from './useDeleteContractById';
 export * from './useDownloadInvoiceId';
 export * from './useEmployeeByIds';
 export * from './useEmployeeOptions';

--- a/packages/kokoas-client/src/hooksQuery/useDeleteContractById.ts
+++ b/packages/kokoas-client/src/hooksQuery/useDeleteContractById.ts
@@ -1,23 +1,25 @@
-import { useQuery } from '@tanstack/react-query';
-import { getContracts } from 'api-kintone';
-import { AppIds } from 'config';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { deleteContractById } from 'api-kintone';
 import { useCommonOptions } from './useCommonOptions';
+import { AppIds } from 'config';
 
 
 /**
- * 契約を取得する。
- * @deprecated 契約に関するデータは見積もりに依存しなくなるため、この関数は廃止されます。
+ * 契約を削除する。
+ * 
  */
-export const useContracts = (params: Parameters<typeof getContracts>[0]) => {
-  const {
-    onError,
-  } = useCommonOptions();
+export const useDeleteContractById = () => {
+  const commonOptions = useCommonOptions();
+  const qc = useQueryClient();
 
-  return useQuery(
-    [AppIds.projEstimates, 'contracts', params],
-    () => getContracts(params),
+  return useMutation(
+    deleteContractById,
     {
-      onError,
+      ...commonOptions,
+      onSuccess: () => {
+        commonOptions.onSuccess();
+        qc.invalidateQueries({ queryKey: [AppIds.contracts] });
+      },
     },
   );
 };

--- a/packages/kokoas-client/src/hooksQuery/useDeleteContractById.ts
+++ b/packages/kokoas-client/src/hooksQuery/useDeleteContractById.ts
@@ -1,0 +1,23 @@
+import { useQuery } from '@tanstack/react-query';
+import { getContracts } from 'api-kintone';
+import { AppIds } from 'config';
+import { useCommonOptions } from './useCommonOptions';
+
+
+/**
+ * 契約を取得する。
+ * @deprecated 契約に関するデータは見積もりに依存しなくなるため、この関数は廃止されます。
+ */
+export const useContracts = (params: Parameters<typeof getContracts>[0]) => {
+  const {
+    onError,
+  } = useCommonOptions();
+
+  return useQuery(
+    [AppIds.projEstimates, 'contracts', params],
+    () => getContracts(params),
+    {
+      onError,
+    },
+  );
+};

--- a/packages/kokoas-client/src/hooksQuery/useDeleteContractById.ts
+++ b/packages/kokoas-client/src/hooksQuery/useDeleteContractById.ts
@@ -2,6 +2,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { deleteContractById } from 'api-kintone';
 import { useCommonOptions } from './useCommonOptions';
 import { AppIds } from 'config';
+import { useSnackBar } from '../hooks/useSnackBar';
 
 
 /**
@@ -10,6 +11,8 @@ import { AppIds } from 'config';
  */
 export const useDeleteContractById = () => {
   const commonOptions = useCommonOptions();
+  const { setSnackState } = useSnackBar();
+
   const qc = useQueryClient();
 
   return useMutation(
@@ -17,7 +20,11 @@ export const useDeleteContractById = () => {
     {
       ...commonOptions,
       onSuccess: () => {
-        commonOptions.onSuccess();
+        setSnackState({
+          open: true,
+          message: '削除が出来ました。',
+          severity: 'success',
+        });
         qc.invalidateQueries({ queryKey: [AppIds.contracts] });
       },
     },

--- a/packages/kokoas-client/src/pages/projContractV2/parts/DeleteButton.tsx
+++ b/packages/kokoas-client/src/pages/projContractV2/parts/DeleteButton.tsx
@@ -38,7 +38,7 @@ export const DeleteButton = () => {
         onClose={handleClose}
       >
         <DialogTitle>
-          まじで削除しますか？
+          本当に削除しますか？
         </DialogTitle>
         <DialogContent>
           <Alert

--- a/packages/kokoas-client/src/pages/projContractV2/parts/DeleteButton.tsx
+++ b/packages/kokoas-client/src/pages/projContractV2/parts/DeleteButton.tsx
@@ -1,17 +1,23 @@
-import { Alert, Button, Dialog, DialogActions, DialogContent, DialogTitle } from '@mui/material';
+import { Alert, Button, Dialog, DialogActions, DialogContent, DialogTitle, Tooltip } from '@mui/material';
 import { useDeleteContractById } from 'kokoas-client/src/hooksQuery';
 import { useState } from 'react';
-import { useFormContext } from 'react-hook-form';
+import { useWatch } from 'react-hook-form';
 import { TypeOfForm } from '../schema';
 import { useNavigate } from 'react-router-dom';
 import { pages } from '../../Router';
+import DeleteIcon from '@mui/icons-material/Delete';
 
 /**
  * 削除出来るのは、未処理の契約書のみ
  */
 export const DeleteButton = () => {
-  const { getValues } = useFormContext<TypeOfForm>();
   const [open, setOpen] = useState(false);
+
+  const [contractId, envelopeStatus] = useWatch<TypeOfForm>({
+    name: ['contractId', 'envelopeStatus'],
+  });
+
+  const hasContract = !!envelopeStatus;
 
   const { mutateAsync } = useDeleteContractById();
   const navigate = useNavigate();
@@ -19,20 +25,27 @@ export const DeleteButton = () => {
   const handleClose = () => setOpen(false);
 
   const handleDelete = async () => {
-    const contractId = getValues('contractId');
-    await mutateAsync(contractId || '');
+    await mutateAsync(contractId as string);
     navigate(`/${pages.projContractSearch}`);
   };
 
   return (
     <>
-      <Button
-        variant='outlined'
-        color='error'
-        onClick={() => setOpen(true)}
+      <Tooltip
+        title={'未処理の契約書のみ削除出来ます。'}
       >
-        削除
-      </Button>
+        <div>
+          <Button
+            variant='outlined'
+            color='error'
+            onClick={() => setOpen(true)}
+            disabled={hasContract}
+            startIcon={<DeleteIcon />}
+          >
+            削除
+          </Button>
+        </div>
+      </Tooltip>
       <Dialog
         open={open}
         onClose={handleClose}
@@ -58,6 +71,7 @@ export const DeleteButton = () => {
             variant='contained'
             color='error'
             onClick={handleDelete}
+            startIcon={<DeleteIcon />}
           >
             削除
           </Button>

--- a/packages/kokoas-client/src/pages/projContractV2/parts/DeleteButton.tsx
+++ b/packages/kokoas-client/src/pages/projContractV2/parts/DeleteButton.tsx
@@ -1,0 +1,68 @@
+import { Alert, Button, Dialog, DialogActions, DialogContent, DialogTitle } from '@mui/material';
+import { useDeleteContractById } from 'kokoas-client/src/hooksQuery';
+import { useState } from 'react';
+import { useFormContext } from 'react-hook-form';
+import { TypeOfForm } from '../schema';
+import { useNavigate } from 'react-router-dom';
+import { pages } from '../../Router';
+
+/**
+ * 削除出来るのは、未処理の契約書のみ
+ */
+export const DeleteButton = () => {
+  const { getValues } = useFormContext<TypeOfForm>();
+  const [open, setOpen] = useState(false);
+
+  const { mutateAsync } = useDeleteContractById();
+  const navigate = useNavigate();
+
+  const handleClose = () => setOpen(false);
+
+  const handleDelete = async () => {
+    const contractId = getValues('contractId');
+    await mutateAsync(contractId || '');
+    navigate(`/${pages.projContractSearch}`);
+  };
+
+  return (
+    <>
+      <Button
+        variant='outlined'
+        color='error'
+        onClick={() => setOpen(true)}
+      >
+        削除
+      </Button>
+      <Dialog
+        open={open}
+        onClose={handleClose}
+      >
+        <DialogTitle>
+          まじで削除しますか？
+        </DialogTitle>
+        <DialogContent>
+          <Alert
+            severity='error'
+            variant='standard'
+          >
+            削除したら、元に戻せません。
+          </Alert>
+        </DialogContent>
+        <DialogActions>
+          <Button
+            onClick={handleClose}
+          >
+            キャンセル
+          </Button>
+          <Button
+            variant='contained'
+            color='error'
+            onClick={handleDelete}
+          >
+            削除
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </>
+  );
+};

--- a/packages/kokoas-client/src/pages/projContractV2/parts/DeleteButton.tsx
+++ b/packages/kokoas-client/src/pages/projContractV2/parts/DeleteButton.tsx
@@ -17,7 +17,7 @@ export const DeleteButton = () => {
     name: ['contractId', 'envelopeStatus'],
   });
 
-  const hasContract = !!envelopeStatus;
+  const canDelete = !envelopeStatus && !!contractId;
 
   const { mutateAsync } = useDeleteContractById();
   const navigate = useNavigate();
@@ -39,7 +39,7 @@ export const DeleteButton = () => {
             variant='outlined'
             color='error'
             onClick={() => setOpen(true)}
-            disabled={hasContract}
+            disabled={!canDelete}
             startIcon={<DeleteIcon />}
           >
             削除

--- a/packages/kokoas-client/src/pages/projContractV2/sections/FormActions.tsx
+++ b/packages/kokoas-client/src/pages/projContractV2/sections/FormActions.tsx
@@ -17,11 +17,9 @@ export const FormActions = () => {
 
   const [
     contractId,
-    envelopeStatus,
   ] = useWatch<TypeOfForm>({
     name: [
       'contractId',
-      'envelopeStatus',
     ],
   });
 
@@ -42,35 +40,37 @@ export const FormActions = () => {
   ]);
 
   return (
-    <Stack
-      direction="row"
-      spacing={2}
-      pt={2}
-    >
-      <Button
-        variant="outlined"
-        size="large"
-        startIcon={<SaveIcon />}
-        onClick={handleSubmit}
+    <>
+      <Stack
+        direction="row"
+        spacing={2}
+        py={2}
+        alignItems={'center'}
       >
-        保存
-      </Button>
+        <Button
+          variant="outlined"
+          size="large"
+          startIcon={<SaveIcon />}
+          onClick={handleSubmit}
+        >
+          保存
+        </Button>
 
-      {contractId && (
+        {contractId && (
         <PreviewButton disabled={isDirty} />
-      )}
+        )}
 
-      {contractId && !envelopeStatus && (
+     
         <DeleteButton />
-      )}
+
+      </Stack>
 
       {errorMessage && (
       <Alert severity="error" >
         {errorMessage}
       </Alert>
       )}
-
-      
-    </Stack>
+    </>
+    
   );
 };

--- a/packages/kokoas-client/src/pages/projContractV2/sections/FormActions.tsx
+++ b/packages/kokoas-client/src/pages/projContractV2/sections/FormActions.tsx
@@ -5,6 +5,7 @@ import { useFormState, useWatch } from 'react-hook-form';
 import { TypeOfForm } from '../schema';
 import { useMemo } from 'react';
 import { PreviewButton } from '../parts/preview/PreviewButton';
+import { DeleteButton } from '../parts/DeleteButton';
 
 export const FormActions = () => {
   const handleSubmit = useSubmitHandler();
@@ -14,8 +15,14 @@ export const FormActions = () => {
     isValidating, 
   } = useFormState<TypeOfForm>();
 
-  const contractId = useWatch<TypeOfForm>({
-    name: 'contractId',
+  const [
+    contractId,
+    envelopeStatus,
+  ] = useWatch<TypeOfForm>({
+    name: [
+      'contractId',
+      'envelopeStatus',
+    ],
   });
 
   const errorMessage = useMemo(() => {
@@ -45,14 +52,16 @@ export const FormActions = () => {
         size="large"
         startIcon={<SaveIcon />}
         onClick={handleSubmit}
-        //disabled={isSaveDisabled}
       >
         保存
       </Button>
 
       {contractId && (
-      <PreviewButton disabled={isDirty} />
+        <PreviewButton disabled={isDirty} />
+      )}
 
+      {contractId && !envelopeStatus && (
+        <DeleteButton />
       )}
 
       {errorMessage && (


### PR DESCRIPTION
## 変更

- 未処理の契約の削除機能を追加しました

## 理由

- 間違って契約のレコードを作成した場合、削除出来るように。

## 備考

- 完全削除なので、元に戻せません。削除出来るのは未処理のみ。