### PR TITLE
T306-エンヴェロープを修正するAPIエンドポイントを追加する

### DIFF
--- a/packages/kokoas-server/src/api/docusign/createCorrectView.test.ts
+++ b/packages/kokoas-server/src/api/docusign/createCorrectView.test.ts
@@ -1,8 +1,8 @@
 import { createCorrectView } from './createCorrectView';
 
-describe('Create sender', () => {
+describe('correctView', () => {
 
-  it('should generate link correct view', async () => {
+  it('修正ビューのURLをDocusignによって生成する', async () => {
     const result = await createCorrectView('dcdc8c8c-6d3b-413e-8498-29fa034c6e87')
       .catch((err) => {
         console.log('err', err);

--- a/packages/kokoas-server/src/api/docusign/createCorrectView.test.ts
+++ b/packages/kokoas-server/src/api/docusign/createCorrectView.test.ts
@@ -1,0 +1,14 @@
+import { createCorrectView } from './createCorrectView';
+
+describe('Create sender', () => {
+
+  it('should generate link correct view', async () => {
+    const result = await createCorrectView('dcdc8c8c-6d3b-413e-8498-29fa034c6e87')
+      .catch((err) => {
+        console.log('err', err);
+      });
+    console.log('result', result);
+
+    expect(result).toHaveProperty('url');
+  });
+});

--- a/packages/kokoas-server/src/api/docusign/createCorrectView.ts
+++ b/packages/kokoas-server/src/api/docusign/createCorrectView.ts
@@ -1,0 +1,19 @@
+import { EnvelopesApi } from 'docusign-esign';
+import { apiClient } from '../../config';
+import { getAccountId } from './authentication';
+
+
+export const createCorrectView = async (
+  envelopeId: string,
+) => {
+  const accountId = await getAccountId();
+  console.log('createCorrectView AccountId: ', accountId);
+  const envApi = new EnvelopesApi(apiClient);
+
+  console.log(accountId, envelopeId);
+
+  return envApi.createCorrectView(
+    accountId,
+    envelopeId,
+  );
+};

--- a/packages/kokoas-server/src/api/docusign/createCorrectView.ts
+++ b/packages/kokoas-server/src/api/docusign/createCorrectView.ts
@@ -1,19 +1,31 @@
-import { EnvelopesApi } from 'docusign-esign';
+import { CorrectViewRequest, EnvelopesApi } from 'docusign-esign';
 import { apiClient } from '../../config';
 import { getAccountId } from './authentication';
 
-
+/**
+ * @see https://developers.docusign.com/docs/esign-rest-api/reference/envelopes/envelopeviews/createcorrect/
+ * @param envelopeId 
+ * @param returnUrl 
+ */
 export const createCorrectView = async (
   envelopeId: string,
+  returnUrl = 'https://cocosumo.net/',
 ) => {
   const accountId = await getAccountId();
-  console.log('createCorrectView AccountId: ', accountId);
   const envApi = new EnvelopesApi(apiClient);
 
-  console.log(accountId, envelopeId);
+
+  const viewRequest: CorrectViewRequest = {
+    returnUrl,
+  };
+
+  console.log('createCorrectView AccountId: ', accountId, returnUrl);
 
   return envApi.createCorrectView(
     accountId,
     envelopeId,
+    {
+      'correctViewRequest': viewRequest,
+    },
   );
 };

--- a/packages/kokoas-server/src/handleRequest/reqCreateCorrectView.ts
+++ b/packages/kokoas-server/src/handleRequest/reqCreateCorrectView.ts
@@ -1,5 +1,6 @@
 import { RequestHandler } from 'express';
 import { createCorrectView } from '../api/docusign/createCorrectView';
+import validator from 'validator';
 
 export const reqCreateCorrectView: RequestHandler<
 unknown,
@@ -27,6 +28,10 @@ unknown,
     res.status(200).json(result);
     
   } catch (error) {
-    res.status(400).send(`編集リクエストが失敗しました。Docusign上で確認するよう管理者にご連絡ください。 ${error.message}`);
+    const sanitizedError = validator.escape(error.message) ;
+ 
+    res
+      .status(400)
+      .send(`編集リクエストが失敗しました。Docusign上で確認するよう管理者にご連絡ください。 ${sanitizedError}`);
   }
 };

--- a/packages/kokoas-server/src/handleRequest/reqCreateCorrectView.ts
+++ b/packages/kokoas-server/src/handleRequest/reqCreateCorrectView.ts
@@ -1,0 +1,32 @@
+import { RequestHandler } from 'express';
+import { createCorrectView } from '../api/docusign/createCorrectView';
+
+export const reqCreateCorrectView: RequestHandler<
+unknown,
+unknown,
+{
+  envelopeId: string,
+}
+> = async (req, res) => {
+  const body = req.body;
+
+  const {
+    envelopeId = '',
+  } = body;
+
+  try {
+
+    if (!envelopeId) {
+      throw new Error('EnvelopeId is required');
+    }
+    
+    console.log('Request correct view', envelopeId);
+    const result = await createCorrectView(envelopeId);
+
+    console.log('Sending correct view url.');
+    res.status(200).json(result);
+    
+  } catch (error) {
+    res.status(400).send(`編集リクエストが失敗しました。Docusign上で確認するよう管理者にご連絡ください。 ${error.message}`);
+  }
+};

--- a/packages/kokoas-server/src/handleRequest/reqCreateCorrectView.ts
+++ b/packages/kokoas-server/src/handleRequest/reqCreateCorrectView.ts
@@ -7,12 +7,14 @@ unknown,
 unknown,
 {
   envelopeId: string,
+  returnUrl?: string,
 }
 > = async (req, res) => {
   const body = req.body;
 
   const {
     envelopeId = '',
+    returnUrl,
   } = body;
 
   try {
@@ -22,7 +24,7 @@ unknown,
     }
     
     console.log('Request correct view', envelopeId);
-    const result = await createCorrectView(envelopeId);
+    const result = await createCorrectView(envelopeId, returnUrl);
 
     console.log('Sending correct view url.');
     res.status(200).json(result);

--- a/packages/kokoas-server/src/route/docusign.ts
+++ b/packages/kokoas-server/src/route/docusign.ts
@@ -12,6 +12,7 @@ import { reqResendContract } from '../handleRequest/reqResendContract';
 import { docusignEndpoints } from 'libs';
 import { reqDownloadContractV2 } from '../handleRequest/reqDownloadContractV2';
 import { reqVoidEnvelopeV2 } from '../handleRequest/reqVoidEnvelopeV2';
+import { reqCreateCorrectView } from '../handleRequest/reqCreateCorrectView';
 
 
 const route = router();
@@ -43,6 +44,8 @@ route.get('/contract/download', reqDownloadContract);
 route.get(`/${docusignEndpoints.downloadContract}`, reqDownloadContractV2);
 route.post(`/${docusignEndpoints.sendDirect}`, reqSendContractDirectV2);
 route.post(`/${docusignEndpoints.void}`, reqVoidEnvelopeV2);
+
+route.post(`/${docusignEndpoints.correct}`, reqCreateCorrectView);
 
 route.get('/test', (req, res)=>{
   console.log('Connection test is success');

--- a/packages/libs/src/endpoints.ts
+++ b/packages/libs/src/endpoints.ts
@@ -44,4 +44,7 @@ export const docusignEndpoints = {
   downloadContract: 'contract/download/v2',
   sendDirect: 'contract/send/direct/v2',
   void: 'contract/void/v2',
+
+  /** 修正画面 */
+  correct: 'contract/correct',
 } as const;


### PR DESCRIPTION
## 変更

1. サーバに　contract/correct　というAPIエンドポイントを追加しました。

## 理由

1. Docusign上の修正画面に簡単に移動出来るように。

## テスト

- createCorrectViewの単体テストあり。
- APIエンドポイント自体のテストはありません。(手動でpostmanなどが使えます)


![image](https://github.com/Lorenzras/yumecoco-monorepo/assets/2501255/3fbeb502-4239-4bce-b9a6-d42bd489e139)

