### PR TITLE
契約一覧のE2Eテストの修正しました。

### DIFF
--- a/packages/kokoas-client/src/components/reactHookForm/ControlledCheckbox.tsx
+++ b/packages/kokoas-client/src/components/reactHookForm/ControlledCheckbox.tsx
@@ -36,7 +36,7 @@ export function ControlledCheckBox<T extends FieldValues >({
                   field.onChange(e);
                   onChange?.(e, checked);
                 }}
-                indeterminate={value && indeterminate}
+                indeterminate={indeterminate}
               />)}
             label={label}
           />

--- a/packages/kokoas-client/src/pages/projContractSearchV2/parts/filterDialog/ContractStatusIncomplete.tsx
+++ b/packages/kokoas-client/src/pages/projContractSearchV2/parts/filterDialog/ContractStatusIncomplete.tsx
@@ -1,4 +1,4 @@
-import { Box, Collapse } from '@mui/material';
+import { Box } from '@mui/material';
 import { ControlledCheckBox } from 'kokoas-client/src/components/reactHookForm';
 import { SyntheticEvent } from 'react';
 import { useFormContext, useWatch } from 'react-hook-form';
@@ -21,10 +21,6 @@ export const ContractStatusIncomplete = () => {
     setValue,
     getValues,
   } = useFormContext<TypeOfForm>();
-  const contractIncomplete = useWatch({
-    name: 'contractIncomplete',
-    control,
-  });
 
 
   const contractSteps = useWatch({
@@ -32,7 +28,10 @@ export const ContractStatusIncomplete = () => {
     control,
   });
 
-  const isPartialSteps = contractSteps.some((step) => !step);
+
+
+  const isPartialSteps = contractSteps.some((step) => !step) && !contractSteps.every((step) => !step);
+
 
   const handleChangeIncompleteCheckbox = (_: SyntheticEvent<HTMLInputElement>, checked: boolean) => {
 
@@ -66,19 +65,17 @@ export const ContractStatusIncomplete = () => {
         onChange={handleChangeIncompleteCheckbox}
       />
 
-      <Collapse in={contractIncomplete}>
-
-        <Box sx={{ display: 'flex', flexDirection: 'column', ml: 3 }}>
-          {stepsKeys.map((key) => (
-            <ControlledCheckBox
-              key={key}
-              label={translateKey(key)}
-              control={control}
-              name={key}
-              onChange={handleChangeStepCheckbox}
-            />))}
-        </Box>
-      </Collapse>
+      <Box sx={{ display: 'flex', flexDirection: 'column', ml: 3 }}>
+        {stepsKeys.map((key) => (
+          <ControlledCheckBox
+            key={key}
+            label={translateKey(key)}
+            control={control}
+            name={key}
+            onChange={handleChangeStepCheckbox}
+          />))}
+      </Box>
+ 
     </>
 
   );

--- a/packages/kokoas-e2e/cypress/e2e/contract/contractSearch.cy.ts
+++ b/packages/kokoas-e2e/cypress/e2e/contract/contractSearch.cy.ts
@@ -220,13 +220,14 @@ describe('契約一覧', () => {
       cy.get('@filterChipsContainer').find('.MuiChip-root')
         .then(($chips) => $chips.get().reverse())
         .each(($chip, index, { length }) => {
-          const isLast = index === length - 1;
+          const isLast = index === length - 2;
           const statusText = $chip.text();
-     
+          console.log(statusText);
+
+          // 全レコード表示になるため、契約未完了と最後のチップの時、アサーションしない。
           if (!isLast) {
             cy.wrap($chip).find('.MuiChip-deleteIcon')
               .click();
-
             cy.get('@tableBody')
               .should('not.contain', statusText); // 削除したフィルターチップのテキストが、テーブルに含まれていないことをアサートします。
           }


### PR DESCRIPTION
## 変更

1. 「未完了の契約のみを表示する」で、最後の条件チップを削除するとき、結果を確認しないようにする。

## 理由

1. 条件チップをすべて削除したら、全レコードになる。