### PR TITLE
自社案件の案件メンバー一括削除

### DIFF
--- a/packages/api-andpad/src/@get/getMembers.ts
+++ b/packages/api-andpad/src/@get/getMembers.ts
@@ -2,6 +2,8 @@ import axios, { AxiosError } from 'axios';
 import { ZodError } from 'zod';
 import { getToken } from '../@auth/andpadClient';
 import { endpoints } from '../endpoints';
+import { GetMembersResult, getMembersResult } from 'types';
+import { notifyAdmin } from 'libs/src/notifyAdmin';
 
 export const getMembers = async ({
   systemId,
@@ -22,8 +24,16 @@ export const getMembers = async ({
       },
     });
 
-    return data;
+    const result = getMembersResult.safeParse(data);
+
+    if (!result.success) {
+      await notifyAdmin('Andpad側でgetMembersのレスポンスの仕様が変更されています。' + JSON.stringify(result.error));
+    }
+
+    return data as GetMembersResult;
+
   } catch (err) {
+
     const {
       response,
       errors,

--- a/packages/api-andpad/src/@post/addMembers.ts
+++ b/packages/api-andpad/src/@post/addMembers.ts
@@ -13,6 +13,7 @@ import { notifyAdmin } from 'libs/src/notifyAdmin';
  * @param param
  * @param param.systemId 自社案件ID
  * @param param.members 社員番号の配列 (Kintone上の社員名簿)
+ * @param param.sendNotification trueの場合、メンバー追加時にメンバーに通知が行われる
  */
 export const addMembers = async ({
   systemId,
@@ -57,7 +58,7 @@ export const addMembers = async ({
       }
     } catch (err) {
       if (err instanceof ZodError) {
-        await notifyAdmin(`ANDPADの自社案件の案件メンバー一括登録APIのレスポンスのスキーマが変更されています。${err.message} ${JSON.stringify(data)}`);
+        await notifyAdmin(`Andpad側で自社案件の案件メンバー一括登録APIのレスポンスの仕様が変更されています。${err.message} ${JSON.stringify(data)}`);
       }
       return data as AddMembersResult201;
 

--- a/packages/api-andpad/src/@post/addMembers.ts
+++ b/packages/api-andpad/src/@post/addMembers.ts
@@ -2,27 +2,10 @@ import axios, { AxiosError } from 'axios';
 import { getToken } from '../@auth/andpadClient';
 import { endpoints } from '../endpoints';
 import { AddMembersResult201, addMembersResult201, addMembersResult207 } from 'types';
-import { sendMessage } from 'api-chatwork';
 import { ZodError } from 'zod';
-import { chatworkRooms } from 'config';
+import { ReqAddMembersBody } from '../types';
+import { notifyAdmin } from 'libs/src/notifyAdmin';
 
-interface BodySchema {
-  /** 案件管理ID利用フラグ。trueを指定した場合、パスのorder_idを案件管理IDとして扱う */
-  use_order_common_id?: boolean,
-
-  /** 案件メンバー追加が成功したユーザに案件招待のお知らせを送るかどうか。 */
-  send_notification?: boolean,
-
-  /** emailもありますが、今回はcommon_id (社員名簿のuuid) のみに固定します。 */
-  identification_type: 'common_id' 
-
-  members : Array<{
-    key: string // 社員番号
-    role: 'admin'
-    job_names?: string[]
-  }>
-
-} 
 
 /**
  * 自社案件への案件メンバー一括登録
@@ -42,7 +25,7 @@ export const addMembers = async ({
 }) => {
   try {
 
-    const body : BodySchema =  {
+    const body : ReqAddMembersBody =  {
       identification_type: 'common_id',
       send_notification: sendNotification,
       members: members.map((member) => ({
@@ -74,14 +57,11 @@ export const addMembers = async ({
       }
     } catch (err) {
       if (err instanceof ZodError) {
-        await sendMessage({
-          body: `ANDPADの案件メンバーの追加APIは変更仕様があるかもしれません。${err.message} ${JSON.stringify(data)}`,
-          roomId: chatworkRooms.test,
-        }).catch();
-        return data as AddMembersResult201;
+        await notifyAdmin(`ANDPADの自社案件の案件メンバー一括登録APIのレスポンスのスキーマが変更されています。${err.message} ${JSON.stringify(data)}`);
       }
+      return data as AddMembersResult201;
+
     }
-    
 
   } catch (err) {
     console.error(err);

--- a/packages/api-andpad/src/@post/deleteMembers.test.ts
+++ b/packages/api-andpad/src/@post/deleteMembers.test.ts
@@ -13,20 +13,23 @@ describe('addMembers', () => {
       systemId,
     });
 
-    console.log('delete members for testing.');
-    const {} = await deleteMembers({
+    
+    const delResult = await deleteMembers({
       members,
       systemId,
     });
+    console.log('deleted result:', delResult);
+
+    if ('errors' in delResult) {
+      console.log('削除済み', JSON.stringify(delResult.errors, null, 2));
+    }
 
 
-    const {} = await getMembers({
+    const { data } = await getMembers({
       systemId,
     });
 
-
-    // assert that there is a member with the given key
-    expect(result).toHaveProperty('removed_members');
+    expect(data.find((member) => member.common_id === members[0])).toBeUndefined();
 
   });
 });

--- a/packages/api-andpad/src/@post/deleteMembers.test.ts
+++ b/packages/api-andpad/src/@post/deleteMembers.test.ts
@@ -1,0 +1,32 @@
+import { getMembers } from '../@get/getMembers';
+import { addMembers } from './addMembers';
+import { deleteMembers } from './deleteMembers';
+
+describe('addMembers', () => {
+  it('should return added members', async () => {
+    const members = ['2878b722-da66-44e0-934c-3f130154bbdc'];
+    const systemId = '10776817';
+    console.log('add members for testing.');
+
+    await addMembers({
+      members,
+      systemId,
+    });
+
+    console.log('delete members for testing.');
+    const {} = await deleteMembers({
+      members,
+      systemId,
+    });
+
+
+    const {} = await getMembers({
+      systemId,
+    });
+
+
+    // assert that there is a member with the given key
+    expect(result).toHaveProperty('removed_members');
+
+  });
+});

--- a/packages/api-andpad/src/@post/deleteMembers.ts
+++ b/packages/api-andpad/src/@post/deleteMembers.ts
@@ -1,0 +1,65 @@
+import axios, { AxiosError } from 'axios';
+import { ReqDelMembersBody } from '../types';
+import { endpoints } from '../endpoints';
+import { getToken } from '../@auth/andpadClient';
+import { DelMembersResult201, delMembersResult201, delMembersResult207 } from 'types';
+import { ZodError } from 'zod';
+
+import { notifyAdmin } from 'libs/src/notifyAdmin';
+
+export const deleteMembers = async ({
+  systemId,
+  members,
+} : {
+  systemId: string,
+  members: string[],
+}) => {
+
+  try {
+
+    const body : ReqDelMembersBody = {
+      identification_type: 'common_id',
+      members: members.map((member) => ({
+        key: member,
+      })),
+    };
+    const { data, status } = await axios({
+      url: endpoints.deleteMembers(systemId),
+      method: 'DELETE',
+      headers:{
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${await getToken()}`,
+      },
+      data: body,
+    });
+
+    try {
+
+      if (status === 200) {
+        return delMembersResult201.parse(data);
+      } else if (status === 207) {
+        return delMembersResult207.parse(data);
+      } else {
+        return data as DelMembersResult201;
+      }
+    } catch (err) {
+      if (err instanceof ZodError) {
+        await notifyAdmin(`ANDPADの自社案件の案件メンバー一括削除APIのレスポンスのスキーマが変更されています。${err.message} ${JSON.stringify(data)}`);
+      }
+      return data as DelMembersResult201;
+    }
+
+  } catch (err) {
+    let errMessage = '案件メンバーの追加に失敗しました。管理者に連絡してください';
+    if (err instanceof AxiosError) {
+      const { response } = err;
+      if (response) {
+        const { status } = response;
+        errMessage = `案件メンバーの追加に失敗しました。管理者に連絡してください。${status} ${err.message}`;
+      }
+    }
+
+    throw new Error(errMessage);
+  }
+  
+};

--- a/packages/api-andpad/src/@post/deleteMembers.ts
+++ b/packages/api-andpad/src/@post/deleteMembers.ts
@@ -10,15 +10,17 @@ import { notifyAdmin } from 'libs/src/notifyAdmin';
 export const deleteMembers = async ({
   systemId,
   members,
+  idType = 'common_id',
 } : {
   systemId: string,
   members: string[],
+  idType?: 'common_id' | 'email',
 }) => {
 
   try {
 
     const body : ReqDelMembersBody = {
-      identification_type: 'common_id',
+      identification_type: idType,
       members: members.map((member) => ({
         key: member,
       })),
@@ -44,7 +46,7 @@ export const deleteMembers = async ({
       }
     } catch (err) {
       if (err instanceof ZodError) {
-        await notifyAdmin(`ANDPADの自社案件の案件メンバー一括削除APIのレスポンスのスキーマが変更されています。${err.message} ${JSON.stringify(data)}`);
+        await notifyAdmin(`Andpad側で自社案件の案件メンバー一括削除APIのレスポンスの仕様が変更されています。${err.message} ${JSON.stringify(data)}`);
       }
       return data as DelMembersResult201;
     }

--- a/packages/api-andpad/src/endpoints.ts
+++ b/packages/api-andpad/src/endpoints.ts
@@ -21,4 +21,8 @@ export const endpoints = {
 
   /** 自社案件への案件メンバー一括登録 */
   addMembers:  (systemId: string) => `${baseURL}/workman/clients/our/orders/${systemId}/members/bulk`,
+
+  /** 自社案件の案件メンバー一括削除 */
+  deleteMembers:  (systemId: string) => `${baseURL}/workman/clients/our/orders/${systemId}/members/bulk`,
+
 } as const;

--- a/packages/api-andpad/src/types.ts
+++ b/packages/api-andpad/src/types.ts
@@ -167,3 +167,30 @@ export const getMyOrdersResponse = z.object({
 
 
 export type GetMyOrdersResponse = z.infer<typeof getMyOrdersResponse>; 
+
+/** メンバー招待 */
+
+export interface ReqMemberBody {
+  /** 案件管理ID利用フラグ。trueを指定した場合、パスのorder_idを案件管理IDとして扱う */
+  use_order_common_id?: boolean,
+
+  /** emailもありますが、今回はcommon_id (社員名簿のuuid) のみに固定します。 */
+  identification_type: 'common_id' 
+
+} 
+
+export interface ReqDelMembersBody extends ReqMemberBody {
+  members : Array<{
+    key: string // 社員番号
+  }> 
+}
+
+export interface ReqAddMembersBody extends ReqMemberBody {
+  /** 案件メンバー追加が成功したユーザに案件招待のお知らせを送るかどうか。 */
+  send_notification?: boolean,
+  members : Array<{
+    key: string // 社員番号
+    role: 'admin'
+    job_names?: string[]
+  }>
+}

--- a/packages/api-andpad/src/types.ts
+++ b/packages/api-andpad/src/types.ts
@@ -175,7 +175,7 @@ export interface ReqMemberBody {
   use_order_common_id?: boolean,
 
   /** emailもありますが、今回はcommon_id (社員名簿のuuid) のみに固定します。 */
-  identification_type: 'common_id' 
+  identification_type: 'common_id' | 'email',
 
 } 
 

--- a/packages/libs/src/notifyAdmin.ts
+++ b/packages/libs/src/notifyAdmin.ts
@@ -1,0 +1,16 @@
+import { sendMessage } from 'api-chatwork';
+import { chatworkRooms } from 'config';
+
+/** Adminに通知 */
+export const notifyAdmin = async (message: string) => {
+
+  try {
+    await sendMessage({
+      body: message,
+      roomId: chatworkRooms.test,
+    });
+
+  } catch (err) {
+    console.error(`Chatwork送信にエラーが発生しました。${err.message}`);
+  }
+};

--- a/packages/types/src/common/andpad.ts
+++ b/packages/types/src/common/andpad.ts
@@ -20,9 +20,34 @@ const userSchema = z.object({
   email: z.string().email(),
 });
 
+const extendedUserSchema = userSchema
+  .and(z.object({
+    name: z.string(),
+    client: z.object({
+      id: z.number().int()
+        .nullable(),
+      name: z.string().nullable(),
+    }),
+    role: z.enum(['admin', 'basic']),
+    job_names: z.array(z.string()),
+  }));
+
 /**
  * 案件メンバー一覧取得
  */
+
+export const getMembersResult = z.object({
+  pagination: z.object({
+    //integer >= 1
+    page: z.number().int(),
+    per_page: z.number().int(),
+    last_page: z.number().int(),
+    total: z.number().int(),
+  }),
+  data: z.array(extendedUserSchema),
+});
+
+export type GetMembersResult = z.infer<typeof getMembersResult>;
 
 
 /** 

--- a/packages/types/src/common/andpad.ts
+++ b/packages/types/src/common/andpad.ts
@@ -1,38 +1,70 @@
 import { z } from 'zod';
 
-const joinedMembers = z.array(
+const errors = z.array(
   z.object({
-    user_id: z.number().int(),
-    common_id: z.string()
-      .max(190)
-      .nullable(),
-    email: z.string().email(),
+    message: z.string(),
+    item: z.object({
+      index: z.number().int(),
+      key: z.string(),
+      role: z.string().optional(),
+      job_names: z.array(z.string().max(191)).optional(),
+    }),
+      
+  }),
+);
+
+const userSchema = z.object({
+  user_id: z.number().int(),
+  common_id: z.string().max(190)
+    .nullable(),
+  email: z.string().email(),
+});
+
+/**
+ * 案件メンバー一覧取得
+ */
+
+
+/** 
+ * 自社案件への案件メンバー一括登録 
+ * */
+
+const joinedMembers = z.array(
+  userSchema.and(z.object({
+    
     name: z.string(),
     client: z.object({}),
     role: z.enum(['admin', 'basic']),
     job_names: z.array(z.string()),
-  }),
+  })),
 );
 
 export const addMembersResult201 = z.object({
   joined_members: joinedMembers,
 });
 
-export const addMembersResult207 = z.object({
-  joined_members: joinedMembers,
-  errors: z.array(
-    z.object({
-      message: z.string(),
-      item: z.object({
-        index: z.number().int(),
-        key: z.string(),
-        role: z.string().optional(),
-        job_names: z.array(z.string().max(191)).optional(),
-      }),
-      
-    }),
-  ),
-});
+export const addMembersResult207 = addMembersResult201
+  .and(z.object({
+    errors: errors,
+  }));
 
 export type AddMembersResult201 = z.infer<typeof addMembersResult201>;
 export type AddMembersResult207 = z.infer<typeof addMembersResult207>;
+
+/** 
+ * 自社案件の案件メンバー一括削除
+ * */
+
+const removedMembers = z.array(userSchema);
+
+export const delMembersResult201 = z.object({
+  removed_members: removedMembers,
+});
+
+export const delMembersResult207 = delMembersResult201
+  .and(z.object({
+    errors: errors,
+  }));
+
+export type DelMembersResult201 = z.infer<typeof delMembersResult201>;
+export type DelMembersResult207 = z.infer<typeof delMembersResult207>;


### PR DESCRIPTION
## 変更

1. deleteMembersのAPIの追加

## 理由

1. 招待で必要になるため

## テスト

- 結合テストあり
