### PR TITLE
契約登録　金額を入力の際、空の場合ゼロを残さないようにする

### DIFF
--- a/packages/kokoas-client/src/hooks/useNumberCommaField.ts
+++ b/packages/kokoas-client/src/hooks/useNumberCommaField.ts
@@ -39,7 +39,7 @@ export const useNumberCommaField = ({
   return {
     onFocus: ({ target }) => {
       target.value = target.value.replace(/,/g, '');
-      //target.select(); // ダブって原因でした。
+      target.select(); // ダブって原因でした。
     },
     onCompositionStart : () => {
       //const el = e.target as HTMLInputElement;   

--- a/packages/kokoas-client/src/pages/projContractV2/fields/ProfitRate.tsx
+++ b/packages/kokoas-client/src/pages/projContractV2/fields/ProfitRate.tsx
@@ -41,6 +41,9 @@ export const ProfitRate = ({
             name={name}
             variant={'outlined'}
             type='number'
+            onFocus={(e) => {
+              e.target.select();
+            }}
             onChange={(e) => {
               const profitRate = +e.target.value;
               onChange(typeof profitRate === 'number' ? profitRate : e.target.value);


### PR DESCRIPTION
## 変更

1. onFocusで選択状態にする。

## 理由

1. 桁間違い原因の解消

## テスト

- 実行方法
