### PR TITLE
hotfix-見積もりが開けるようにする

### DIFF
--- a/packages/kokoas-client/src/components/reactHookForm/ControlledCheckbox.tsx
+++ b/packages/kokoas-client/src/components/reactHookForm/ControlledCheckbox.tsx
@@ -1,5 +1,5 @@
 import { Checkbox, CheckboxProps, FormControlLabel } from '@mui/material';
-import { Control, Controller, FieldValues, Path, UnPackAsyncDefaultValues } from 'react-hook-form';
+import { Control, Controller, FieldValues, FieldPath } from 'react-hook-form';
 
 
 /**
@@ -15,7 +15,7 @@ export function ControlledCheckBox<T extends FieldValues >({
   ...others
 }: CheckboxProps & {
   control: Control<T>
-  name: Path<UnPackAsyncDefaultValues<T>>,
+  name: FieldPath<T>,
   label: string,
 }) {
 

--- a/packages/kokoas-client/src/pages/Router.tsx
+++ b/packages/kokoas-client/src/pages/Router.tsx
@@ -11,6 +11,7 @@ import { memo } from 'react';
 import { FormContractSearch } from './projContractSearchV2/FormContractSearch';
 import { UnderDevelopment } from './UnderDevelopment';
 import { FormContract } from './projContractV2/FormContract';
+import { FormProjEstimate } from './projEstimate/FormProjEstimate';
 
 
 
@@ -74,8 +75,8 @@ const Router = () => (
     {/* 見込み登録 */}
     <Route path={`${pages.projProspect}`} element={<FormikProjProspect />} key={'edit'} />
 
-    {/* 見積もり登録 */}
-    {/* <Route path={`${pages.projEstimate}`} element={<FormProjEstimate />} /> */}
+    見積もり登録
+    <Route path={`${pages.projEstimate}`} element={<FormProjEstimate />} />
 
     {/* 契約 */}
     {/*     <Route path={`${pages.projContractPreview}`} element={<FormikContract />} />

--- a/packages/kokoas-client/src/pages/projEstimate/api/convertEstimateToForm.ts
+++ b/packages/kokoas-client/src/pages/projEstimate/api/convertEstimateToForm.ts
@@ -8,6 +8,7 @@ import { TunitChoices } from '../validationSchema';
 export const convertEstimateToForm = (
   recEstimate: IProjestimates,
 ) : Partial<TypeOfForm> => {
+  console.log(recEstimate);
 
   const {
     uuid,
@@ -24,6 +25,8 @@ export const convertEstimateToForm = (
     $revision,
     remarks,
   } = recEstimate;
+
+ 
 
   const parsedTaxRate = +tax.value / 100;
 
@@ -141,7 +144,7 @@ export const convertEstimateToForm = (
     totalAmountBeforeTax,
     totalAmountAfterTax,
     estimateRevision: $revision.value,
-    remarks: remarks.value,
+    remarks: remarks?.value || '',
   };
 
 };

--- a/packages/kokoas-client/src/pages/projEstimate/api/convertEstimateToForm.ts
+++ b/packages/kokoas-client/src/pages/projEstimate/api/convertEstimateToForm.ts
@@ -8,7 +8,6 @@ import { TunitChoices } from '../validationSchema';
 export const convertEstimateToForm = (
   recEstimate: IProjestimates,
 ) : Partial<TypeOfForm> => {
-  console.log(recEstimate);
 
   const {
     uuid,


### PR DESCRIPTION
## 変更

1. 見積もり登録を公開しましたが、当面、メニュには出さない。

## 理由

1. 変換処理で利用されるとのこと。

## テスト

- 実行方法
