### PR TITLE
hotfix-工事情報をAndpadへ登録する不安定なE2Eテストを修正する

### DIFF
--- a/packages/kokoas-e2e/cypress/e2e/project/log.cy.ts
+++ b/packages/kokoas-e2e/cypress/e2e/project/log.cy.ts
@@ -25,7 +25,7 @@ describe('log', () => {
 
         cy.contains('Andpadへ案件更新しますか').should('not.exist');
         cy.contains('保存が出来ました').should('exist');
-        cy.contains('保存が出来ました').should('not.exist');
+        cy.contains('保存が出来ました').should('not.exist', { timeout: 10000 });
 
 
         cy.get('@latestLog').invoke('text')


### PR DESCRIPTION
## 変更

1. 「保存が出来ました」がなくなるまで、デフォールト４秒でした、10秒待つようにしました。

## 理由

1. 単独で実行すると、「保存が出来ました」は４秒以内になくなりますが、全体テストになると失敗することはあるため。

## テスト

- `nx cy:e2e kokoas-e2e`


## 備考

- 私の環境ではPCのスペックのおかげで、全体テストを５回やって、すべて成功していましたが、もし他環境で不安定だったら、別対策を設けます。