### PR TITLE
入力の前にクリアする

### DIFF
--- a/packages/kokoas-e2e/cypress/e2e/prospect/input.cy.ts
+++ b/packages/kokoas-e2e/cypress/e2e/prospect/input.cy.ts
@@ -27,6 +27,7 @@ describe('見込み管理：入力', () => {
           .focus();
 
         cy.get('@contractAmtField')
+          .clear()
           .type(testVal, { delay: 100 });
 
         cy.get('@contractAmtField').blur();


### PR DESCRIPTION
## 変更

1. 入力の前にクリアする

## 理由

1. fixes #334 

## テスト

- nx cy:open kokoas-e2e
prospects/input.cy.ts