### PR TITLE
工事登録画面の編集出来ない警告のリンクを修正しました。

### DIFF
--- a/packages/kokoas-client/src/components/ui/information/UneditableInfo.tsx
+++ b/packages/kokoas-client/src/components/ui/information/UneditableInfo.tsx
@@ -3,16 +3,18 @@ import { useNavigate } from 'react-router-dom';
 import { pages } from '../../../pages/Router';
 
 export const UneditableInfo = ({
-  projId, isVisible,
+  projId, 
+  projName,
+  isVisible,
 }: {
   projId?: string
+  projName?: string,
   isVisible: boolean,
 }) => {
   const navigate = useNavigate();
   return (
     <Zoom in={isVisible} unmountOnExit={true}>
-
-
+      
       <Grid item xs={12} >
 
         <Alert
@@ -30,7 +32,7 @@ export const UneditableInfo = ({
           <br />
           {projId &&
           <Button
-            onClick={()=>navigate(`${pages.projContractPreview}?projId=${projId}`)}
+            onClick={()=>navigate(`/${pages.projContractSearch}?mainSearch=${projName}`)}
             color="inherit"
             variant={'outlined'}
             size="small"

--- a/packages/kokoas-client/src/pages/projRegister/FormConstruction.tsx
+++ b/packages/kokoas-client/src/pages/projRegister/FormConstruction.tsx
@@ -28,6 +28,7 @@ export const FormConstruction  = () => {
 
   const {
     projId,
+    projName,
     storeId,
     territory,
     projTypeId,
@@ -51,14 +52,18 @@ export const FormConstruction  = () => {
           textColor='#FFF'
           secondaryLabel={projDataId}
         />
-        <Grid container item xl={8}
+        <Grid container item
           spacing={2} mb={12}
         >
           <RecordSelect />
 
           {!!projId && <LogDisplay />}
        
-          <UneditableInfo isVisible={isFormDisabled} projId={projId} />
+          <UneditableInfo 
+            projId={projId}
+            projName={projName}
+            isVisible={isFormDisabled} 
+          />
           <CustInfo />
 
           {custGroupId && (


### PR DESCRIPTION
## 変更

1. 前は旧契約画面のままに飛ぶようになっていましたが、検索画面に飛ぶようにしました。

## 理由

1. 不具合です。

## テスト

e2eテスト
- gotoContractSearch.cy.ts