### PR TITLE
hotfix-契約画面のプレビューのE2Eテスト

### DIFF
--- a/packages/kokoas-e2e/cypress/e2e/contractPreview2/preview.cy.ts
+++ b/packages/kokoas-e2e/cypress/e2e/contractPreview2/preview.cy.ts
@@ -1,0 +1,11 @@
+import { beforeEach, describe } from 'local-cypress';
+
+describe('プレビュー', () => {
+  beforeEach(() => {
+    
+  })
+  
+  it('プレビュー画面が表示されること', () => {
+    
+  });
+});

--- a/packages/kokoas-e2e/cypress/e2e/contractPreview2/preview.cy.ts
+++ b/packages/kokoas-e2e/cypress/e2e/contractPreview2/preview.cy.ts
@@ -1,11 +1,35 @@
-import { beforeEach, describe } from 'local-cypress';
+import { beforeEach, cy, describe, expect } from 'local-cypress';
+import { ReqDownloadContractV2Response } from 'types';
 
 describe('プレビュー', () => {
   beforeEach(() => {
-    
-  })
+    cy.login();
+    cy.fixture('testIds').then((testIds) => {
+      cy.visit(`/project/contract/preview/v2?contractId=${testIds.contractId}`);
+    });
+  });
   
   it('プレビュー画面が表示されること', () => {
-    
+    cy.intercept(
+      {
+        method: 'POST',
+        url: '**/k/api/proxy/call.json*',
+      }, (req) => {
+        // 契約ダウンロード以外、他kintone/proxyへのリクエストはそのまま通す
+        if (!req.body.url.includes('contract/download')) {
+          return;
+        }
+
+        req.continue((res) => {
+          const {
+            documents,
+          } = JSON.parse(res.body.result.body) as ReqDownloadContractV2Response;
+          expect(documents.length).to.be.greaterThan(0, '書類が1つ以上存在すること');
+        });
+      },
+    );
+
+    cy.contains('button', 'プレビュー').click();
+   
   });
 });

--- a/packages/kokoas-e2e/cypress/e2e/contractPreview2/preview.cy.ts
+++ b/packages/kokoas-e2e/cypress/e2e/contractPreview2/preview.cy.ts
@@ -27,7 +27,7 @@ describe('プレビュー', () => {
           expect(documents.length).to.be.greaterThan(0, '書類が1つ以上存在すること');
         });
       },
-    );
+    ).as('downloadContract');
 
     cy.contains('button', 'プレビュー').click();
    


### PR DESCRIPTION
## 変更

1. プレビューのE2Eテスト

## 理由

1. ちゃんとプレビューが機能しているかテストです。

## テスト

`nx cy:open kokoas-e2e`

- cypress\e2e\contractPreview2\preview.cy.ts
