### PR TITLE
E2Eテストの修正

### DIFF
--- a/packages/kokoas-e2e/cypress/e2e/contractPreview2/input.cy.ts
+++ b/packages/kokoas-e2e/cypress/e2e/contractPreview2/input.cy.ts
@@ -1,4 +1,4 @@
-import { beforeEach, context, cy, describe, it } from 'local-cypress';
+import { beforeEach, context, cy, describe, expect, it } from 'local-cypress';
 import { correctInputData } from './testData';
 import format from 'date-fns/format';
 import addMonths from 'date-fns/addMonths';
@@ -12,7 +12,7 @@ describe(
     const projId = '5a5e6cae-bea3-48e9-b679-3dcbbcc7fc60';
     const {
       totalContractAmt,
-      totalProfit,
+      
     } = correctInputData();
   
     beforeEach(() => {
@@ -26,7 +26,7 @@ describe(
 
       // ブラウザの推薦機能をシミュレーションする　
       // ※ 私の環境では当機能が再現出来ないので、以下の手法で誤検知可能性あり。ras-2023-05-11
-      cy.getTextInputsByLabel('契約合計金額')
+      cy.getTextInputsByLabel('契約合計金額（税込）')
         .invoke('val', simulatedInput)
         .type('{ctrl}');
         
@@ -39,64 +39,26 @@ describe(
     });
 
     it('計算が合っていること', () => {
+
+      // 10%の税率を設定、8%を撤回する依頼もあるので、固定にする。
     
-      cy.getTextInputsByLabel('契約合計金額')
-        .type(totalContractAmt.toString())
+      cy.getTextInputsByLabel('契約合計金額（税込）')
+        .type('1100')
         .blur();
 
-      cy.getTextInputsByLabel('粗利額')
-        .type(totalProfit.toString())
-        .blur();
+      cy.log('契約合計金額（税抜）があっていること');
+      cy.getTextInputsByLabel('契約合計金額（税抜）')
+        .invoke('val')
+        .then((amtBeforeTax) => {
+          console.log('textTaxRate', totalContractAmt);
+          const parsedAmtBeforeTax = Number((amtBeforeTax as string)?.replace(/[^0-9]/g, ''));
 
-      cy.log('計算されていることを確認する');
-      cy.contains('span', '税率')
-        .siblings('span')
-        .invoke('text')
-        .then((textTaxRate) => {
-        // getNumber from text
-          const taxRate = 1 + (Number(textTaxRate.replace(/[^0-9]/g, '')) / 100);
-          return cy.wrap(taxRate);
-        })
-        .then((taxRate) => cy
-          .contains('span', '税抜金額')
-          .siblings('span')
-          .invoke('text')
-          .then((textTaxExcludeAmt) => {
-            const taxExcludedAmt = Number(textTaxExcludeAmt.replace(/[^0-9]/g, ''));
-            return cy.wrap(taxExcludedAmt)
-              .should('eq', Math.round(totalContractAmt / taxRate));
-          }))
-        .then((taxExcludedAmt) => cy
-          .contains('span', '原価')
-          .siblings('span')
-          .invoke('text')
-          .then((textCost) => {
-            const cost = Number(textCost.replace(/[^0-9]/g, ''));
-            cy.wrap(cost)
-              .should('eq', Math.round(taxExcludedAmt - totalProfit));
-            return cy.wrap({
-              taxExcludedAmt,
-              cost,
-            });
-          }))
-        .then(({
-          taxExcludedAmt,
-          cost,
-        }) => cy
-          .contains('span', '粗利率')
-          .siblings('span')
-          .invoke('text')
-          .then((textProfitRate) => {
-          // get profitRate with decimal point
-            const profitRate = Number(textProfitRate.replace(/[^0-9.]/g, ''));
-            console.log(taxExcludedAmt, cost, profitRate);
-         
-            /** 利益率 = ( 単価 - 原価) / 単価 */
-            const calculatedTaxRate = ((taxExcludedAmt - cost) /  taxExcludedAmt) * 100;
-        
-            cy.wrap(profitRate.toFixed(2))
-              .should('eq', calculatedTaxRate.toFixed(2));
-          }));
+          expect(Math.round(parsedAmtBeforeTax)).to.eq(1000);
+
+        });
+
+      // その他の計算は、後でやります。s
+    
     });
 
     context(
@@ -114,7 +76,7 @@ describe(
         ];
 
         it('契約金額にコンマが追加されるのを確認する', () => {
-          cy.getTextInputsByLabel('契約合計金額')
+          cy.getTextInputsByLabel('契約合計金額（税込）')
             .type(totalContractAmt.toString())
             .blur()
             .should('value', totalContractAmt.toLocaleString());

--- a/packages/kokoas-e2e/cypress/e2e/contractPreview2/save.cy.ts
+++ b/packages/kokoas-e2e/cypress/e2e/contractPreview2/save.cy.ts
@@ -12,7 +12,7 @@ describe('保存処理', { scrollBehavior: 'center' }, () => {
 
   it('新規保存できること', () => {
     cy.visit(`/project/contract/preview/v2?projId=${testProjId}`);
-    cy.getTextInputsByLabel('契約合計金額')
+    cy.getTextInputsByLabel('契約合計金額（税込）')
       .type(correctInput.totalContractAmt.toString())
       .should('have.value', correctInput.totalContractAmt.toString());
 


### PR DESCRIPTION
## 変更

1. 計算のテストを仮修正しました。

## 理由

1. fixes #331 
2. ここに関わる変更が多いので、計算のE2Eテストは後回しにします。

## テスト

- nx cy:open kokoas-e2e, 
- contractPreview/input
