### PR TITLE
hotfix-契約一覧で検索ボタンを押すとエラーになる

### DIFF
--- a/packages/kokoas-client/src/pages/projContractSearchV2/FormContractSearch.tsx
+++ b/packages/kokoas-client/src/pages/projContractSearchV2/FormContractSearch.tsx
@@ -24,6 +24,8 @@ export const FormContractSearch = () => {
 
   const newValues = useNewValuesFromParams();
 
+  console.log('newValues', newValues);
+
   const methods = useForm<TypeOfForm>({
     defaultValues: {
       ...newValues,

--- a/packages/kokoas-client/src/pages/projContractSearchV2/parts/filterDialog/DateRangeField.tsx
+++ b/packages/kokoas-client/src/pages/projContractSearchV2/parts/filterDialog/DateRangeField.tsx
@@ -1,6 +1,7 @@
 import { JADatePicker } from 'kokoas-client/src/components';
 import { Controller, useFormContext } from 'react-hook-form';
 import { KeyOfForm, TypeOfForm } from '../../form';
+import parseISO from 'date-fns/parseISO';
 
 export const DateRangeField = ({
   name,
@@ -22,11 +23,10 @@ export const DateRangeField = ({
       }) => {
 
         const isShowError = !!error?.message && !!isTouched;
-
         return (
           <JADatePicker
             {...field}
-            value={field.value ?? null} // keep it controlled
+            value={field.value ? parseISO(field.value as string) : null} // keep it controlled
             slotProps={{
               textField: {
                 onBlur,


### PR DESCRIPTION
## 変更

1.dateのフィールドにvalueを与える際、変換をする。

## 理由

1. MUIの新datpickerがDate型じゃないと、エラーになる。今まで、ISOのストリングが大丈夫でした。
