### PR TITLE
349 契約画面の登録で小数点以下を見たくない 

### DIFF
--- a/packages/kokoas-client/src/pages/projContractV2/api/convertContractToForm.ts
+++ b/packages/kokoas-client/src/pages/projContractV2/api/convertContractToForm.ts
@@ -1,7 +1,7 @@
 import { parseKintoneDate } from 'kokoas-client/src/lib';
 import { IContracts } from 'types';
 import { TypeOfForm } from '../schema';
-import { calculateAmount } from 'libs';
+import { calculateAmount, roundTo } from 'libs';
 
 export const convertContractToForm = (
   contract: IContracts,
@@ -68,12 +68,12 @@ export const convertContractToForm = (
     contractId: uuid.value,
     projId: projId.value,
 
-    totalContractAmtAfterTax: +totalContractAmt.value,
-    totalProfit: +totalProfit.value,
+    totalContractAmtAfterTax: roundTo(+totalContractAmt.value),
+    totalProfit: roundTo(+totalProfit.value),
     taxRate: +tax.value,
-    profitRate: +(profitRate || 0) * 100,
-    totalContractAmtBeforeTax: +(amountBeforeTax || 0),
-    costPrice: +(costPrice || 0),
+    profitRate: roundTo(+(profitRate || 0) * 100, 2),
+    totalContractAmtBeforeTax: roundTo(+(amountBeforeTax || 0)),
+    costPrice: roundTo(+(costPrice || 0)),
     
 
     hasContractAmt: !!+contractAmt.value,

--- a/packages/kokoas-client/src/pages/projContractV2/fields/ControlledCurrencyInput.tsx
+++ b/packages/kokoas-client/src/pages/projContractV2/fields/ControlledCurrencyInput.tsx
@@ -1,8 +1,9 @@
-import { Controller, useFormContext } from 'react-hook-form';
+import { Controller } from 'react-hook-form';
 import { TypeOfForm } from '../schema';
 import { NumberCommaField } from 'kokoas-client/src/components/ui/textfield/NumberCommaField';
 import { TextFieldProps } from '@mui/material';
 import { calculateAmount } from 'libs';
+import { useFormContextExtended } from '../hooks/useFormContextExtended';
 
 
 export const ControlledCurrencyInput = ({
@@ -20,7 +21,11 @@ export const ControlledCurrencyInput = ({
 }) => {
 
 
-  const { control, getValues, setValue } = useFormContext<TypeOfForm>();
+  const {
+    setRoundedValue,
+    control,
+    getValues,
+  } = useFormContextExtended();
 
   return (
     <Controller
@@ -68,9 +73,9 @@ export const ControlledCurrencyInput = ({
                     profitRate,
                   });
 
-                  setValue('totalContractAmtBeforeTax', amountBeforeTax || 0);
-                  setValue('totalProfit', profit || 0);
-                  setValue('costPrice', costPrice || 0);
+                  setRoundedValue('totalContractAmtBeforeTax', amountBeforeTax);
+                  setRoundedValue('totalProfit', profit);
+                  setRoundedValue('costPrice', costPrice);
                   break;
                 }
                 case 'totalContractAmtBeforeTax': {
@@ -85,9 +90,9 @@ export const ControlledCurrencyInput = ({
                     profitRate,
                   });
 
-                  setValue('totalContractAmtAfterTax', amountAfterTax || 0);
-                  setValue('totalProfit', profit || 0);
-                  setValue('costPrice', costPrice || 0);
+                  setRoundedValue('totalContractAmtAfterTax', amountAfterTax);
+                  setRoundedValue('totalProfit', profit);
+                  setRoundedValue('costPrice', costPrice);
                   break;
                 }
                 case 'totalProfit': {
@@ -101,9 +106,9 @@ export const ControlledCurrencyInput = ({
                     profit: parsedValue,
                     taxRate,
                   });
-                  setValue('totalContractAmtBeforeTax', amountBeforeTax || 0);
-                  setValue('profitRate', (profitRate || 0) * 100);
-                  setValue('costPrice', costPrice || 0);
+                  setRoundedValue('totalContractAmtBeforeTax', amountBeforeTax);
+                  setRoundedValue('costPrice', costPrice);
+                  setRoundedValue('profitRate', profitRate * 100, 2);
                   break;
                 }
                 case 'costPrice' : {
@@ -118,9 +123,9 @@ export const ControlledCurrencyInput = ({
                     taxRate,
                   });
 
-                  setValue('totalContractAmtBeforeTax', amountBeforeTax || 0);
-                  setValue('profitRate', (profitRate || 0) * 100);
-                  setValue('totalProfit', profit || 0);
+                  setRoundedValue('totalContractAmtBeforeTax', amountBeforeTax || 0);
+                  setRoundedValue('totalProfit', profit || 0);
+                  setRoundedValue('profitRate', profitRate * 100, 2);
                 }
               }
 

--- a/packages/kokoas-client/src/pages/projContractV2/fields/ProfitRate.tsx
+++ b/packages/kokoas-client/src/pages/projContractV2/fields/ProfitRate.tsx
@@ -42,12 +42,11 @@ export const ProfitRate = ({
             variant={'outlined'}
             type='number'
             onChange={(e) => {
-             
-
               const profitRate = +e.target.value;
-             
+              onChange(e.target.value);
+
               if (!isNaN(profitRate)) {
-                onChange(profitRate);
+                
                 const totalContractAmtAfterTax = getValues('totalContractAmtAfterTax');
                 const taxRate = getValues('taxRate');
 

--- a/packages/kokoas-client/src/pages/projContractV2/fields/ProfitRate.tsx
+++ b/packages/kokoas-client/src/pages/projContractV2/fields/ProfitRate.tsx
@@ -1,14 +1,19 @@
-import { Controller, useFormContext } from 'react-hook-form';
-import { TypeOfForm } from '../schema';
+import { Controller } from 'react-hook-form';
 import { InputAdornment, TextField } from '@mui/material';
 import { calculateAmount } from 'libs';
+import { useFormContextExtended } from '../hooks/useFormContextExtended';
 
 export const ProfitRate = ({
   disabled,
 }: {
   disabled: boolean,
 }) => {
-  const { control, setValue, getValues } = useFormContext<TypeOfForm>();
+
+  const {
+    setRoundedValue,
+    control,
+    getValues,
+  } = useFormContextExtended();
 
   return (
     <Controller
@@ -56,9 +61,9 @@ export const ProfitRate = ({
                   profitRate: profitRate / 100,
                 });
 
-                setValue('totalContractAmtBeforeTax', amountBeforeTax || 0);
-                setValue('totalProfit', profit || 0);
-                setValue('costPrice', costPrice || 0);
+                setRoundedValue('totalContractAmtBeforeTax', amountBeforeTax || 0);
+                setRoundedValue('totalProfit', profit || 0);
+                setRoundedValue('costPrice', costPrice || 0);
               }
              
             }}

--- a/packages/kokoas-client/src/pages/projContractV2/fields/TaxRate.tsx
+++ b/packages/kokoas-client/src/pages/projContractV2/fields/TaxRate.tsx
@@ -1,7 +1,7 @@
 import { FormControl, FormControlLabel, FormLabel, Radio, RadioGroup } from '@mui/material';
-import { Controller, useFormContext } from 'react-hook-form';
-import { TypeOfForm } from '../schema';
+import { Controller } from 'react-hook-form';
 import { calculateAmount } from 'libs';
+import { useFormContextExtended } from '../hooks/useFormContextExtended';
 
 const taxRates = [
   {
@@ -16,7 +16,7 @@ const taxRates = [
 
 export const TaxRate = () => {
 
-  const { control, setValue, getValues } = useFormContext<TypeOfForm>();
+  const { control, setRoundedValue, getValues } = useFormContextExtended();
 
   return (
     <Controller
@@ -54,8 +54,8 @@ export const TaxRate = () => {
                   profitRate: profitRate / 100,
                 });
 
-                setValue('totalContractAmtBeforeTax', amountBeforeTax || 0);
-                setValue('totalProfit', profit || 0);
+                setRoundedValue('totalContractAmtBeforeTax', amountBeforeTax || 0);
+                setRoundedValue('totalProfit', profit || 0);
 
               }}
             >

--- a/packages/kokoas-client/src/pages/projContractV2/hooks/useFormContextExtended.ts
+++ b/packages/kokoas-client/src/pages/projContractV2/hooks/useFormContextExtended.ts
@@ -1,0 +1,27 @@
+import { useFormContext } from 'react-hook-form';
+import { TypeOfForm } from '../schema';
+import { useCallback } from 'react';
+import { KeyOfForm } from '../form';
+import { roundTo } from 'libs';
+
+export const useFormContextExtended = () => {
+  const formMethods = useFormContext<TypeOfForm>();
+
+  const { setValue } = formMethods;
+
+  const setRoundedValue = useCallback(
+    (key: KeyOfForm, value = 0, precision = 0) => {
+      setValue(
+        key, 
+        roundTo(value, precision),
+      );
+    }, 
+    [setValue],
+  );
+
+  return {
+    ...formMethods,
+    setRoundedValue,
+  };
+
+};

--- a/packages/kokoas-e2e/cypress/e2e/contractPreview2/testData.ts
+++ b/packages/kokoas-e2e/cypress/e2e/contractPreview2/testData.ts
@@ -1,6 +1,6 @@
 // import faker
 import { faker } from '@faker-js/faker';
-import { calculateAmount } from 'libs';
+import { calculateAmount, Values } from 'libs';
 
 
 
@@ -19,7 +19,7 @@ export const inputData = calculateAmount({
   profit: 1000,
 });
 
-export const labelMap: Record<keyof typeof inputData, string> = {
+export const labelMap: Record<keyof Values, string> = {
   amountAfterTax: '契約合計金額（税込）',
   amountBeforeTax: '契約合計金額（税抜）',
   profit: '粗利額 （税抜）',

--- a/packages/kokoas-e2e/cypress/e2e/contractPreview2/testData.ts
+++ b/packages/kokoas-e2e/cypress/e2e/contractPreview2/testData.ts
@@ -1,5 +1,8 @@
 // import faker
 import { faker } from '@faker-js/faker';
+import { calculateAmount } from 'libs';
+
+
 
 export const correctInputData = () => {
   const minTotalContractAmt = 100000;
@@ -10,5 +13,20 @@ export const correctInputData = () => {
     totalProfit: faker.datatype.number({ min: minTotalContractAmt / 2, max: totalContractAmt / 2, precision: 1000 }),
   });
 };
+
+export const inputData = calculateAmount({
+  amountAfterTax: 33333,
+  profit: 1000,
+});
+
+export const labelMap: Record<keyof typeof inputData, string> = {
+  amountAfterTax: '契約合計金額（税込）',
+  amountBeforeTax: '契約合計金額（税抜）',
+  profit: '粗利額 （税抜）',
+  costPrice: '原価',
+  profitRate: '粗利率',
+  taxRate: '税率',
+};
+
 
 export const testProjId = '5a5e6cae-bea3-48e9-b679-3dcbbcc7fc60';

--- a/packages/libs/src/calculateAmount.ts
+++ b/packages/libs/src/calculateAmount.ts
@@ -27,7 +27,7 @@ import { calcBeforeTax } from './calcBeforeTax';
 import { calcAfterTax, calcProfitRate } from 'libs';
 
 
-interface Values {
+export interface Values {
 
   /** 金額（税抜） */
   amountAfterTax?: number,

--- a/packages/libs/src/roundTo.test.ts
+++ b/packages/libs/src/roundTo.test.ts
@@ -92,7 +92,9 @@ describe('roundTo', () => {
   
   it('roundHalfDown', () => {
     // 五捨六入
-
+    expect(roundTo(1.50, 0, 4)).toEqual(1);
+    expect(roundTo(1.59, 0, 4)).toEqual(1);
+    expect(roundTo(1.60, 0, 4)).toEqual(2);
     expect(roundTo(0.001, 2, 4)).toEqual(0);
     expect(roundTo(0.01, 2, 4)).toEqual(0.01);
     expect(roundTo(0.555, 2, 4)).toEqual(0.55);

--- a/packages/libs/src/roundTo.test.ts
+++ b/packages/libs/src/roundTo.test.ts
@@ -1,21 +1,116 @@
 import { roundTo } from './roundTo';
 
-it('roundTo', () => {
+describe('roundTo', () => {
+  it('roundHalfUp', () => {
+    // 四捨五入
+    expect(roundTo(0.001, 2, 1)).toEqual(0);
+    expect(roundTo(0.01, 2, 1)).toEqual(0.01);
+    expect(roundTo(0.555, 2, 1)).toEqual(0.56);
+    expect(roundTo(0.99999999999, 2, 1)).toEqual(1);
+    expect(roundTo(0.129, 2, 1)).toEqual(0.13);
+    expect(roundTo(0.129, 1, 1)).toEqual(0.1);
 
-  expect(roundTo(0.001, 2)).toEqual(0);
-  expect(roundTo(0.01, 2)).toEqual(0.01);
-  expect(roundTo(0.555, 2)).toEqual(0.56);
-  expect(roundTo(0.99999999999, 2)).toEqual(1);
-  expect(roundTo(0.129, 2)).toEqual(0.13);
-  expect(roundTo(0.129, 1)).toEqual(0.1);
+    expect(roundTo(1.005, 2, 1)).toEqual(1.01);
+    expect(roundTo(1.005, 0, 1)).toEqual(1);
+    expect(roundTo(1.005, 0)).toEqual(1);
 
-  expect(roundTo(1.005, 2)).toEqual(1.01);
-  expect(roundTo(1.005, 0)).toEqual(1);
-  expect(roundTo(1.005)).toEqual(1);
+    expect(roundTo(50.99999999999, 2, 1)).toEqual(51);
 
-  expect(roundTo(50.99999999999, 2)).toEqual(51);
+    expect(roundTo(22.1212, 2, 1)).toEqual(22.12);
+    expect(roundTo(22.555, 2, 1)).toEqual(22.56);
 
-  expect(roundTo(22.1212, 2)).toEqual(22.12);
-  expect(roundTo(22.555, 2)).toEqual(22.56);
+    expect(roundTo(345.555, -1, 1)).toEqual(350);
+    expect(roundTo(345.555, -2, 1)).toEqual(300);
+
+  });
+
+  it('roundHalfEven', () => {
+    // 五捨五超入
+
+    expect(roundTo(0.001, 2, 2)).toEqual(0);
+    expect(roundTo(0.01, 2, 2)).toEqual(0.01);
+    expect(roundTo(0.555, 2, 2)).toEqual(0.56);
+    expect(roundTo(0.99999999999, 2, 2)).toEqual(1);
+    expect(roundTo(0.129, 2, 2)).toEqual(0.13);
+    expect(roundTo(0.129, 1, 2)).toEqual(0.1);
+
+    expect(roundTo(1.006, 2, 2)).toEqual(1.01);
+    expect(roundTo(1.006, 0, 2)).toEqual(1);
+    expect(roundTo(1.006)).toEqual(1);
+
+    expect(roundTo(50.99999999999, 2, 2)).toEqual(51);
+
+    expect(roundTo(22.1212, 2, 2)).toEqual(22.12);
+    expect(roundTo(22.666, 2, 2)).toEqual(22.67);
+
+    expect(roundTo(456.555, -1, 2)).toEqual(460);
+    expect(roundTo(456.555, -2, 2)).toEqual(500);
+  });
+
+  it('roundDown', () => {
+    // 切り捨て
+    expect(roundTo(0.001, 2, 0)).toEqual(0);
+    expect(roundTo(0.01, 2, 0)).toEqual(0.01);
+    expect(roundTo(0.555, 2, 0)).toEqual(0.55);
+    expect(roundTo(0.99999999999, 2, 0)).toEqual(0.99);
+    expect(roundTo(0.129, 2, 0)).toEqual(0.12);
+    expect(roundTo(0.129, 1, 0)).toEqual(0.1);
+
+    expect(roundTo(1.066, 2, 0)).toEqual(1.06);
+    expect(roundTo(1.066, 0, 0)).toEqual(1);
+
+    expect(roundTo(50.99999999999, 2, 0)).toEqual(50.99);
+
+    expect(roundTo(22.1212, 2, 0)).toEqual(22.12);
+    expect(roundTo(22.666, 2, 0)).toEqual(22.66);
+    
+    expect(roundTo(456.555, -1, 0)).toEqual(450);
+    expect(roundTo(456.555, -2, 0)).toEqual(400);
+  });
+
+  
+  it('roundUp', () => {
+    // 切り上げ
+    expect(roundTo(0.001, 2, 3)).toEqual(0.01);
+    expect(roundTo(0.01, 2, 3)).toEqual(0.01);
+    expect(roundTo(0.555, 2, 3)).toEqual(0.56);
+    expect(roundTo(0.99999999999, 2, 3)).toEqual(1);
+    expect(roundTo(0.129, 2, 3)).toEqual(0.13);
+    expect(roundTo(0.129, 1, 3)).toEqual(0.2);
+
+    expect(roundTo(1.066, 2, 3)).toEqual(1.07);
+    expect(roundTo(1.066, 0, 3)).toEqual(2);
+
+    expect(roundTo(50.99999999999, 2, 3)).toEqual(51);
+
+    expect(roundTo(22.1212, 2, 3)).toEqual(22.13);
+    expect(roundTo(22.666, 2, 3)).toEqual(22.67);
+    
+    expect(roundTo(456.555, -1, 3)).toEqual(460);
+    expect(roundTo(456.555, -2, 3)).toEqual(500);
+  });
+  
+  it('roundHalfDown', () => {
+    // 五捨六入
+
+    expect(roundTo(0.001, 2, 4)).toEqual(0);
+    expect(roundTo(0.01, 2, 4)).toEqual(0.01);
+    expect(roundTo(0.555, 2, 4)).toEqual(0.55);
+    expect(roundTo(0.99999999999, 2, 4)).toEqual(1);
+    expect(roundTo(0.129, 2, 4)).toEqual(0.13);
+    expect(roundTo(0.129, 1, 4)).toEqual(0.1);
+
+    expect(roundTo(1.006, 2, 4)).toEqual(1.01);
+    expect(roundTo(1.006, 0, 4)).toEqual(1);
+    expect(roundTo(1.006)).toEqual(1);
+
+    expect(roundTo(50.99999999999, 2, 4)).toEqual(51);
+
+    expect(roundTo(22.1212, 2, 4)).toEqual(22.12);
+    expect(roundTo(22.666, 2, 4)).toEqual(22.67);
+
+    expect(roundTo(456.555, -1, 4)).toEqual(460);
+    expect(roundTo(456.555, -2, 4)).toEqual(400);
+  });
 
 });

--- a/packages/libs/src/roundTo.ts
+++ b/packages/libs/src/roundTo.ts
@@ -11,7 +11,30 @@ import { Big } from 'big.js';
  * 
  * @see https://mikemcl.github.io/big.js/#round
  *  
+ * rounding mode Property(rmProperty)
+ * Big.roundDown     : 0 : 切り捨て
+ * Big.roundHalfUp   : 1 : 四捨五入
+ * Big.roundHalfEven : 2 : 五捨五超入
+ * Big.roundUp       : 3 : 切り上げ
+ * Big.roundHalfDown : 4 : 五捨六入
+ * 
  */
-export const roundTo = (value: number, precision = 0) => new Big(value)
-  .round(precision)
-  .toNumber();
+export const roundTo = (value: number, precision = 0, rmProperty = 2) => {
+
+  if (rmProperty === 4) {
+    const base = Big(precision).plus(1)
+      .toNumber();
+    const exponent = Big(10).pow(base);
+    const adjustedValue = Big(1).div(exponent);
+    const newValue = Big(value).minus(adjustedValue);
+    
+    return Big(newValue).round(precision, 1)
+      .toNumber();
+
+  } else {
+    return new Big(value)
+      .round(precision, rmProperty)
+      .toNumber();
+  }
+
+};

--- a/packages/libs/src/roundTo.ts
+++ b/packages/libs/src/roundTo.ts
@@ -1,3 +1,5 @@
+import { Big } from 'big.js';
+
 /**
  * なぜ：
  * 
@@ -7,10 +9,9 @@
  * 22.555.toPrecision(2) // 23 ×
  * Math.round(22.555) // 23 ×
  * 
- * 長くなりますが、小数点に正確さが必要で、追加しました。
- * それ以外、出来るだけ通常の関数かライブラリーを利用します。
- * 
- * ざっくりなので、もし、よりいいやり方ありましたら、以下の編集し、roundTo.test.tsでテストください。
+ * @see https://mikemcl.github.io/big.js/#round
  *  
  */
-export const roundTo = (value: number, precision = 0) =>  Number(Math.round(Number(`${value}e${precision}`)) + 'e-' + precision);
+export const roundTo = (value: number, precision = 0) => new Big(value)
+  .round(precision)
+  .toNumber();


### PR DESCRIPTION
## 変更

1. roundTo を BigJsに移行しました。
2. useFormContextExtended を 作成しました。

## 理由

1. 統一化させるため
2. 柔軟にRHFのuseFormContextを拡張できる出来るため。利用箇所が広がったら、アプリ範囲のhooksに移行します。
3. fix #349 

## テスト

単体：
- libs/roundTo.test.ts

E2E:
- contractPreview2/input.cy.ts

## 備考

- どんどんPRを出しますが、テストに網羅的に出来ない場合があります。推薦機能で修正案を頂くとうれしいです。