### PR TITLE
契約書の発注者に「様」を付けなくなりました。

### DIFF
--- a/packages/kokoas-server/src/handleRequest/reqSendContractDirectV2/generateContractPdfV2.ts
+++ b/packages/kokoas-server/src/handleRequest/reqSendContractDirectV2/generateContractPdfV2.ts
@@ -128,7 +128,7 @@ export const generateContractPdfV2 = async (
   // 顧客名
   drawText(
     firstPage,
-    customers.map(({ custName }) => `${custName} 様` ).join('、'),
+    customers.map(({ custName }) => `${custName} ` ).join('、'),
     {
       x: x1,
       y: 673,


### PR DESCRIPTION
## 変更

1. Removed 様

## 理由

1. 一般の契約書の合わせるため

## テスト

- 実行方法
