### PR TITLE
工事登録の住所を顧客登録に合わせる/直接転記しない

### DIFF
--- a/packages/kokoas-client/src/pages/projRegister/hooks/useResolveParams.ts
+++ b/packages/kokoas-client/src/pages/projRegister/hooks/useResolveParams.ts
@@ -77,18 +77,10 @@ export const useResolveParams = () => {
       });
 
     } else if (custGroupIdFromURL && !projIdFromURL && custGroupRec && custRecs) {
-      const {
-        postalCode,
-        address1,
-        address2,
-      } = custRecs[0];
 
       setInitForm({
         ...initialValues,
         ...convertCustGroupToForm(custGroupRec),
-        postal: postalCode.value.replace('-', ''),
-        address1: address1.value,
-        address2: address2.value,
       });
 
     } else if (!custGroupIdFromURL && !projIdFromURL) {

--- a/packages/kokoas-client/src/pages/projRegister/sections/location/ConstructionLocation.tsx
+++ b/packages/kokoas-client/src/pages/projRegister/sections/location/ConstructionLocation.tsx
@@ -1,6 +1,7 @@
 import {
   Grid,
   FormHelperText,
+  Stack,
 } from '@mui/material';
 import {
   FormikLabeledCheckBox,
@@ -16,6 +17,7 @@ import { getFieldName, initialValues } from '../../form';
 import { useFormikContext } from 'formik';
 import { useCallback } from 'react';
 import { getAddressByPostal } from 'api-kintone';
+import { CopyCustomerAddress } from './CopyCustomerAddress';
 
 export const ConstructionLocation = () => {
 
@@ -78,6 +80,7 @@ export const ConstructionLocation = () => {
         <FormHelperText id="my-helper-text">
           過去の工事情報から参照する
         </FormHelperText>
+
       </Grid>
 
       {/* Offset. Remove when migrated to Grid2 */}
@@ -94,15 +97,20 @@ export const ConstructionLocation = () => {
         />
       </Grid>
       <Grid item>
-        <SearchAddress
-          handleChange={({ postalCode, prefecture, city, town }) => {
-            setValues((prev) => ({
-              ...prev,
-              postal: postalCode,
-              address1: [prefecture, city, town].join(''),
-            }));
-          }}
-        />
+        <Stack direction={'row'} spacing={2}>
+          <SearchAddress
+            handleChange={({ postalCode, prefecture, city, town }) => {
+              setValues((prev) => ({
+                ...prev,
+                postal: postalCode,
+                address1: [prefecture, city, town].join(''),
+              }));
+            }}
+          />
+
+          <CopyCustomerAddress />
+        </Stack>
+        
       </Grid>
 
       <Grid item md={12} />

--- a/packages/kokoas-client/src/pages/projRegister/sections/location/CopyCustomerAddress.tsx
+++ b/packages/kokoas-client/src/pages/projRegister/sections/location/CopyCustomerAddress.tsx
@@ -1,0 +1,47 @@
+import { Button } from '@mui/material';
+import { useFormikContext } from 'formik';
+import { TypeOfForm } from '../../form';
+import { useCustomersByCustGroupId } from 'kokoas-client/src/hooksQuery';
+
+export const CopyCustomerAddress = () => {
+  const {
+    setValues, 
+    values: {
+      custGroupId,
+    } } = useFormikContext<TypeOfForm>();
+
+  const { data: customers } = useCustomersByCustGroupId(custGroupId || '');
+
+  const {
+    postalCode,
+    address1,
+    address2,
+  } = customers?.[0] || {};
+
+  /* postal: postalCode.value.replace('-', ''),
+        address1: address1.value,
+        address2: address2.value, */
+
+  return (
+    <Button
+      //size='large'
+      color='primary' 
+      variant='contained'
+      disabled={!customers}
+      onClick={() => {
+        setValues((prev) => {
+          return {
+            ...prev,
+            postal: postalCode?.value.replace('-', '') || '',
+            address1: address1?.value || '',
+            address2: address2?.value || '',
+          };
+        });
+      }}
+    >
+      現住所を
+      <br />
+      コピーする
+    </Button>
+  );
+};


### PR DESCRIPTION
## 変更

**変更前：**
工事登録の時、住所のデフォールトは顧客情報にする
https://rdmuhwtt6gx7.cybozu.com/k/236/show#record=54

**変更後：**
上を撤回し、代わりに現在住所のボタンを配置する。
https://rdmuhwtt6gx7.cybozu.com/k/236/show#record=58

## 理由

住所が違う場合、削除する手間が大きいため。
