### PR TITLE
T306 1 contract add correct feature ras

### DIFF
--- a/packages/kokoas-client/src/api/docusign/getCorrectViewUrl.test.ts
+++ b/packages/kokoas-client/src/api/docusign/getCorrectViewUrl.test.ts
@@ -1,0 +1,18 @@
+import { getCorrectViewUrl } from './getCorrectViewUrl';
+
+describe('getCorrectViewUrl', () => {
+  it('修正画面のURLを取得できる', async () => {
+    /**
+     * Note:
+     * ドキュメントにないですが、修正ビューURLを生成したあと、また生成したら、前のURLが無効になります。
+     */
+    const envelopeId = 'dcdc8c8c-6d3b-413e-8498-29fa034c6e87';
+
+    const result = await getCorrectViewUrl(envelopeId);
+
+    console.log(result);
+
+    expect(typeof result.url).toBe('string');
+  
+  });
+});

--- a/packages/kokoas-client/src/api/docusign/getCorrectViewUrl.test.ts
+++ b/packages/kokoas-client/src/api/docusign/getCorrectViewUrl.test.ts
@@ -5,6 +5,7 @@ describe('getCorrectViewUrl', () => {
     /**
      * Note:
      * ドキュメントにないですが、修正ビューURLを生成したあと、また生成したら、前のURLが無効になります。
+     * よって、キャッシュするかどうか検証中。
      */
     const envelopeId = 'dcdc8c8c-6d3b-413e-8498-29fa034c6e87';
 

--- a/packages/kokoas-client/src/api/docusign/getCorrectViewUrl.test.ts
+++ b/packages/kokoas-client/src/api/docusign/getCorrectViewUrl.test.ts
@@ -9,7 +9,7 @@ describe('getCorrectViewUrl', () => {
      */
     const envelopeId = 'dcdc8c8c-6d3b-413e-8498-29fa034c6e87';
 
-    const result = await getCorrectViewUrl(envelopeId);
+    const result = await getCorrectViewUrl({ envelopeId });
 
     console.log(result);
 

--- a/packages/kokoas-client/src/api/docusign/getCorrectViewUrl.ts
+++ b/packages/kokoas-client/src/api/docusign/getCorrectViewUrl.ts
@@ -1,0 +1,28 @@
+import { baseUrl } from 'config';
+import { docusignEndpoints, kintoneProxyWrapper } from 'libs';
+import { ApiNodes } from 'types';
+import { z } from 'zod';
+
+export const getCorrectViewUrl = async (envelopeId: string) => {
+  if (!envelopeId) throw new Error('エンベロープIDは設定していません。');
+
+
+  const apiNode: ApiNodes = 'docusign';
+
+  const endpoint = `${baseUrl}/${apiNode}/${docusignEndpoints.correct}`;
+
+  const { data } = await kintoneProxyWrapper({
+    url: endpoint,
+    method: 'POST',
+    data: {
+      envelopeId,
+    },
+    headers: {},
+  });
+
+  const correctViewResult = z.object({
+    url: z.string(),
+  });
+
+  return correctViewResult.parse(data);
+};

--- a/packages/kokoas-client/src/api/docusign/getCorrectViewUrl.ts
+++ b/packages/kokoas-client/src/api/docusign/getCorrectViewUrl.ts
@@ -17,7 +17,9 @@ export const getCorrectViewUrl = async (envelopeId: string) => {
     data: {
       envelopeId,
     },
-    headers: {},
+    headers: {
+      'Content-Type': 'application/json',
+    },
   });
 
   const correctViewResult = z.object({

--- a/packages/kokoas-client/src/api/docusign/getCorrectViewUrl.ts
+++ b/packages/kokoas-client/src/api/docusign/getCorrectViewUrl.ts
@@ -3,7 +3,13 @@ import { docusignEndpoints, kintoneProxyWrapper } from 'libs';
 import { ApiNodes } from 'types';
 import { z } from 'zod';
 
-export const getCorrectViewUrl = async (envelopeId: string) => {
+export const getCorrectViewUrl = async ({
+  envelopeId,
+  returnUrl,
+}:{
+  envelopeId: string,
+  returnUrl?: string,
+}) => {
   if (!envelopeId) throw new Error('エンベロープIDは設定していません。');
 
 
@@ -16,6 +22,7 @@ export const getCorrectViewUrl = async (envelopeId: string) => {
     method: 'POST',
     data: {
       envelopeId,
+      returnUrl,
     },
     headers: {
       'Content-Type': 'application/json',

--- a/packages/kokoas-client/src/hooksQuery/index.ts
+++ b/packages/kokoas-client/src/hooksQuery/index.ts
@@ -9,6 +9,7 @@ export * from './useCommonOptions';
 export * from './useContractById';
 export * from './useContractByProjId';
 export * from './useContractCheckersByStoreId';
+export * from './useContractCorrectView';
 export * from './useContractFilesById';
 export * from './useContracts';
 export * from './useContractsByCustGroupId';

--- a/packages/kokoas-client/src/hooksQuery/useContractCorrectView.ts
+++ b/packages/kokoas-client/src/hooksQuery/useContractCorrectView.ts
@@ -1,0 +1,35 @@
+
+
+import { useMutation } from '@tanstack/react-query';
+import { getCorrectViewUrl } from '../api/docusign/getCorrectViewUrl';
+import { useSnackBar } from '../hooks/useSnackBar';
+
+
+/**
+ * 契約の修正画面のリンク取得する
+ */
+export const useContractCorrectView = () => {
+  const { setSnackState } = useSnackBar();
+
+  return useMutation(
+    getCorrectViewUrl,
+    {
+      onError: (error : Error) => {
+        setSnackState({
+          open: true,
+          message: error.message,
+          severity: 'error',
+        });
+      },
+      onSuccess: () => {
+        setSnackState({
+          open: true,
+          message: '修正画面を開きます',
+          severity: 'success',
+        });
+      },
+      
+    },
+  );
+
+};

--- a/packages/kokoas-client/src/lib/jaEnvStatus.ts
+++ b/packages/kokoas-client/src/lib/jaEnvStatus.ts
@@ -37,12 +37,23 @@ export const jaEnvelopeStatus  = (
         ja: '無効化中',
         desc: '無効化中です。',
       };
+    case 'correct' : {
+      return {
+        ja: '修正',
+        desc: '送信者が訂正のために封筒を開封しました。このステータスの封筒には署名プロセスが停止されます',
+      };
+    }
     case '': {
       return {
         ja: '未作成',
         desc: '契約はDocusign上でまだ作成していません。',
       };
     }
-    default: throw new Error('Unknown status.');
+    default: {
+      return {
+        ja: status,
+        desc: '未定義のステータスです。管理者へお問い合わせください。',
+      };
+    }
   }
 };

--- a/packages/kokoas-client/src/pages/projContractV2/parts/preview/menu/ContractActionMenu.tsx
+++ b/packages/kokoas-client/src/pages/projContractV2/parts/preview/menu/ContractActionMenu.tsx
@@ -2,6 +2,7 @@ import { Button, Menu } from '@mui/material';
 import MoreIcon from '@mui/icons-material/More';
 import { useState } from 'react';
 import { MenuVoidContract } from './void/MenuVoidContract';
+import { MenuCorrectContract } from './correct/MenuCorrectContract';
 
 
 export const ContractActionMenu = () => {
@@ -38,6 +39,8 @@ export const ContractActionMenu = () => {
         }}
       >
 
+        <MenuCorrectContract />
+        
         <MenuVoidContract />
 
       </Menu>

--- a/packages/kokoas-client/src/pages/projContractV2/parts/preview/menu/correct/EditContractDialog.tsx
+++ b/packages/kokoas-client/src/pages/projContractV2/parts/preview/menu/correct/EditContractDialog.tsx
@@ -1,4 +1,4 @@
-import { Alert, Button, Dialog, DialogActions, DialogContent, DialogTitle } from '@mui/material';
+import { Alert, AlertTitle, Button, Dialog, DialogActions, DialogContent, DialogTitle, Link } from '@mui/material';
 import { DialogCloseButton } from 'kokoas-client/src/components';
 import { Loading } from 'kokoas-client/src/components/ui/loading/Loading';
 import { useContractCorrectView } from 'kokoas-client/src/hooksQuery';
@@ -45,9 +45,18 @@ export const EditContractDialog = ({
         )}
         {!isLoading && (
         <Alert
-          severity="info"
+          severity="warning"
         >
-          送信したエンベロープが完了していない場合は、そのエンベロープを修正することができます。
+          <AlertTitle>
+            送信したエンベロープが完了していない場合は、修正することができます。
+          </AlertTitle>
+  
+          文書を修正したら、必ず［修正］または［変更の破棄］をクリックしてください。文書を修正した後でこれらをクリックせずにブラウザーを閉じると、受信者が文書にアクセスなくなります。
+          詳細は
+          <Link href='https://support.docusign.com/s/articles/FAQs-related-to-correcting-envelopes-in-DocuSign?language=ja&rsc_301' target='_blank'>
+            こちら
+          </Link>
+          。
         </Alert>
         )}
 

--- a/packages/kokoas-client/src/pages/projContractV2/parts/preview/menu/correct/EditContractDialog.tsx
+++ b/packages/kokoas-client/src/pages/projContractV2/parts/preview/menu/correct/EditContractDialog.tsx
@@ -1,0 +1,73 @@
+import { Alert, Button, Dialog, DialogActions, DialogContent, DialogTitle } from '@mui/material';
+import { DialogCloseButton } from 'kokoas-client/src/components';
+import { Loading } from 'kokoas-client/src/components/ui/loading/Loading';
+import { useContractCorrectView } from 'kokoas-client/src/hooksQuery';
+import { TypeOfForm } from 'kokoas-client/src/pages/projContractV2/schema';
+import { useFormContext } from 'react-hook-form';
+
+
+export const EditContractDialog = ({
+  open,
+  handleClose,
+}: {
+  open: boolean;
+  handleClose: () => void;
+}) => {
+  const { getValues } = useFormContext<TypeOfForm>();
+  const { 
+    mutateAsync: getContractView, 
+    isLoading,
+  } = useContractCorrectView();
+
+  const handleOpenCorrectView = async () => {
+    const envelopeId = getValues('envelopeId');
+    const {
+      url,
+    } = await getContractView(envelopeId as string);
+    window.open(url, '_blank');
+    handleClose();
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onClose={handleClose}
+      fullWidth
+      maxWidth={'sm'}
+    >
+      <DialogTitle >
+        修正しますか。
+        <DialogCloseButton handleClose={handleClose} />
+      </DialogTitle>
+      <DialogContent>
+        {isLoading && (
+          <Loading />
+        )}
+        {!isLoading && (
+        <Alert
+          severity="info"
+        >
+          送信したエンベロープが完了していない場合は、そのエンベロープを修正することができます。
+        </Alert>
+        )}
+
+      </DialogContent>
+
+      {!isLoading && (
+        <DialogActions>
+          <Button onClick={handleClose}>
+            キャンセル
+          </Button>
+          <Button
+            variant='contained'
+            onClick={handleOpenCorrectView}
+          >
+            修正
+          </Button>
+        </DialogActions>
+      )}
+      
+
+    </Dialog>
+  );
+};

--- a/packages/kokoas-client/src/pages/projContractV2/parts/preview/menu/correct/EditContractDialog.tsx
+++ b/packages/kokoas-client/src/pages/projContractV2/parts/preview/menu/correct/EditContractDialog.tsx
@@ -20,12 +20,15 @@ export const EditContractDialog = ({
   } = useContractCorrectView();
 
   const handleOpenCorrectView = async () => {
-    const envelopeId = getValues('envelopeId');
+    const envelopeId = getValues('envelopeId') as string;
     const {
       url,
-    } = await getContractView(envelopeId as string);
-    window.open(url, '_blank');
-    handleClose();
+    } = await getContractView({
+      envelopeId,
+      returnUrl: window.location.href,
+    });
+
+    window.open(url, '_self');
   };
 
   return (

--- a/packages/kokoas-client/src/pages/projContractV2/parts/preview/menu/correct/EditContractDialog.tsx
+++ b/packages/kokoas-client/src/pages/projContractV2/parts/preview/menu/correct/EditContractDialog.tsx
@@ -28,6 +28,8 @@ export const EditContractDialog = ({
       returnUrl: window.location.href,
     });
 
+    handleClose();
+
     window.open(url, '_self');
   };
 

--- a/packages/kokoas-client/src/pages/projContractV2/parts/preview/menu/correct/MenuCorrectContract.tsx
+++ b/packages/kokoas-client/src/pages/projContractV2/parts/preview/menu/correct/MenuCorrectContract.tsx
@@ -1,0 +1,36 @@
+import { MenuItem, Tooltip  } from '@mui/material';
+
+import { useState } from 'react';
+import { useWatch } from 'react-hook-form';
+import { TypeOfForm } from 'kokoas-client/src/pages/projContractV2/schema';
+import { TEnvelopeStatus } from 'types';
+
+/**
+ * エンベロープを修正する
+ * @see https://support.docusign.com/s/document-item?language=ja&rsc_301=&langSet=1&bundleId=oeq1643226594604&topicId=dxr1578456334187.html&_LANG=jajp
+ */
+const editableStates: TEnvelopeStatus[] = ['sent', 'created'];
+
+export const MenuCorrectContract = () => {
+  const [open, setOpen] = useState(false);
+  const envelopeStatus = useWatch<TypeOfForm>({
+    name: 'envelopeStatus',
+  }) as TEnvelopeStatus;
+
+  const isEditableState = editableStates.includes(envelopeStatus);
+
+  return (
+    <Tooltip title={!isEditableState ? '進捗中の契約のみ修正出来ます' : ''}>
+      <div>
+        <MenuItem 
+          disabled={!isEditableState}
+          onClick={() => {
+            setOpen(true);
+          }}
+        >
+          取り下げ
+        </MenuItem>
+      </div>
+    </Tooltip>
+  );
+};

--- a/packages/kokoas-client/src/pages/projContractV2/parts/preview/menu/correct/MenuCorrectContract.tsx
+++ b/packages/kokoas-client/src/pages/projContractV2/parts/preview/menu/correct/MenuCorrectContract.tsx
@@ -9,7 +9,7 @@ import { TEnvelopeStatus } from 'types';
  * エンベロープを修正する
  * @see https://support.docusign.com/s/document-item?language=ja&rsc_301=&langSet=1&bundleId=oeq1643226594604&topicId=dxr1578456334187.html&_LANG=jajp
  */
-const editableStates: TEnvelopeStatus[] = ['sent', 'created'];
+const editableStates: TEnvelopeStatus[] = ['sent', 'created', 'correct'];
 
 export const MenuCorrectContract = () => {
   const [open, setOpen] = useState(false);
@@ -28,7 +28,7 @@ export const MenuCorrectContract = () => {
             setOpen(true);
           }}
         >
-          取り下げ
+          修正
         </MenuItem>
       </div>
     </Tooltip>

--- a/packages/kokoas-client/src/pages/projContractV2/parts/preview/menu/correct/MenuCorrectContract.tsx
+++ b/packages/kokoas-client/src/pages/projContractV2/parts/preview/menu/correct/MenuCorrectContract.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import { useWatch } from 'react-hook-form';
 import { TypeOfForm } from 'kokoas-client/src/pages/projContractV2/schema';
 import { TEnvelopeStatus } from 'types';
+import { EditContractDialog } from './EditContractDialog';
 
 /**
  * エンベロープを修正する
@@ -20,17 +21,25 @@ export const MenuCorrectContract = () => {
   const isEditableState = editableStates.includes(envelopeStatus);
 
   return (
-    <Tooltip title={!isEditableState ? '進捗中の契約のみ修正出来ます' : ''}>
-      <div>
-        <MenuItem 
-          disabled={!isEditableState}
-          onClick={() => {
-            setOpen(true);
-          }}
-        >
-          修正
-        </MenuItem>
-      </div>
-    </Tooltip>
+    <>
+      <Tooltip title={!isEditableState ? '進捗中の契約のみ修正出来ます' : ''}>
+        <div>
+          <MenuItem 
+            disabled={!isEditableState}
+            onClick={() => {
+              setOpen(true);
+            }}
+          >
+            修正
+          </MenuItem>
+        </div>
+      </Tooltip>
+    
+      <EditContractDialog 
+        handleClose={()=> setOpen(false)} 
+        open={open}
+      />
+    </>
+    
   );
 };

--- a/packages/types/src/common/docusign.ts
+++ b/packages/types/src/common/docusign.ts
@@ -1,13 +1,28 @@
 
-export const envelopeStatuses = [
-  'sent',
-  'created',
-  'completed',
-  'delivered',
-  'voiding',
+/**
+ * docusignのステータスコード
+ * @see https://developers.docusign.com/docs/esign-rest-api/esign101/concepts/envelopes/status-codes/
+ */
+export const envelopeStatuses = [  
+  'authoritativecopy', 
+  'completed',  
+  'correct',   
+  'created',   
+  'declined',   
+  'deleted',   
+  'delivered',   
+  'sent',   
+  'signed',   
+  'template',   
+  'timedout',   
+  'transfercompleted',   
   'voided',
+
+  // custom statuses
+  'voiding',
   '',
 ] as const;
+
 
 export type TEnvelopeStatus = typeof envelopeStatuses[number];
 


### PR DESCRIPTION
## 変更

1. Docusign上で契約を編集出来るようになりました。

## 理由

1. 現状、修正する際、管理者がDocusignにログインが必要で、対象エンベロープを探すのに手間でした。今、１クリックで、編集画面に飛べるようになりました。

## テスト

- 実行方法


## 備考

- [編集出来るように条件があります](https://support.docusign.com/s/articles/FAQs-related-to-correcting-envelopes-in-DocuSign?language=ja&rsc_301)。
- 現状、契約内容は固定で、編集出来ない状態です。引き続き、https://trello.com/c/3q6bSjxD で対応しようと思います。