### PR TITLE
hotfix-契約書の生成：契約人数に合わせて、「印」マークを設ける。

### DIFF
--- a/packages/kokoas-client/src/api/docusign/downloadContract.ts
+++ b/packages/kokoas-client/src/api/docusign/downloadContract.ts
@@ -12,7 +12,7 @@ export const downloadContract = async ({
 
   const queryStr = qs.stringify({
     contractId,
-    ukeoiDocVersion: '20230501',
+    ukeoiDocVersion: '20230523',
   });
 
   const apiNode: ApiNodes = 'docusign';

--- a/packages/kokoas-client/src/pages/projContractV2/parts/preview/startcontract/StartDialog.tsx
+++ b/packages/kokoas-client/src/pages/projContractV2/parts/preview/startcontract/StartDialog.tsx
@@ -32,7 +32,7 @@ export const StartDialog = ({
 
   const handleSendContract = async () => {
     const contractId = getValues('contractId') as string;
-    await mutateAsync({ contractId, signMethod: method, ukeoiDocVersion: '20230501' });
+    await mutateAsync({ contractId, signMethod: method, ukeoiDocVersion: '20230523' });
 
     handleClose();
   };

--- a/packages/kokoas-server/src/handleRequest/reqDownloadContractV2.ts
+++ b/packages/kokoas-server/src/handleRequest/reqDownloadContractV2.ts
@@ -25,7 +25,7 @@ ReqDownloadContractParams
     const contractData = await getContractDataV2({
       contractId,
       signMethod: 'electronic',
-      ukeoiDocVersion: '20230501',
+      ukeoiDocVersion: ukeoiDocVersion,
     });
 
     const {

--- a/packages/kokoas-server/src/handleRequest/reqSendContractDirectV2/generateContractPdfV2.test.ts
+++ b/packages/kokoas-server/src/handleRequest/reqSendContractDirectV2/generateContractPdfV2.test.ts
@@ -7,13 +7,13 @@ import { generateContractPdfV2 } from './generateContractPdfV2';
 describe('Contract', () => {
   it('should generate contract in pdf', async () =>{
     const contractData = await getContractDataV2({
-      contractId: '12128397-14e7-47d5-90b6-f8b655b39988',
+      contractId: '1de692dc-de27-4001-b946-50e9bbb35b8c',
       signMethod: 'electronic',
-      ukeoiDocVersion: '20230501',
+      ukeoiDocVersion: '20230523',
     });
 
     console.log(contractData);
-    const pdf = await generateContractPdfV2(contractData, 'Uint8Array ');
+    const pdf = await generateContractPdfV2(contractData, 'Uint8Array ', '20230523');
     const savePath = path.join(__dirname, '__TEST__', 'ukeoiV2.test.pdf');
 
     await fsPromise.writeFile(savePath, pdf);

--- a/packages/kokoas-server/src/handleRequest/reqSendContractDirectV2/generateContractPdfV2.ts
+++ b/packages/kokoas-server/src/handleRequest/reqSendContractDirectV2/generateContractPdfV2.ts
@@ -160,7 +160,24 @@ export const generateContractPdfV2 = async (
       weight: 0.1,
     },
   );
-  // drawCustAddress(customers, x2, firstPage, msChinoFont);
+  
+  // 印の位置
+  const signWidth = 240;
+  const signGap = signWidth / 2;
+
+  customers.forEach((_, idx) => {
+    const signX = x2 + (signGap * (idx + 1));
+  
+    drawText(
+      firstPage,
+      '印',
+      {
+        x: signX,
+        y: 225,
+        font: msChinoFont,
+      },
+    );
+  });
 
   // 工事場所
   drawText(
@@ -408,6 +425,10 @@ export const generateContractPdfV2 = async (
       weight: 0.1,
     },
   );
+
+  // サイン印
+  
+
 
   // 担当者名
   drawText(

--- a/packages/kokoas-server/src/handleRequest/reqSendContractDirectV2/generateContractPdfV2.ts
+++ b/packages/kokoas-server/src/handleRequest/reqSendContractDirectV2/generateContractPdfV2.ts
@@ -163,7 +163,7 @@ export const generateContractPdfV2 = async (
   
   // 印の位置
   const signWidth = 240;
-  const signGap = signWidth / 2;
+  const signGap = signWidth / customers.length;
 
   customers.forEach((_, idx) => {
     const signX = x2 + (signGap * (idx + 1));
@@ -175,6 +175,20 @@ export const generateContractPdfV2 = async (
         x: signX,
         y: 225,
         font: msChinoFont,
+      },
+    );
+
+    drawText(
+      firstPage,
+      `c${idx + 1}`,
+      {
+        x: signX - 40,
+        y: 225,
+        font: msChinoFont,
+        color: grayscale(0.96), // 白に近い色
+      },
+      {
+        weight: 0.1,
       },
     );
   });

--- a/packages/kokoas-server/src/handleRequest/reqSendContractDirectV2/getContractDataV2.test.ts
+++ b/packages/kokoas-server/src/handleRequest/reqSendContractDirectV2/getContractDataV2.test.ts
@@ -5,7 +5,7 @@ describe('Contract', () => {
     const result = await getContractDataV2({
       contractId: '12128397-14e7-47d5-90b6-f8b655b39988',
       signMethod: 'electronic',
-      ukeoiDocVersion: '20230501',
+      ukeoiDocVersion: '20230523',
     });
 
     console.log(result);

--- a/packages/kokoas-server/src/handleRequest/reqSendContractDirectV2/processContractV2.test.ts
+++ b/packages/kokoas-server/src/handleRequest/reqSendContractDirectV2/processContractV2.test.ts
@@ -13,7 +13,7 @@ it('should porcess contract', async () => {
     {
       contractId: '12128397-14e7-47d5-90b6-f8b655b39988',
       signMethod: 'electronic',
-      ukeoiDocVersion: '20230501',
+      ukeoiDocVersion: '20230523',
     },
     'sent',
   ).catch((e) => {

--- a/packages/kokoas-server/src/handleRequest/webhookDocusign/handleTriggers.ts
+++ b/packages/kokoas-server/src/handleRequest/webhookDocusign/handleTriggers.ts
@@ -36,6 +36,7 @@ export const handleTriggers: RequestHandler = async (req, res) =>{
       case 'envelope-voided':
       case 'envelope-deleted':
       case 'envelope-discard':
+      case 'envelope-declined':
         await voidEnvelope(data.envelopeId);
         break;
       // case 'envelope-sent':


### PR DESCRIPTION
## 変更

1. 契約書の生成：契約人数に合わせて、「印」マークを並べて配置。

### ３人

![image](https://github.com/Lorenzras/yumecoco-monorepo/assets/2501255/fbc76719-cb33-47e6-872f-c901375145a2)

### ２人

![image](https://github.com/Lorenzras/yumecoco-monorepo/assets/2501255/9513c16a-f809-4f8b-bb25-ffaba6eca7fe)

### 一人

![image](https://github.com/Lorenzras/yumecoco-monorepo/assets/2501255/942e239a-4cdc-4edf-89ad-dd1957238fa5)


## 理由

1. 店長から依頼

## テスト

- 20230523のファイルのバージョンでgenerateContractPDFV2の結合テストあり。
