### PR TITLE
T314 自社案件の案件メンバー情報一括更新

### DIFF
--- a/packages/api-andpad/src/@patch/updateMembers.test.ts
+++ b/packages/api-andpad/src/@patch/updateMembers.test.ts
@@ -1,0 +1,25 @@
+import { updateMembers } from './updateMembers';
+
+describe('updateMembers', () => {
+  const members = ['2878b722-da66-44e0-934c-3f130154bbdc'];
+  const systemId = '10776817';
+  it('should return updated_members', async () => {
+    const result = await updateMembers({
+      members,
+      systemId,
+    });
+    console.log(result);
+    expect(result.updated_members).toBeDefined();
+
+  });
+
+  it('should return errors for invalid members', async () => {
+    const result = await updateMembers({
+      members: ['invalid-member'],
+      systemId,
+    });
+    console.log(result);
+    expect(result).toHaveProperty('errors');
+
+  });
+});

--- a/packages/api-andpad/src/@patch/updateMembers.ts
+++ b/packages/api-andpad/src/@patch/updateMembers.ts
@@ -1,0 +1,73 @@
+import axios, { AxiosError } from 'axios';
+import { endpoints } from '../endpoints';
+import { ReqUpdateMembersBody } from '../types';
+import { getToken } from '../@auth/andpadClient';
+import { UpdateMembersResult200, updateMembersResult200, updateMembersResult207 } from 'types';
+import { ZodError } from 'zod';
+import { notifyAdmin } from 'libs/src/notifyAdmin';
+
+/** 自社案件の案件メンバー情報一括更新 */
+export const updateMembers = async ({
+  systemId,
+  members,
+  idType = 'common_id',
+}: {
+  systemId: string,
+  members: string[],
+  idType?: 'common_id' | 'email',
+}) => {
+
+  try {
+    const body : ReqUpdateMembersBody = {
+      identification_type: idType,
+      members: members.map((member) => ({
+        key: member,
+        role: 'admin',
+      })),
+    };
+
+    const { data, status } = await axios({
+      url: endpoints.updateMembers(systemId),
+      method: 'PATCH',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${await getToken()}`,
+    
+      }, 
+      data: body, 
+    });
+
+    console.log('updateMembersの結果', JSON.stringify(data, null, 2), status);
+
+
+    try {
+      if (status === 200) {
+        return updateMembersResult200.parse(data);
+      } else if (status === 207) {
+        return updateMembersResult207.parse(data);
+      } else {
+        return data as UpdateMembersResult200;
+      }
+
+    } catch (err) {
+      if (err instanceof ZodError) {
+        await notifyAdmin(`Andpad側で自社案件の案件メンバー情報一括更新APIのレスポンスの仕様が変更されています。${err.message} ${JSON.stringify(data)}`);
+      }
+    }
+
+  } catch (err) {
+    console.error(err);
+
+    if (err instanceof AxiosError) {
+      const { response } = err;
+      if (response) {
+        const { status } = response;
+        throw new Error(`案件メンバーの更新に失敗しました。管理者に連絡してください。${status} ${err.message}`);
+      }
+    }
+  }
+  
+
+
+  
+};

--- a/packages/api-andpad/src/@patch/updateMembers.ts
+++ b/packages/api-andpad/src/@patch/updateMembers.ts
@@ -45,9 +45,7 @@ export const updateMembers = async ({
         return updateMembersResult200.parse(data);
       } else if (status === 207) {
         return updateMembersResult207.parse(data);
-      } else {
-        return data as UpdateMembersResult200;
-      }
+      } 
 
     } catch (err) {
       if (err instanceof ZodError) {
@@ -55,19 +53,22 @@ export const updateMembers = async ({
       }
     }
 
-  } catch (err) {
-    console.error(err);
+    return data as UpdateMembersResult200;
 
+  } catch (err) {
+    let errMessage = '自社案件の案件メンバー情報一括更新。管理者に連絡してください';
     if (err instanceof AxiosError) {
       const { response } = err;
       if (response) {
         const { status } = response;
-        throw new Error(`案件メンバーの更新に失敗しました。管理者に連絡してください。${status} ${err.message}`);
+        errMessage = `案件メンバーの追加に失敗しました。管理者に連絡してください。${status} ${err.message}`;
       }
     }
+
+    throw new Error(errMessage);
   }
-  
-
-
-  
 };
+  
+
+
+  

--- a/packages/api-andpad/src/@post/deleteMembers.test.ts
+++ b/packages/api-andpad/src/@post/deleteMembers.test.ts
@@ -21,6 +21,7 @@ describe('addMembers', () => {
     console.log('deleted result:', delResult);
 
     if ('errors' in delResult) {
+      // 案件管理者が1人の時に案件管理者を削除することはできません。
       console.log('削除済み', JSON.stringify(delResult.errors, null, 2));
     }
 

--- a/packages/api-andpad/src/endpoints.ts
+++ b/packages/api-andpad/src/endpoints.ts
@@ -1,5 +1,7 @@
 import { baseURL } from './config';
 
+const getMembersBulkEndpoint = (systemId: string) => `${baseURL}/workman/clients/our/orders/${systemId}/members/bulk`;
+
 export const endpoints = {
   /** 認証コードの取得 */
   authCode: `${baseURL}/auth/oauth/authorize`,
@@ -20,9 +22,10 @@ export const endpoints = {
   getMembers: (systemId: string) => `${baseURL}/workman/clients/our/orders/${systemId}/members`,
 
   /** 自社案件への案件メンバー一括登録 */
-  addMembers:  (systemId: string) => `${baseURL}/workman/clients/our/orders/${systemId}/members/bulk`,
+  addMembers:  getMembersBulkEndpoint,
 
   /** 自社案件の案件メンバー一括削除 */
-  deleteMembers:  (systemId: string) => `${baseURL}/workman/clients/our/orders/${systemId}/members/bulk`,
+  deleteMembers:  getMembersBulkEndpoint,
 
+  updateMembers: getMembersBulkEndpoint,
 } as const;

--- a/packages/api-andpad/src/types.ts
+++ b/packages/api-andpad/src/types.ts
@@ -179,18 +179,25 @@ export interface ReqMemberBody {
 
 } 
 
+export interface Member {
+  key: string // 社員番号
+}
+
+export interface ExtendedMember extends Member {
+  role: 'admin' | 'basic'
+  job_names?: string[]
+}
+
 export interface ReqDelMembersBody extends ReqMemberBody {
-  members : Array<{
-    key: string // 社員番号
-  }> 
+  members : Array<Member> 
 }
 
 export interface ReqAddMembersBody extends ReqMemberBody {
   /** 案件メンバー追加が成功したユーザに案件招待のお知らせを送るかどうか。 */
   send_notification?: boolean,
-  members : Array<{
-    key: string // 社員番号
-    role: 'admin'
-    job_names?: string[]
-  }>
+  members : Array<ExtendedMember>
 }
+
+export interface ReqUpdateMembersBody extends ReqMemberBody {
+  members : Array<ExtendedMember>
+} 

--- a/packages/types/src/common/andpad.ts
+++ b/packages/types/src/common/andpad.ts
@@ -23,13 +23,17 @@ const userSchema = z.object({
 const extendedUserSchema = userSchema
   .and(z.object({
     name: z.string(),
+    role: z.enum(['admin', 'basic']),
+    job_names: z.array(z.string()),
+  }));
+
+const extendedUserSchemaWithClient = extendedUserSchema
+  .and(z.object({
     client: z.object({
       id: z.number().int()
         .nullable(),
       name: z.string().nullable(),
     }),
-    role: z.enum(['admin', 'basic']),
-    job_names: z.array(z.string()),
   }));
 
 /**
@@ -44,7 +48,7 @@ export const getMembersResult = z.object({
     last_page: z.number().int(),
     total: z.number().int(),
   }),
-  data: z.array(extendedUserSchema),
+  data: z.array(extendedUserSchemaWithClient),
 });
 
 export type GetMembersResult = z.infer<typeof getMembersResult>;
@@ -93,3 +97,22 @@ export const delMembersResult207 = delMembersResult201
 
 export type DelMembersResult201 = z.infer<typeof delMembersResult201>;
 export type DelMembersResult207 = z.infer<typeof delMembersResult207>;
+
+
+/** 
+ * 自社案件の案件メンバー情報一括更新 
+ * */
+
+const updatedMembers = z.array(extendedUserSchema);
+
+export const updateMembersResult200 = z.object({
+  updated_members: updatedMembers,
+});
+
+export const updateMembersResult207 = updateMembersResult200
+  .and(z.object({
+    errors: errors,
+  }));
+
+export type UpdateMembersResult200 = z.infer<typeof updateMembersResult200>;
+export type UpdateMembersResult207 = z.infer<typeof updateMembersResult207>;

--- a/packages/types/src/common/andpad.ts
+++ b/packages/types/src/common/andpad.ts
@@ -22,7 +22,7 @@ const userSchema = z.object({
 
 const extendedUserSchema = userSchema
   .and(z.object({
-    name: z.string(),
+    name: z.string().optional(),
     role: z.enum(['admin', 'basic']),
     job_names: z.array(z.string()),
   }));


### PR DESCRIPTION
## 変更

1. updateMembersを追加しました。

## 理由

1. AndpadのAPI

## テスト

- 結合テストありますが、網羅的じゃない。必要に応じて更新。
