### PR TITLE
hotfix-契約書類の顧客署名欄の「印」をなくし、「署名」を追加する。

### DIFF
--- a/packages/kokoas-server/src/handleRequest/reqSendContractDirectV2/generateContractPdfV2.test.ts
+++ b/packages/kokoas-server/src/handleRequest/reqSendContractDirectV2/generateContractPdfV2.test.ts
@@ -12,12 +12,21 @@ describe('Contract', () => {
       ukeoiDocVersion: '20230523',
     });
 
-    console.log(contractData);
-    const pdf = await generateContractPdfV2(contractData, 'Uint8Array ', '20230523');
-    const savePath = path.join(__dirname, '__TEST__', 'ukeoiV2.test.pdf');
-
-    await fsPromise.writeFile(savePath, pdf);
-
-    expect(fs.existsSync(savePath)).toBe(true);
+    
+    for (let i = 1; i <= 3 ; i++) {
+      // limit number of customers based on i
+      const mockData : Awaited<ReturnType<typeof getContractDataV2>> = {
+        ...contractData,
+        customers: contractData.customers.slice(0, i),
+      };
+      const pdf = await generateContractPdfV2(mockData, 'Uint8Array ', '20230523');
+      const savePath = path.join(__dirname, '__TEST__', `ukeoi_custcount_${i}.pdf`);
+      await fsPromise.writeFile(savePath, pdf);
+      expect(fs.existsSync(savePath)).toBe(true);
+    }
+   
   }, 60000);
+
+
+  
 });

--- a/packages/kokoas-server/src/handleRequest/reqSendContractDirectV2/generateContractPdfV2.ts
+++ b/packages/kokoas-server/src/handleRequest/reqSendContractDirectV2/generateContractPdfV2.ts
@@ -166,13 +166,28 @@ export const generateContractPdfV2 = async (
   const signGap = signWidth / customers.length;
 
   customers.forEach((_, idx) => {
-    const signX = x2 + (signGap * (idx + 1));
+    const signX = x2 + (signGap * idx);
+  
+    drawText(
+      firstPage,
+      '署名',
+      {
+        x: signX,
+        y: 225,
+        font: msChinoFont,
+        size: 8,
+        color: grayscale(0.7), // 白に近い色
+      },
+      {
+        weight: 0.1,
+      },
+    );
 
     drawText(
       firstPage,
       `c${idx + 1}`,
       {
-        x: signX - 40,
+        x: signX + 40,
         y: 225,
         font: msChinoFont,
         color: grayscale(0.96), // 白に近い色

--- a/packages/kokoas-server/src/handleRequest/reqSendContractDirectV2/generateContractPdfV2.ts
+++ b/packages/kokoas-server/src/handleRequest/reqSendContractDirectV2/generateContractPdfV2.ts
@@ -167,16 +167,6 @@ export const generateContractPdfV2 = async (
 
   customers.forEach((_, idx) => {
     const signX = x2 + (signGap * (idx + 1));
-  
-    drawText(
-      firstPage,
-      '印',
-      {
-        x: signX,
-        y: 225,
-        font: msChinoFont,
-      },
-    );
 
     drawText(
       firstPage,


### PR DESCRIPTION
## 変更

1. 契約書類の顧客署名欄に「印」を生成しなくなりました。変わりに「署名」を生成する。

## 理由

1. 店長が高橋さんに確認して、印の生成の要件の撤回の依頼が来ました。署名は紙でも電子でも、関係なく「印」が不要だそうです。

## テスト

- generateContractPdfV2.test.ts
