### PR TITLE
金額がマイナスの場合の文字色を変更

### DIFF
--- a/packages/kokoas-client/src/components/ui/textfield/NumberCommaField.tsx
+++ b/packages/kokoas-client/src/components/ui/textfield/NumberCommaField.tsx
@@ -18,14 +18,15 @@ export type NumberCommaFieldProps = Omit<TextFieldProps, 'onChange' | 'onBlur' |
  * 固定の部分があるので、必要に応じて改修　~ Ras
  */
 export const NumberCommaField = forwardRef<HTMLInputElement, NumberCommaFieldProps>((props, ref) => {
-  
-  const { 
+
+  const {
     value,
     onChange,
     onBlur,
+    inputProps,
     ...others
   } = props;
-  
+
   const textProps = useNumberCommaField({
     onChange,
     onBlur,
@@ -33,11 +34,14 @@ export const NumberCommaField = forwardRef<HTMLInputElement, NumberCommaFieldPro
   });
 
   return (
-    <TextField 
+    <TextField
       ref={ref}
       type='text' // numberだと、コンマを入れることが出来ない
-      inputProps={{ 
-        style: { textAlign: 'right' }, 
+      inputProps={{
+        style: {
+          ...inputProps?.style,
+          textAlign: 'right',
+        },
       }}
       InputProps={{
         endAdornment: (
@@ -46,7 +50,7 @@ export const NumberCommaField = forwardRef<HTMLInputElement, NumberCommaFieldPro
           </InputAdornment>
         ),
       }}
-      {...others} 
+      {...others}
       {...textProps}
     />
   );

--- a/packages/kokoas-client/src/pages/projContractV2/fields/ControlledCurrencyInput.tsx
+++ b/packages/kokoas-client/src/pages/projContractV2/fields/ControlledCurrencyInput.tsx
@@ -40,7 +40,7 @@ export const ControlledCurrencyInput = ({
         fieldState: {
           error,
         },
-        
+
       }) => {
 
         return (
@@ -51,13 +51,14 @@ export const ControlledCurrencyInput = ({
             defaultValue={typeof value === 'number' ? (value as number).toLocaleString() : value}
             name={name}
             variant={variant}
+            inputProps={{ style: { color: value as number >= 0 ? 'black' : 'orange' } }}
             onChange={(v) => {
               const commaRemoved = typeof v === 'string' ? v.replace(/,/g, '') : v;
               const parsedValue = +commaRemoved;
               onChange(isNaN(parsedValue) ? v : parsedValue);
 
               const taxRate = getValues('taxRate');
-            
+
 
               // 逆算
               switch (name) {
@@ -111,7 +112,7 @@ export const ControlledCurrencyInput = ({
                   setRoundedValue('profitRate', profitRate * 100, 2);
                   break;
                 }
-                case 'costPrice' : {
+                case 'costPrice': {
                   const totalContractAmtAfterTax = getValues('totalContractAmtAfterTax');
                   const {
                     amountBeforeTax,

--- a/packages/kokoas-client/src/pages/projContractV2/parts/TaxAmount.tsx
+++ b/packages/kokoas-client/src/pages/projContractV2/parts/TaxAmount.tsx
@@ -1,26 +1,26 @@
 import { useWatch } from 'react-hook-form';
 import { TypeOfForm } from '../schema';
-import { Chip, Stack } from '@mui/material';
+import { Chip, Stack, Typography } from '@mui/material';
 
 export const TaxAmount = () => {
 
   const [
     totalContractAmtAfterTax,
     totalContractAmtBeforeTax,
-  ]  = useWatch<TypeOfForm>({
+  ] = useWatch<TypeOfForm>({
     name: [
       'totalContractAmtAfterTax',
       'totalContractAmtBeforeTax',
     ],
-    
+
   }) as number[];
 
 
   const taxValue = totalContractAmtAfterTax - totalContractAmtBeforeTax;
   return (
-    <Chip 
+    <Chip
       sx={{
-        '& .MuiChip-label' : {
+        '& .MuiChip-label': {
           width: '100%',
         },
       }}
@@ -28,10 +28,20 @@ export const TaxAmount = () => {
         <div>
           消費税
         </div>
-        <div>
-          {`${taxValue.toLocaleString()} 円`}
-        </div>
+        <Stack
+          direction={'row'}
+          alignItems={'center'}
+          justifyContent={'space-around'}
+          spacing={1.5}
+        >
+          <Typography color={taxValue >= 0 ? 'black' : 'orange'}>
+            {`${taxValue.toLocaleString()} `}
+          </Typography>
+          <div>
+            円
+          </div>
+        </Stack>
       </Stack>}
-    /> 
+    />
   );
 };

--- a/packages/kokoas-e2e/cypress/e2e/contractPreview2/input.cy.ts
+++ b/packages/kokoas-e2e/cypress/e2e/contractPreview2/input.cy.ts
@@ -182,6 +182,37 @@ describe(
             .should('have.value', roundTo(amountBeforeTax).toLocaleString());
         });
 
+        it('契約金額にマイナスの値を入力したら、オレンジ色になること', () => {
+          const inputValue = -2200;
+          const {
+            amountBeforeTax,
+            costPrice,
+            profit,
+          } = calculateAmount({
+            amountAfterTax: inputValue,
+            profitRate: (profitRate / 100),
+          });
+
+          cy.getTextInputsByLabel(labelMap.amountAfterTax )
+            .invoke('val', '')
+            .clear()
+            .type((inputValue).toString(), { delay: 50 })
+            .should('have.value', inputValue)
+            .should('have.css', 'color', 'rgb(255, 165, 0)');
+
+          cy.getTextInputsByLabel(labelMap.amountBeforeTax )
+            .should('have.value', roundTo(amountBeforeTax).toLocaleString())
+            .should('have.css', 'color', 'rgb(255, 165, 0)');
+
+          cy.getTextInputsByLabel(labelMap.costPrice)
+            .should('have.value', roundTo(costPrice).toLocaleString())
+            .should('have.css', 'color', 'rgb(255, 165, 0)');
+
+          cy.getTextInputsByLabel(labelMap.profit)
+            .should('have.value', roundTo(profit).toLocaleString())
+            .should('have.css', 'color', 'rgb(255, 165, 0)');
+        });
+
         // TODO: 他のフィールドの計算が合っていることを確認する
       },
     );

--- a/packages/libs/src/roundTo.ts
+++ b/packages/libs/src/roundTo.ts
@@ -19,7 +19,7 @@ import { Big } from 'big.js';
  * Big.roundHalfDown : 4 : 五捨六入
  * 
  */
-export const roundTo = (value: number, precision = 0, rmProperty = 2) => {
+export const roundTo = (value: number, precision = 0, rmProperty = 1) => {
 
   if (rmProperty === 4) {
     const base = Big(precision).plus(1)


### PR DESCRIPTION
## 変更

1. 契約書の契約金額がマイナスの場合、色を変更します。

## 理由

fix #386 

## テスト

- e2e　contractPreview2/input.cy
- ```計算が合っていることと小数点以下が出ないこと```内、 ```契約金額にマイナスの値を入力したら、オレンジ色になること```
