### PR TITLE
hotfix-契約登録：粗利額をゼロ以外登録出来ないようにする

### DIFF
--- a/packages/kokoas-client/src/pages/projContractV2/schema.tsx
+++ b/packages/kokoas-client/src/pages/projContractV2/schema.tsx
@@ -31,7 +31,13 @@ const schema = z.object({
   totalContractAmtBeforeTax: z.number(),
 
   /** 粗利額 */
-  totalProfit: z.number().gt(0),
+  totalProfit: z.number()
+    .refine(
+      (val) => val !== 0, 
+      {
+        message: '粗利額が0円です。',
+      },
+    ),
 
   /** 粗利率 */
   profitRate: z.number(),


### PR DESCRIPTION
## 変更

粗利額のバリデーション

### 変更前

- positiveのみOK

### 変更後

- negativeとpositiveもOK

## 理由

1. 依頼