### PR TITLE
工事画面のログを下に配置

### DIFF
--- a/packages/kokoas-client/src/pages/projRegister/FormConstruction.tsx
+++ b/packages/kokoas-client/src/pages/projRegister/FormConstruction.tsx
@@ -56,8 +56,6 @@ export const FormConstruction  = () => {
 
         <ExternalLinks />
 
-        {!!projId && <LogDisplay />}
-
         <UneditableInfo 
           projId={projId}
           projName={projName}
@@ -74,13 +72,17 @@ export const FormConstruction  = () => {
             projTypeId={projTypeId}
           />
           <Remarks />
+
+                  
+          {!!projId && <LogDisplay />}
               
           {isEditMode && <StatusControls />}
 
         </>
         )}
 
-        
+
+
         <FabSave onClick={submitForm} url="project" appear={!!custGroupId && dirty} />
       </MainContainer>
 


### PR DESCRIPTION
## 変更

1. 工事画面のログを下に配置

## 理由

1. https://trello.com/c/UQClz76w

