### PR TITLE
hotfix-契約画面-チェックボックスにDBから状態を反映しない現象を改修しました。

### DIFF
--- a/packages/kokoas-client/src/pages/projContractV2/parts/RefundAmount.tsx
+++ b/packages/kokoas-client/src/pages/projContractV2/parts/RefundAmount.tsx
@@ -7,7 +7,7 @@ export const RefundAmount = () => {
   const { 
     control, 
     register,  
-    resetField,
+    setValue,
     getFieldState, 
   } = useFormContext<TypeOfForm>();
 
@@ -22,13 +22,14 @@ export const RefundAmount = () => {
         label={'返金額'}
         control={(
           <Checkbox
+            checked={isChecked}
             {...register('hasRefund', {
               onChange: (e) => {
                 if (!e.target.checked) {
                   // チェックを外したら、エラーがあればクリアする
                   const { error } = getFieldState('refundAmt');
                   if (error) {
-                    resetField('refundAmt');
+                    setValue('refundAmt', 0);
                   }
                 }
               },

--- a/packages/kokoas-client/src/pages/projContractV2/parts/SubsidyAmount.tsx
+++ b/packages/kokoas-client/src/pages/projContractV2/parts/SubsidyAmount.tsx
@@ -16,6 +16,7 @@ export const SubsidyAmount = () => {
         label={'補助金'}
         control={(
           <Checkbox
+            checked={isChecked}
             {...register('hasSubsidy', {
               onChange: (e) => {
                 if (!e.target.checked) {


### PR DESCRIPTION
## 変更

1. チェックボックスにcheckedのpropを設定するように。

## 理由

1. RFHのregisterはcontrolledのフィールドに初期値反映しないため。
