### PR TITLE
fix-should alert for specific input errors

### DIFF
--- a/packages/kokoas-client/src/pages/projRegisterV2/api/fieldMapJa.ts
+++ b/packages/kokoas-client/src/pages/projRegisterV2/api/fieldMapJa.ts
@@ -1,0 +1,36 @@
+import { KForm } from '../schema';
+
+export const fieldMapJa : Record<KForm, string> = {
+  address1: '住所1',
+  address2: '住所2',
+  buildingType: '建物種別',
+  cancelStatus: 'キャンセルステータス',
+  cocoConst1: '工事担当者１',
+  cocoConst2: '工事担当者２',
+  createdDate: '登録日',
+  custGroupId: '顧客グループ',
+  custName: '顧客名',
+  finalAddress1: '確定住所1',
+  finalAddress2: '確定住所2',
+  finalPostal: '確定郵便番号',
+
+  hasCompletedContract: '契約完了',
+  hasContract: '契約中',
+  isAddressKari: '仮住所',
+
+  isShowFinalAddress: '確定住所を表示',
+  logs: 'ログ',
+
+  memo: 'メモ',
+
+  postal: '郵便番号',
+  projDataId: '工事データID',
+  projId: '工事ID',
+  projName: '工事名',
+  projTypeId: '工事種別ID',
+  projTypeName: '工事種別名',
+  status: 'ステータス',
+  storeCode: '店舗コード',
+  storeId: '店舗ID',
+  territory: 'エリア',
+};

--- a/packages/kokoas-client/src/pages/projRegisterV2/schema.ts
+++ b/packages/kokoas-client/src/pages/projRegisterV2/schema.ts
@@ -10,7 +10,7 @@ export const schema = z.object({
   projTypeId: z.string().nonempty({
     message: '工事種別を選択してください。',
   }),
-  projName: z.string(),
+  projName: z.string().nonempty(),
   projDataId: z.string(),
   createdDate: z.string(),
   storeCode: z.string(),

--- a/packages/kokoas-client/src/pages/projRegisterV2/sections/formActions/FormActions.tsx
+++ b/packages/kokoas-client/src/pages/projRegisterV2/sections/formActions/FormActions.tsx
@@ -7,6 +7,8 @@ import { useSnackBar } from 'kokoas-client/src/hooks';
 import { useNavigate } from 'react-router-dom';
 import { pages } from 'kokoas-client/src/pages/Router';
 import { generateParams } from 'kokoas-client/src/helpers/url';
+import { fieldMapJa } from '../../api/fieldMapJA';
+import { KForm } from '../../schema';
 
 export const FormActions = () => {
   const { setSnackState } = useSnackBar();
@@ -33,9 +35,17 @@ export const FormActions = () => {
     },
     (errors) => {
       console.warn(errors); // 保存できない原因で、残す
+      // summarize errors into string
+      const errorString = Object.entries(errors).reduce((acc, [key, value]) => {
+        if (value) {
+          acc += `${fieldMapJa[key as KForm]}: ${value.message}\n`;
+        }
+        return acc;
+      }, '');
+
       setSnackState({
         open: true,
-        message: '入力内容に不備があります', 
+        message: `「${errorString}」  修正が出来ない場合はお手数ですが、管理者に連絡してください。`, 
         severity: 'error',
         
       });


### PR DESCRIPTION
There could be field errors in the form that are not fixable by the user.
This is either due to a regression bug or an old data where fields where not required, but are required now, and vice versa.
