### PR TITLE
API追加：getContractsByProjId

### DIFF
--- a/packages/api-kintone/src/contracts/getContractsByProjId.test.ts
+++ b/packages/api-kintone/src/contracts/getContractsByProjId.test.ts
@@ -1,0 +1,16 @@
+import { getContractsByProjId } from './getContractsByProjId';
+
+describe('getContractsByProjId', () => {
+  it('projIdで契約を取得する', async () => {
+    const testProjId = 'adebcd51-aaea-4150-8b21-7373710408e2';
+    //https://rdmuhwtt6gx7.cybozu.com/k/176/#/project/edit?projId=adebcd51-aaea-4150-8b21-7373710408e2
+
+    const result = await getContractsByProjId(testProjId);
+
+    expect(result).toBeInstanceOf(Array);
+    expect(result.length).toBeGreaterThan(0);
+    expect(result[0].$id).toBeDefined();
+    
+  });
+
+});

--- a/packages/api-kintone/src/contracts/getContractsByProjId.ts
+++ b/packages/api-kintone/src/contracts/getContractsByProjId.ts
@@ -1,0 +1,10 @@
+import { RecordKey } from './config';
+import { getAllContracts } from './getAllContracts';
+
+const projIdKey : RecordKey = 'projId';
+
+export const getContractsByProjId = async (projId: string) => {
+  return getAllContracts({
+    condition: `${projIdKey} = "${projId}"`,
+  });
+};


### PR DESCRIPTION
## 変更

1. getContractsByProjIdというAPIを追加しました。

## 理由

1. 工事番号で契約の配列を取得するAPIは必要になります。

## テスト

- 単体テストあり
