### PR TITLE
hotfix-js/path-injection の対策

### DIFF
--- a/packages/kokoas-server/src/assets/getFilePath.ts
+++ b/packages/kokoas-server/src/assets/getFilePath.ts
@@ -19,6 +19,16 @@ export const getFilePath = ({
   version?: string
 }) => {
 
+  // js/path-injection攻撃に対する対策
+  [
+    fileType,
+    version,
+  ].forEach((value) => {
+    if (!validator.isAlphanumeric(value)) {
+      throw new Error('不正なファイルパス');
+    }
+  });
+
   let assetFolder = '';
 
   switch (fileType) {
@@ -29,11 +39,6 @@ export const getFilePath = ({
     default:
       assetFolder = fileType;
       break;
-  }
-
-  // js/path-injection に対する対策 
-  if (!validator.isAlphanumeric(fileType)) {
-    throw new Error('Invalid fileType.');
   }
 
   const filePath = path.join(__dirname, assetFolder, `${fileName}${version}.${fileType}`);

--- a/packages/kokoas-server/src/assets/getFilePath.ts
+++ b/packages/kokoas-server/src/assets/getFilePath.ts
@@ -19,14 +19,10 @@ export const getFilePath = ({
 }) => {
 
   // js/path-injection攻撃に対する対策
-  [
-    fileType,
-    version,
-  ].forEach((value) => {
-    if (value.includes('/') || value.includes('\\') || value.includes('..')) {
-      throw new Error('不正なファイルパス');
-    }
-  });
+  if (fileType.includes('/') || fileName.includes('\\') || fileName.includes('..')) {
+    throw new Error('不正なファイルパス');
+  }
+  
 
   let assetFolder = '';
 

--- a/packages/kokoas-server/src/assets/getFilePath.ts
+++ b/packages/kokoas-server/src/assets/getFilePath.ts
@@ -1,6 +1,5 @@
 import path from 'path';
 import fs from 'fs';
-import validator from 'validator';
 
 type FileName =
 | '見積書'
@@ -24,7 +23,7 @@ export const getFilePath = ({
     fileType,
     version,
   ].forEach((value) => {
-    if (!validator.isAlphanumeric(value)) {
+    if (value.includes('/') || value.includes('\\') || value.includes('..')) {
       throw new Error('不正なファイルパス');
     }
   });

--- a/packages/kokoas-server/src/assets/getFilePath.ts
+++ b/packages/kokoas-server/src/assets/getFilePath.ts
@@ -1,5 +1,6 @@
 import path from 'path';
 import fs from 'fs';
+import validator from 'validator';
 
 type FileName =
 | '見積書'
@@ -30,7 +31,13 @@ export const getFilePath = ({
       break;
   }
 
+  // js/path-injection に対する対策 
+  if (!validator.isAlphanumeric(fileType)) {
+    throw new Error('Invalid fileType.');
+  }
+
   const filePath = path.join(__dirname, assetFolder, `${fileName}${version}.${fileType}`);
+
 
   if (fs.existsSync(filePath)) {
     return filePath;


### PR DESCRIPTION
## セキュリティに関する事象
変更点は、js/path-injectionにおけるセキュリティ対策です。ngrokのログを確認すると、脆弱性のあるエンドポイントへの不審なアクセスは確認されていません。

- fix #220

## 社内におけるリスクについて
Kintoneにログインする必要があるため、リクエストを改ざんするにはある程度の技術力が必要です。そのため、発生可能性は低いと考えています。ただし、この脆弱性が悪用された場合、サーバのすべてのファイルにアクセスされてしまう可能性があります。そのため、発生可能性は低いですが影響度は高いリスクとなります。

## 対策について
当面の間、渡されたパスに不正な値がある場合、リクエストがエラーとなるように対策しました。社内でクラウド型ストレージが整備された際には、パスではなくファイルIDを指定することで、この脆弱性に対する対策が可能となります。