### PR TITLE
T311-契約一覧テーブルの引用元を契約アプリに変更する

### DIFF
--- a/packages/kokoas-client/src/hooksQuery/index.ts
+++ b/packages/kokoas-client/src/hooksQuery/index.ts
@@ -13,6 +13,8 @@ export * from './useContractFilesById';
 export * from './useContracts';
 export * from './useContractsByCustGroupId';
 export * from './useContractsByProjId';
+export * from './useContractsV2ByCustGroupId';
+export * from './useContractV2';
 export * from './useConvertToAndpadByProjId';
 export * from './useCustGroupById';
 export * from './useCustGroupByProjId';

--- a/packages/kokoas-client/src/pages/projInvoice/FormInvoice.tsx
+++ b/packages/kokoas-client/src/pages/projInvoice/FormInvoice.tsx
@@ -12,12 +12,12 @@ import { pages } from '../Router';
 import { useEffect, useRef } from 'react';
 import { useSnackBar } from 'kokoas-client/src/hooks';
 import isEmpty from 'lodash/isEmpty';
-import { EstimatesTable } from './fieldComponents/EstimatesTable';
 import { BillingEntryTable } from './fieldComponents/BillingEntryTable';
 import { EmptyBox } from 'kokoas-client/src/components/ui/information/EmptyBox';
 import { BillingTotal } from './fieldComponents/BillingTotal';
 import { SelectInvoices } from './fieldComponents/selectInvoices/SelectInvoices';
 import { ActionButtons } from './fieldComponents/ActionButtons';
+import { EstimatesTable } from './fieldComponents/EstimatesTable';
 
 
 
@@ -31,14 +31,14 @@ export const FormInvoice = () => {
   const {
     custGroupId,
     custName,
-    estimates,
+    contracts,
     invoiceStatus,
     invoiceId,
   } = values;
 
 
 
-  const totalAmountExceeded = estimates.some(({ contractAmount, billedAmount, billingAmount, isShow }) => {
+  const totalAmountExceeded = contracts.some(({ contractAmount, billedAmount, billingAmount, isShow }) => {
     const totalBilledAmount = +billedAmount + +billingAmount;
     const isUnderContractAmount = (+contractAmount > 0) && (totalBilledAmount > +contractAmount);
     const isOverContractAmount = (+contractAmount <= 0) && (totalBilledAmount < +contractAmount);

--- a/packages/kokoas-client/src/pages/projInvoice/api/convertContractsToForm.ts
+++ b/packages/kokoas-client/src/pages/projInvoice/api/convertContractsToForm.ts
@@ -50,7 +50,7 @@ export const convertContractsToForm = ({
       billingAmount: Number(invoiceDetails?.amountPerContract.value ?? ''),
       amountType: invoiceDetails?.paymentType.value ?? '',
       isShow: false,
-      estimateId: contract.uuid.value,
+      contractId: contract.uuid.value,
     });
   });
 

--- a/packages/kokoas-client/src/pages/projInvoice/api/convertInvoiceToForm.ts
+++ b/packages/kokoas-client/src/pages/projInvoice/api/convertInvoiceToForm.ts
@@ -68,7 +68,7 @@ export const convertInvoiceToForm = (
       billingAmount: Number(amountPerContract.value),
       amountType: paymentType.value,
       isShow: true,
-      estimateId: estimateId.value,
+      contractId: estimateId.value,
     });
 
     return acc;
@@ -81,7 +81,7 @@ export const convertInvoiceToForm = (
     plannedPaymentDate: plannedPaymentDate.value ? parseISO(plannedPaymentDate.value) : '',
     undecidedPaymentDate: !plannedPaymentDate.value,
     exceedChecked: Boolean(exceedChecked.value),
-    estimates: newEstimates,
+    contracts: newEstimates,
     invoiceStatus: invoiceStatus.value as TInvoiceStatus,
   };
 

--- a/packages/kokoas-client/src/pages/projInvoice/api/convertToKintone.ts
+++ b/packages/kokoas-client/src/pages/projInvoice/api/convertToKintone.ts
@@ -4,13 +4,13 @@ import { TypeOfForm } from '../form';
 
 export const convertToKintone = ({
   custGroupId,
-  estimates,
+  contracts,
   plannedPaymentDate,
   exceedChecked,
   invoiceStatus,
 }: TypeOfForm) => {
 
-  const billingAmount = estimates.reduce((acc, cur) => {
+  const billingAmount = contracts.reduce((acc, cur) => {
     return acc + +cur.billingAmount;
   }, 0);
 
@@ -25,12 +25,12 @@ export const convertToKintone = ({
     invoiceStatus: { value: invoiceStatus },
     estimateLists: {
       type: 'SUBTABLE',
-      value: estimates.filter(({ isShow }) => !!isShow)
+      value: contracts.filter(({ isShow }) => !!isShow)
         .map(({
           projId,
           dataId,
           projTypeName,
-          estimateId,
+          contractId,
           billingAmount: amountPerContract,
           amountType,
         }) => {
@@ -40,7 +40,7 @@ export const convertToKintone = ({
               projId: { value: projId },
               dataId: { value: dataId },
               projTypeName: { value: projTypeName },
-              estimateId: { value: estimateId },
+              estimateId: { value: contractId },
               amountPerContract: { value: String(amountPerContract) },
               paymentType: { value: amountType },
             },

--- a/packages/kokoas-client/src/pages/projInvoice/fieldComponents/BillingEntryTable.tsx
+++ b/packages/kokoas-client/src/pages/projInvoice/fieldComponents/BillingEntryTable.tsx
@@ -19,11 +19,11 @@ export const BillingEntryTable = ({
 }) => {
 
   const { values, setValues } = useFormikContext<TypeOfForm>();
-  const { custGroupId, estimates } = values;
+  const { custGroupId, contracts } = values;
 
-  const { data: contracts } = useContractsByCustGroupId(custGroupId);
+  const { data: recContracts } = useContractsByCustGroupId(custGroupId);
 
-  const filterTable = estimates.filter((estimate) => estimate.isShow);
+  const filterTable = contracts.filter((contract) => contract.isShow);
 
 
 
@@ -38,21 +38,21 @@ export const BillingEntryTable = ({
           <Table size="small">
             <BillingEntryTableHead />
             <TableBody>
-              <FieldArray name="estimates" >
+              <FieldArray name="contracts" >
                 {({ insert }) => (
                   <>
                     {
-                      estimates.map((row, idx) => {
+                      contracts.map((row, idx) => {
                         if (!row.isShow) return;
                         return (
                           <BillingEntryTableRow
                             estimate={row}
                             idx={idx}
-                            paymentList={contracts?.paymentList}
+                            paymentList={recContracts?.paymentList}
                             isBilled={isBilled}
                             handleInsert={() => {
                               const newRow = {
-                                ...estimates[idx],
+                                ...contracts[idx],
                                 billingAmount: 0,
                                 amountType: '',
                                 estimateIndex: uuidV4(),
@@ -62,7 +62,7 @@ export const BillingEntryTable = ({
                             handleRemove={() => {
                               // 履歴として残せるよう、remove(idx)ではなくisShowで調整する
                               setValues((prev) => produce(prev, (draft) => {
-                                draft.estimates[idx].isShow = false;
+                                draft.contracts[idx].isShow = false;
                               }));
                             }}
                             key={`${row.estimateIndex}`}

--- a/packages/kokoas-client/src/pages/projInvoice/fieldComponents/BillingEntryTableRow.tsx
+++ b/packages/kokoas-client/src/pages/projInvoice/fieldComponents/BillingEntryTableRow.tsx
@@ -31,7 +31,7 @@ export const BillingEntryTableRow = ({
 
   const {
     projTypeName,
-    estimateId,
+    contractId,
     dataId,
     contractAmount,
     billedAmount,
@@ -39,7 +39,7 @@ export const BillingEntryTableRow = ({
     amountType,
   } = estimate;
 
-  const paymentItem = paymentList?.find(({ uuid }) => uuid === estimateId);
+  const paymentItem = paymentList?.find(({ uuid }) => uuid === contractId);
   const paymentTypeOption = paymentItem?.paymentTypeList.map((item) => {
     return ({
       label: item,
@@ -50,7 +50,7 @@ export const BillingEntryTableRow = ({
   const billingAmountChange = (e: ChangeEvent<HTMLInputElement>) => {
     setValues((prev) => {
       const newVal = produce(prev, (draft) => {
-        draft.estimates[idx].billingAmount = Number(e.target.value ?? 0);
+        draft.contracts[idx].billingAmount = Number(e.target.value ?? 0);
       });
 
       return newVal;
@@ -62,7 +62,7 @@ export const BillingEntryTableRow = ({
 
     setValues((prev) => {
       const newVal = produce(prev, (draft) => {
-        draft.estimates[idx].billingAmount = Number(paymentItem?.paymentAmtPerType?.[arrayIdx] ?? 0) ;
+        draft.contracts[idx].billingAmount = Number(paymentItem?.paymentAmtPerType?.[arrayIdx] ?? 0) ;
       });
 
       return newVal;

--- a/packages/kokoas-client/src/pages/projInvoice/fieldComponents/BillingTotal.tsx
+++ b/packages/kokoas-client/src/pages/projInvoice/fieldComponents/BillingTotal.tsx
@@ -28,7 +28,7 @@ const tblLabel: BillingTotalTbl[] = [{
 export const BillingTotal = () => {
 
   const { values } = useFormikContext<TypeOfForm>();
-  const { estimates } = values;
+  const { contracts } = values;
 
 
   return (
@@ -49,7 +49,7 @@ export const BillingTotal = () => {
         </TableHead>
         <TableBody>
           <BillingTotalBody
-            estimates={estimates}
+            estimates={contracts}
           />
         </TableBody>
       </Table>

--- a/packages/kokoas-client/src/pages/projInvoice/fieldComponents/ContractTable.tsx
+++ b/packages/kokoas-client/src/pages/projInvoice/fieldComponents/ContractTable.tsx
@@ -1,4 +1,12 @@
-export const ContractTable = () => {
+export const ContractTable = ({
+  invoiceId,
+  custGroupId,
+  isBilled,
+}:{
+  invoiceId: string
+  custGroupId: string
+  isBilled: boolean
+}) => {
 
   return (
     <>

--- a/packages/kokoas-client/src/pages/projInvoice/fieldComponents/ContractTable.tsx
+++ b/packages/kokoas-client/src/pages/projInvoice/fieldComponents/ContractTable.tsx
@@ -1,0 +1,8 @@
+export const ContractTable = () => {
+
+  return (
+    <>
+      {/* 要編集 */}
+    </>
+  );
+};

--- a/packages/kokoas-client/src/pages/projInvoice/fieldComponents/EstimatesTableBody.tsx
+++ b/packages/kokoas-client/src/pages/projInvoice/fieldComponents/EstimatesTableBody.tsx
@@ -46,18 +46,18 @@ export const EstimateTableBody = ({
 
   const isRefund = contractAmount < 0;
   const disabled = !isRefund ? contractAmount <= billedAmount : contractAmount >= billedAmount;
-  const isExist = values.estimates.find(({ dataId }) => dataId === estimateRow.dataId);
+  const isExist = values.contracts.find(({ dataId }) => dataId === estimateRow.dataId);
 
   const handleCheck = () => {
 
     if (isExist) {
       // 既にestimatesに対象の見積もり枝番情報が含まれる場合、対象の見積もり枝番のisShowの値を反転する
       setValues((prev) => produce(prev, (draft) => {
-        draft.estimates = draft.estimates.map((estimate) => {
-          if (estimateRow.dataId !== estimate.dataId) return estimate;
+        draft.contracts = draft.contracts.map((contract) => {
+          if (estimateRow.dataId !== contract.dataId) return contract;
           return ({
-            ...estimate,
-            isShow: !estimate.isShow,
+            ...contract,
+            isShow: !contract.isShow,
           });
         });
       }));
@@ -69,7 +69,7 @@ export const EstimateTableBody = ({
         isShow: true,
       };
       setValues((prev) => produce(prev, (draft) => {
-        draft.estimates.push(newEstimateRow);
+        draft.contracts.push(newEstimateRow);
       }));
     }
   };

--- a/packages/kokoas-client/src/pages/projInvoice/form.ts
+++ b/packages/kokoas-client/src/pages/projInvoice/form.ts
@@ -22,7 +22,7 @@ export const initialValues = {
   custName: '',
 
   /** 見積もり情報 */
-  estimates: [
+  contracts: [
     {
       /** 見積もりインデックス用uuid */
       estimateIndex: '',
@@ -58,7 +58,7 @@ export const initialValues = {
       isShow: false,
 
       /** 見積もりuuid */
-      estimateId: '',
+      contractId: '',
     },
   ],
 
@@ -78,14 +78,14 @@ export const initialValues = {
 export type TypeOfForm = typeof initialValues;
 export type KeyOfForm = keyof TypeOfForm;
 
-export const initialEstimateRow = initialValues.estimates[0];
+export const initialEstimateRow = initialValues.contracts[0];
 export type EstimateRow = typeof initialEstimateRow;
 
 /* Utility functions */
 
 export const getFieldName = (s: KeyOfForm) => s;
 
-export type TMaterials = TypeOfForm['estimates'][0];
+export type TMaterials = TypeOfForm['contracts'][0];
 export type TKMaterials = keyof TMaterials;
 
 export type TInvoiceStatus =
@@ -98,7 +98,7 @@ export type TInvoiceStatus =
  * 
  フィールド名取得、ヘルパー
  */
-const itemsName = getFieldName('estimates');
+const itemsName = getFieldName('contracts');
 export const getEstimatesFieldName = (
   rowIdx: number, fieldName: TKMaterials,
 ) => `${itemsName}[${rowIdx}].${fieldName}`;

--- a/packages/kokoas-client/src/pages/projInvoice/formValidation.ts
+++ b/packages/kokoas-client/src/pages/projInvoice/formValidation.ts
@@ -13,7 +13,7 @@ const numberValidation = Yup
 
 
 /* unique validations */
-const billingAmountValidation = function (this: { parent: TypeOfForm['estimates'][number] }) {
+const billingAmountValidation = function (this: { parent: TypeOfForm['contracts'][number] }) {
   const {
     contractAmount,
     billingAmount,
@@ -32,11 +32,11 @@ export const validationSchema = Yup
   .object()
   .shape<Partial<Record<KeyOfForm, Yup.AnySchema>>>({
 
-  estimates: Yup.array()
+  contracts: Yup.array()
     .of(
       Yup.object({
         estimateIndex: numberValidation,
-        estimateId: Yup.string(),
+        contractId: Yup.string(),
         contractAmount: numberValidation,
         billingAmount: numberValidation
           .test(

--- a/packages/kokoas-client/src/pages/projInvoice/helper/sortEstimatesByProjId.ts
+++ b/packages/kokoas-client/src/pages/projInvoice/helper/sortEstimatesByProjId.ts
@@ -3,7 +3,6 @@ import { TypeOfForm } from '../form';
 
 /**
  * 工事番号ごとに配列を分割する処理
- * @param estimates 
  */
 export const sortEstimatesByProjId = ({
   records,
@@ -15,7 +14,7 @@ export const sortEstimatesByProjId = ({
 
 
   /* データの再構成 */
-  const convertedEstimates: TypeOfForm['estimates'] | undefined = records?.map((record, idx) => {
+  const convertedEstimates: TypeOfForm['contracts'] | undefined = records?.map((record, idx) => {
 
     return {
       estimateIndex: '',
@@ -29,7 +28,7 @@ export const sortEstimatesByProjId = ({
       billingAmount: 0,
       amountType: '',
       isShow: true,
-      estimateId: record.uuid.value,
+      contractId: record.uuid.value,
     };
 
   });


### PR DESCRIPTION
**変更**
---

 - 請求入力ページ内の契約一覧テーブルの引用元を、見積りから契約に変更します。


**変更理由**
 ---

 - 仕様変更による
 - https://trello.com/c/2iEcJXIo