### PR TITLE
hotfix-印は紙契約のみ

### DIFF
--- a/packages/kokoas-server/src/handleRequest/reqSendContractDirectV2/generateContractPdfV2.test.ts
+++ b/packages/kokoas-server/src/handleRequest/reqSendContractDirectV2/generateContractPdfV2.test.ts
@@ -8,7 +8,7 @@ describe('Contract', () => {
   it('should generate contract in pdf', async () =>{
     const contractData = await getContractDataV2({
       contractId: '1de692dc-de27-4001-b946-50e9bbb35b8c',
-      signMethod: 'electronic',
+      signMethod: 'wetInk',
       ukeoiDocVersion: '20230523',
     });
 

--- a/packages/kokoas-server/src/handleRequest/reqSendContractDirectV2/generateContractPdfV2.test.ts
+++ b/packages/kokoas-server/src/handleRequest/reqSendContractDirectV2/generateContractPdfV2.test.ts
@@ -1,23 +1,44 @@
-import fsPromise from 'fs/promises';
 import fs from 'fs';
+import fsPromise from 'fs/promises';
 import path from 'path';
 import { getContractDataV2 } from 'kokoas-server/src/handleRequest/reqSendContractDirectV2/getContractDataV2';
 import { generateContractPdfV2 } from './generateContractPdfV2';
+import { TSignMethod } from 'types';
 
 describe('Contract', () => {
-  it('should generate contract in pdf', async () =>{
+  const contractId = '1de692dc-de27-4001-b946-50e9bbb35b8c';
+  const ukeoiDocVersion = '20230523';
+  
+
+  const generateAndSavePdf = async (
+    signMethod: TSignMethod,
+  ): Promise<string> => {
     const contractData = await getContractDataV2({
-      contractId: '1de692dc-de27-4001-b946-50e9bbb35b8c',
-      signMethod: 'wetInk',
-      ukeoiDocVersion: '20230523',
+      contractId,
+      signMethod,
+      ukeoiDocVersion,
     });
 
     console.log(contractData);
-    const pdf = await generateContractPdfV2(contractData, 'Uint8Array ', '20230523');
-    const savePath = path.join(__dirname, '__TEST__', 'ukeoiV2.test.pdf');
+
+    const pdf = await generateContractPdfV2(contractData, 'Uint8Array ', ukeoiDocVersion);
+    const savePath = path.join(__dirname, '__TEST__', `ukeoiV2_${signMethod}.test.pdf`);
 
     await fsPromise.writeFile(savePath, pdf);
+    return savePath;
+  };
 
-    expect(fs.existsSync(savePath)).toBe(true);
+  const checkPdfExists = async (savePath: string): Promise<boolean> => {
+    return fs.existsSync(savePath);
+  };
+
+  it('should generate wetink contract in pdf', async () => {
+    const savePath = await generateAndSavePdf('wetInk');
+    expect(await checkPdfExists(savePath)).toBe(true);
+  }, 60000);
+
+  it('should generate electronic contract in pdf', async () => {
+    const savePath = await generateAndSavePdf('electronic');
+    expect(await checkPdfExists(savePath)).toBe(true);
   }, 60000);
 });

--- a/packages/kokoas-server/src/handleRequest/reqSendContractDirectV2/generateContractPdfV2.ts
+++ b/packages/kokoas-server/src/handleRequest/reqSendContractDirectV2/generateContractPdfV2.ts
@@ -52,6 +52,8 @@ export const generateContractPdfV2 = async (
     companyName,
     companyTel,
     representative,
+
+    signMethod,
   } = contractData;
 
   const {
@@ -167,16 +169,17 @@ export const generateContractPdfV2 = async (
 
   customers.forEach((_, idx) => {
     const signX = x2 + (signGap * (idx + 1));
-  
-    drawText(
-      firstPage,
-      '印',
-      {
-        x: signX,
-        y: 225,
-        font: msChinoFont,
-      },
-    );
+    if (signMethod === 'wetInk') {
+      drawText(
+        firstPage,
+        '印',
+        {
+          x: signX,
+          y: 225,
+          font: msChinoFont,
+        },
+      );
+    }
 
     drawText(
       firstPage,


### PR DESCRIPTION
## 変更

前はどのサインの手法でも、印が生成されていました。

### 紙契約
![image](https://github.com/Lorenzras/yumecoco-monorepo/assets/2501255/d5f9a9d1-93e9-4ff7-a07d-e4cb7628435d)

### 電子契約

![image](https://github.com/Lorenzras/yumecoco-monorepo/assets/2501255/3f727049-b85d-4c05-bf56-ac266f18e7a2)

## 理由

1. 高橋さんから依頼。

## テスト

- generateContractPdfV2.test.ts
