### PR TITLE
393 契約画面の粗利額は0以上で契約状態に関わらず常に編集出来るようにする

### DIFF
--- a/packages/kokoas-client/src/lib/zodErrorMapJA.ts
+++ b/packages/kokoas-client/src/lib/zodErrorMapJA.ts
@@ -87,9 +87,9 @@ export const zodErrorMapJA =
             };
           } else if (issue.type === 'number') {
             return {
-              message: `Number must be greater than ${
+              message: `${Number(issue.minimum) + 1} 以上の数字を入れてください ${
                 issue.inclusive ? 'or equal to ' : ''
-              }${issue.minimum}`,
+              }`,
             };
           } else {
             return { message: 'Invalid input' };

--- a/packages/kokoas-client/src/pages/projContractV2/fields/ProfitRate.tsx
+++ b/packages/kokoas-client/src/pages/projContractV2/fields/ProfitRate.tsx
@@ -4,9 +4,9 @@ import { calculateAmount } from 'libs';
 import { useFormContextExtended } from '../hooks/useFormContextExtended';
 
 export const ProfitRate = ({
-  disabled,
+  disabled = false,
 }: {
-  disabled: boolean,
+  disabled?: boolean,
 }) => {
 
   const {

--- a/packages/kokoas-client/src/pages/projContractV2/fields/ProfitRate.tsx
+++ b/packages/kokoas-client/src/pages/projContractV2/fields/ProfitRate.tsx
@@ -70,7 +70,7 @@ export const ProfitRate = ({
             error={!!error}
             disabled={disabled}
             placeholder={'12.34'}
-            helperText={error?.message}
+            helperText={error?.message || '粗利率を入れても自動計算出来ます'}
             inputProps={{ 
               style: { textAlign: 'right' }, 
             }}

--- a/packages/kokoas-client/src/pages/projContractV2/schema.tsx
+++ b/packages/kokoas-client/src/pages/projContractV2/schema.tsx
@@ -31,7 +31,8 @@ const schema = z.object({
   totalContractAmtBeforeTax: z.number(),
 
   /** 粗利額 */
-  totalProfit: z.number(),
+  // must be above 0
+  totalProfit: z.number().min(1),
 
   /** 粗利率 */
   profitRate: z.number(),

--- a/packages/kokoas-client/src/pages/projContractV2/schema.tsx
+++ b/packages/kokoas-client/src/pages/projContractV2/schema.tsx
@@ -31,8 +31,7 @@ const schema = z.object({
   totalContractAmtBeforeTax: z.number(),
 
   /** 粗利額 */
-  // must be above 0
-  totalProfit: z.number().min(1),
+  totalProfit: z.number().gt(0),
 
   /** 粗利率 */
   profitRate: z.number(),

--- a/packages/kokoas-client/src/pages/projContractV2/sections/TotalAmount.tsx
+++ b/packages/kokoas-client/src/pages/projContractV2/sections/TotalAmount.tsx
@@ -22,9 +22,9 @@ export const TotalAmount = ({
       <ControlledCurrencyInput disabled={disabled} name="totalContractAmtAfterTax" label="契約合計金額（税込）" />
       <ControlledCurrencyInput disabled={disabled} name="totalContractAmtBeforeTax" label="契約合計金額（税抜）" />
       <TaxAmount />
-      <ControlledCurrencyInput disabled={disabled} name="costPrice" label="原価" />
-      <ControlledCurrencyInput disabled={disabled} name="totalProfit" label="粗利額 （税抜）" />
-      <ProfitRate disabled={disabled} />
+      <ControlledCurrencyInput name="costPrice" label="原価" />
+      <ControlledCurrencyInput name="totalProfit" label="粗利額 （税抜）" />
+      <ProfitRate />
 
     </Stack>
   );


### PR DESCRIPTION
## 変更

1. バリエーションの更新
2. 粗利率にヘルパーテクストの追加
3. 粗利額が常に編集出来るようにする

## 理由

1. fix #393 

