### PR TITLE
K85-工事登録に「ゆめてつAG」と「ここすも営業担当者」を追加する

### DIFF
--- a/packages/api-kintone/src/custgroups/helpers/groupAgentsByType.test.ts
+++ b/packages/api-kintone/src/custgroups/helpers/groupAgentsByType.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from '@jest/globals';
+import { groupAgentsByType } from './groupAgentsByType';
+import { getCustGroupById } from '../getCustGroupById';
+
+describe('getAgentsByType', () => {
+  it('should return agents by type', async () => {
+    const custGroupRec = await getCustGroupById('fe8029b9-4206-4344-a9d4-6d31918e8bb8');
+
+    const result = groupAgentsByType(custGroupRec.agents);
+
+    console.log(result);
+
+    expect(result).toBeDefined();
+  });
+});

--- a/packages/api-kintone/src/custgroups/helpers/groupAgentsByType.ts
+++ b/packages/api-kintone/src/custgroups/helpers/groupAgentsByType.ts
@@ -4,16 +4,18 @@ import { RecordType } from '../config';
 export const groupAgentsByType = (
   agents: RecordType['agents'],
 ) => {
-  return agents?.value.reduce((acc, cur) => {
-    const { agentType } = cur.value;
-    const type = agentType.value as TAgents;
-    if (acc[type]) {
-      acc[type].push(cur);
-    } else {
-      acc[type] = [cur];
-    }
-    return acc;
-  }
-  , {} as Record<TAgents, RecordType['agents']['value']>);
+  return agents?.value.reduce(
+    (acc, cur) => {
+      const { agentType } = cur.value;
+      const type = agentType.value as TAgents;
+      if (acc[type]) {
+        acc[type].push(cur);
+      } else {
+        acc[type] = [cur];
+      }
+      return acc;
+    }, 
+    {} as Record<TAgents, RecordType['agents']['value']>,
+  );
   
 };

--- a/packages/api-kintone/src/custgroups/helpers/groupAgentsByType.ts
+++ b/packages/api-kintone/src/custgroups/helpers/groupAgentsByType.ts
@@ -1,0 +1,19 @@
+import { TAgents } from 'types';
+import { RecordType } from '../config';
+
+export const groupAgentsByType = (
+  agents: RecordType['agents'],
+) => {
+  return agents?.value.reduce((acc, cur) => {
+    const { agentType } = cur.value;
+    const type = agentType.value as TAgents;
+    if (acc[type]) {
+      acc[type].push(cur);
+    } else {
+      acc[type] = [cur];
+    }
+    return acc;
+  }
+  , {} as Record<TAgents, RecordType['agents']['value']>);
+  
+};

--- a/packages/api-kintone/src/projects/helpers/groupAgentsByType.test.ts
+++ b/packages/api-kintone/src/projects/helpers/groupAgentsByType.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from '@jest/globals';
+import { getProjById } from '../getProjById';
+import { groupAgentsByType } from './groupAgentsByType';
+
+describe('getAgentsByType', () => {
+  it('should return agents by type', async () => {
+    const projRec = await getProjById('adebcd51-aaea-4150-8b21-7373710408e2');
+
+    const result = groupAgentsByType(projRec.agents);
+
+    console.log(result);
+
+    expect(result).toBeDefined();
+  });
+});

--- a/packages/api-kintone/src/projects/helpers/groupAgentsByType.ts
+++ b/packages/api-kintone/src/projects/helpers/groupAgentsByType.ts
@@ -4,16 +4,18 @@ import { RecordType } from '../config';
 export const groupAgentsByType = (
   agents: RecordType['agents'],
 ) => {
-  return agents?.value.reduce((acc, cur) => {
-    const { agentType } = cur.value;
-    const type = agentType.value as TAgents;
-    if (acc[type]) {
-      acc[type].push(cur);
-    } else {
-      acc[type] = [cur];
-    }
-    return acc;
-  }
-  , {} as Record<TAgents, RecordType['agents']['value']>);
+  return agents?.value.reduce(
+    (acc, cur) => {
+      const { agentType } = cur.value;
+      const type = agentType.value as TAgents;
+      if (acc[type]) {
+        acc[type].push(cur);
+      } else {
+        acc[type] = [cur];
+      }
+      return acc;
+    }, 
+    {} as Record<TAgents, RecordType['agents']['value']>,
+  );
   
 };

--- a/packages/api-kintone/src/projects/helpers/groupAgentsByType.ts
+++ b/packages/api-kintone/src/projects/helpers/groupAgentsByType.ts
@@ -1,0 +1,19 @@
+import { TAgents } from 'types';
+import { RecordType } from '../config';
+
+export const groupAgentsByType = (
+  agents: RecordType['agents'],
+) => {
+  return agents?.value.reduce((acc, cur) => {
+    const { agentType } = cur.value;
+    const type = agentType.value as TAgents;
+    if (acc[type]) {
+      acc[type].push(cur);
+    } else {
+      acc[type] = [cur];
+    }
+    return acc;
+  }
+  , {} as Record<TAgents, RecordType['agents']['value']>);
+  
+};

--- a/packages/kokoas-client/src/components/ui/selects/EmployeesSelector/EmployeeSelector.tsx
+++ b/packages/kokoas-client/src/components/ui/selects/EmployeesSelector/EmployeeSelector.tsx
@@ -1,5 +1,5 @@
 import Divider from '@mui/material/Divider';
-import { Box, FormLabel, IconButton, Stack, Tooltip } from '@mui/material';
+import { Box, FormHelperText, FormLabel, IconButton, Stack, Tooltip } from '@mui/material';
 import { SearchByNumber } from './SearchByNumber';
 import { useCallback, useMemo, useState } from 'react';
 import { SearchByName } from './SearchByName';
@@ -15,6 +15,8 @@ export const EmployeeSelector = ({
   onBlur,
   filter,
   required,
+  error,
+  helperText,
 }:{
   label: string,
   /** 社員のuuid */
@@ -23,7 +25,10 @@ export const EmployeeSelector = ({
   onBlur?: () => void,
   filter?: FilterOptions,
   required?: boolean,
+  error?: boolean,
+  helperText?: string,
 }) => {
+
   const [includeInactive, setIncludeInactive] = useState(false);
   const { 
     data,
@@ -57,14 +62,18 @@ export const EmployeeSelector = ({
   return (
     <Stack spacing={0.5} width={300}>
     
-      <FormLabel required={required}>
+      <FormLabel 
+        required={required}
+        error={error}
+      >
         {label}
       </FormLabel>
     
       <Box
         sx={{ 
           bgcolor: 'background.paper',
-          border: '1px solid #ced4da',
+          border: '1px solid',
+          borderColor: error ? 'red' : 'grey.500',
           borderRadius: 1,
           p: '2px 4px', 
           display: 'flex', 
@@ -95,8 +104,10 @@ export const EmployeeSelector = ({
             {!includeInactive && <VisibilityOffIcon />}
           </IconButton>
         </Tooltip>
-        
       </Box>
+      <FormHelperText error={error}>
+        {helperText}
+      </FormHelperText>
     </Stack>
   );
 };

--- a/packages/kokoas-client/src/components/ui/selects/EmployeesSelector/EmployeeSelector.tsx
+++ b/packages/kokoas-client/src/components/ui/selects/EmployeesSelector/EmployeeSelector.tsx
@@ -20,7 +20,7 @@ export const EmployeeSelector = ({
   value: string,
   onChange?: (empId: string,) => void,
   onBlur?: () => void,
-  filter?: FilterOptions
+  filter?: FilterOptions,
 }) => {
   const [includeInactive, setIncludeInactive] = useState(false);
   const { 

--- a/packages/kokoas-client/src/components/ui/selects/EmployeesSelector/EmployeeSelector.tsx
+++ b/packages/kokoas-client/src/components/ui/selects/EmployeesSelector/EmployeeSelector.tsx
@@ -14,6 +14,7 @@ export const EmployeeSelector = ({
   onChange,
   onBlur,
   filter,
+  required,
 }:{
   label: string,
   /** 社員のuuid */
@@ -21,6 +22,7 @@ export const EmployeeSelector = ({
   onChange?: (empId: string,) => void,
   onBlur?: () => void,
   filter?: FilterOptions,
+  required?: boolean,
 }) => {
   const [includeInactive, setIncludeInactive] = useState(false);
   const { 
@@ -55,7 +57,7 @@ export const EmployeeSelector = ({
   return (
     <Stack spacing={0.5} width={300}>
     
-      <FormLabel>
+      <FormLabel required={required}>
         {label}
       </FormLabel>
     

--- a/packages/kokoas-client/src/components/ui/selects/EmployeesSelector/EmployeeSelector.tsx
+++ b/packages/kokoas-client/src/components/ui/selects/EmployeesSelector/EmployeeSelector.tsx
@@ -1,23 +1,13 @@
 import Divider from '@mui/material/Divider';
 import { Box, FormHelperText, FormLabel, IconButton, Stack, Tooltip } from '@mui/material';
 import { SearchByNumber } from './SearchByNumber';
-import { useCallback, useMemo, useState } from 'react';
+import { forwardRef, useCallback, useMemo, useState } from 'react';
 import { SearchByName } from './SearchByName';
 import { FilterOptions, useFilteredEmployees } from './useFilteredEmployees';
 import VisibilityOffIcon from '@mui/icons-material/VisibilityOff';
 import VisibilityIcon from '@mui/icons-material/Visibility';
 
-
-export const EmployeeSelector = ({
-  label,
-  value,
-  onChange,
-  onBlur,
-  filter,
-  required,
-  error,
-  helperText,
-}:{
+interface EmployeeSelectorProps {
   label: string,
   /** 社員のuuid */
   value: string,
@@ -27,7 +17,20 @@ export const EmployeeSelector = ({
   required?: boolean,
   error?: boolean,
   helperText?: string,
-}) => {
+  name?: string,
+}
+
+export const EmployeeSelector = forwardRef<HTMLInputElement, EmployeeSelectorProps>(({
+  label,
+  value,
+  onChange,
+  onBlur,
+  filter,
+  required,
+  error,
+  helperText,
+  name,
+}, ref) => {
 
   const [includeInactive, setIncludeInactive] = useState(false);
   const { 
@@ -89,10 +92,12 @@ export const EmployeeSelector = ({
         <Divider sx={{ height: 28, m: 0.5 }} orientation="vertical" />
 
         <SearchByName
+          name={name}
           onChange={handleChange}
           selectedRecord={selectedEmpRecord}
           filteredData={filteredData}
           onBlur={onBlur}
+          ref={ref}
         />
 
         <Tooltip 
@@ -110,4 +115,6 @@ export const EmployeeSelector = ({
       </FormHelperText>
     </Stack>
   );
-};
+});
+
+EmployeeSelector.displayName = 'EmployeeSelector';

--- a/packages/kokoas-client/src/components/ui/selects/EmployeesSelector/SearchByName.tsx
+++ b/packages/kokoas-client/src/components/ui/selects/EmployeesSelector/SearchByName.tsx
@@ -1,5 +1,5 @@
 import { Autocomplete, InputBase, Stack, Typography, createFilterOptions } from '@mui/material';
-import { useMemo } from 'react';
+import { forwardRef, useMemo } from 'react';
 import { EmpStatus, IEmployees } from 'types';
 
 type Option = {
@@ -11,23 +11,27 @@ type Option = {
   status: EmpStatus,
 };
 
+interface SearchByNameProps {
+  selectedRecord: IEmployees | undefined,
+  filteredData: IEmployees[] | undefined,
+  onChange: (emdId: string | undefined) => void,
+  onBlur?: () => void,
+  name?: string,
+}
+
 const filterOptions = createFilterOptions({
   matchFrom: 'any',
   stringify: (option: Option) => option.empName + option.empNameReading,
 });
 
 
-export const SearchByName = ({
+export const SearchByName = forwardRef<HTMLInputElement, SearchByNameProps >(({
   selectedRecord,
   filteredData,
   onChange,
   onBlur,
-}:{
-  selectedRecord: IEmployees | undefined,
-  filteredData: IEmployees[] | undefined,
-  onChange: (emdId: string | undefined) => void,
-  onBlur?: () => void,
-}) => {
+  name,
+}, ref) => {
 
 
   const options = useMemo(() => {
@@ -99,9 +103,13 @@ export const SearchByName = ({
           <InputBase 
             {...params.InputProps}
             {...rest}
+            name={name}
             placeholder='氏名・ふりがな'
+            inputRef={ref}
           />);
       }}
     />
   );
-};
+});
+
+SearchByName.displayName = 'SearchByName';

--- a/packages/kokoas-client/src/pages/projRegisterV2/Contents.tsx
+++ b/packages/kokoas-client/src/pages/projRegisterV2/Contents.tsx
@@ -7,6 +7,7 @@ import { AndpadSummary } from './sections/andpadSummary/AndpadSummary';
 import { useTypedWatch } from './hooks/useTypedRHF';
 import { CancelStatus } from './sections/cancelStatus.tsx/CancelStatus';
 import { ContractsSummary } from './sections/contractsSummary/ContractsSummary';
+import { OfficersInput } from './sections/officersInput/OfficersInput';
 
 export const Contents = () => {
   const projId = useTypedWatch({
@@ -36,6 +37,9 @@ export const Contents = () => {
 
       <PageSubTitle3 label={'工事情報'} />
       <ProjectInformation />
+
+      <PageSubTitle3 label={'担当者情報'} />
+      <OfficersInput />
 
       <PageSubTitle3 label={'メモ'} />
       <Memo />

--- a/packages/kokoas-client/src/pages/projRegisterV2/api/convertCustGroupToForm.ts
+++ b/packages/kokoas-client/src/pages/projRegisterV2/api/convertCustGroupToForm.ts
@@ -1,5 +1,6 @@
 import { ICustgroups, Territory } from 'types';
 import { TForm } from '../schema';
+import { groupAgentsByType } from 'api-kintone/src/custgroups/helpers/groupAgentsByType';
 
 export const convertCustGroupToForm = (custGroupRec: ICustgroups) : Partial<TForm> => {
   const {
@@ -8,7 +9,13 @@ export const convertCustGroupToForm = (custGroupRec: ICustgroups) : Partial<TFor
     uuid,
     members,
     storeCode,
+    agents,
   } = custGroupRec;
+
+  const {
+    cocoAG,
+    yumeAG,
+  } = groupAgentsByType(agents);
 
   return {
     custGroupId: uuid.value,
@@ -16,6 +23,12 @@ export const convertCustGroupToForm = (custGroupRec: ICustgroups) : Partial<TFor
     territory: territory.value as Territory,
     custName: members.value[0]?.value.customerName.value || '',
     storeCode: storeCode.value,
+
+    cocoAG1: cocoAG?.[0]?.value.employeeId.value || '',
+    cocoAG2: cocoAG?.[1]?.value.employeeId.value || '',
+    yumeAG1: yumeAG?.[0]?.value.employeeId.value || '',
+    yumeAG2: yumeAG?.[1]?.value.employeeId.value || '',
+    
   };
 
 };

--- a/packages/kokoas-client/src/pages/projRegisterV2/api/convertProjToForm.ts
+++ b/packages/kokoas-client/src/pages/projRegisterV2/api/convertProjToForm.ts
@@ -1,8 +1,9 @@
-import { BuildingType, IProjects, RecordCancelStatus, TAgents } from 'types';
+import { BuildingType, IProjects, RecordCancelStatus } from 'types';
 import { TForm } from '../schema';
 import { formatDataId } from 'libs';
 import format from 'date-fns/format';
 import parseISO from 'date-fns/parseISO';
+import { groupAgentsByType } from 'api-kintone/src/projects/helpers/groupAgentsByType';
 
 export const convertProjToForm = (projRec: IProjects) : Partial<TForm> => {
 
@@ -13,10 +14,14 @@ export const convertProjToForm = (projRec: IProjects) : Partial<TForm> => {
     dataId,
     uuid,
      
-    postal, address1, address2,
+    postal, 
+    address1, 
+    address2,
 
     isShowFinalAddress,
-    finalPostal, finalAddress1, finalAddress2,
+    finalPostal, 
+    finalAddress1,
+    finalAddress2,
 
     buildingType, isChkAddressKari, agents, 
     cancelStatus,
@@ -27,9 +32,11 @@ export const convertProjToForm = (projRec: IProjects) : Partial<TForm> => {
     log,
   } = projRec;
 
-  const cocoConst = agents.value.filter(item => {
-    return (item.value.agentType.value as TAgents) === 'cocoConst';
-  }).map(item => item.value.agentId.value);
+  const {
+    cocoAG,
+    cocoConst,
+    yumeAG,
+  } = groupAgentsByType(agents);
 
 
   return {
@@ -45,8 +52,14 @@ export const convertProjToForm = (projRec: IProjects) : Partial<TForm> => {
       .value
       .split(',')
       .filter(Boolean) as RecordCancelStatus[],
-    cocoConst1: cocoConst?.[0] || '',
-    cocoConst2: cocoConst?.[1] || '',
+
+    cocoConst1: cocoConst?.[0]?.value.agentId.value || '',
+    cocoConst2: cocoConst?.[1]?.value.agentId.value || '',
+    cocoAG1: cocoAG?.[0]?.value.agentId.value || '',
+    cocoAG2: cocoAG?.[1]?.value.agentId.value || '',
+    yumeAG1: yumeAG?.[0]?.value.agentId.value || '',
+    yumeAG2: yumeAG?.[1]?.value.agentId.value || '',
+
     createdDate: format(parseISO(createTime.value), 'yyyy/MM/dd'),
     custGroupId: custGroupId.value,
     //isAgentConfirmed: Boolean(+isAgentConfirmed.value),

--- a/packages/kokoas-client/src/pages/projRegisterV2/api/convertToKintone.ts
+++ b/packages/kokoas-client/src/pages/projRegisterV2/api/convertToKintone.ts
@@ -1,11 +1,38 @@
 import {  IProjects, TAgents } from 'types';
 import { TForm } from '../schema';
 
+const convertToAgentsTbl = (
+  empIds: string[],
+  agentType: TAgents,
+) => {
+  return empIds.filter(Boolean)
+    .map(item => {
+      return {
+        id: '',
+        value: {
+          agentType: { value: agentType },
+          agentId: { value: item as string },
+          agentName: { value: '' },
+        },
+      };
+    });
+};
+
 export const convertToKintone = (
   rawValues: TForm,
 ): Partial<IProjects>  => {
   const {
-    cocoConst1, cocoConst2, projTypeId, projName,
+    cocoConst1, 
+    cocoConst2, 
+
+    cocoAG1,
+    cocoAG2,
+
+    yumeAG1,
+    yumeAG2,
+    
+    projTypeId, 
+    projName,
     //sisAgentConfirmed, 
     postal, 
     address1, 
@@ -20,6 +47,14 @@ export const convertToKintone = (
     storeCode,
     memo,
   } = rawValues;
+
+
+
+  const agentsTable = [
+    ...convertToAgentsTbl([cocoConst1, cocoConst2], 'cocoConst'),
+    ...convertToAgentsTbl([cocoAG1, cocoAG2], 'cocoAG'),
+    ...convertToAgentsTbl([yumeAG1, yumeAG2], 'yumeAG'),
+  ];
 
   return {
     ...(custGroupId ? { custGroupId: { value: custGroupId } } : undefined),
@@ -41,18 +76,7 @@ export const convertToKintone = (
     buildingType: { value: buildingType },
     agents: {
       type: 'SUBTABLE',
-      value: [cocoConst1, cocoConst2]
-        .filter(Boolean)
-        .map(item => {
-          return {
-            id: '',
-            value: {
-              agentType: { value: 'cocoConst' as TAgents },
-              agentId: { value: item as string },
-              agentName: { value: '' },
-            },
-          };
-        }),
+      value: agentsTable,
     },
     storeCode: { value: storeCode },
     status: {  value: status  },

--- a/packages/kokoas-client/src/pages/projRegisterV2/api/fieldMapJa.ts
+++ b/packages/kokoas-client/src/pages/projRegisterV2/api/fieldMapJa.ts
@@ -5,8 +5,17 @@ export const fieldMapJa : Record<KForm, string> = {
   address2: '住所2',
   buildingType: '建物種別',
   cancelStatus: 'キャンセルステータス',
+
   cocoConst1: '工事担当者１',
   cocoConst2: '工事担当者２',
+
+  cocoAG1: '営業担当者１',
+  cocoAG2: '営業担当者２',
+
+  yumeAG1: 'ゆめてつAG１',
+  yumeAG2: 'ゆめてつAG２',
+
+
   createdDate: '登録日',
   custGroupId: '顧客グループ',
   custName: '顧客名',

--- a/packages/kokoas-client/src/pages/projRegisterV2/form.ts
+++ b/packages/kokoas-client/src/pages/projRegisterV2/form.ts
@@ -15,6 +15,13 @@ export const initialValues : TForm = {
   
   cocoConst1: '',
   cocoConst2: '',
+
+  yumeAG1: '',
+  yumeAG2: '',
+
+  cocoAG1: '',
+  cocoAG2: '',
+
   postal: '',
   address1: '',
   address2: '',

--- a/packages/kokoas-client/src/pages/projRegisterV2/hooks/useResolveParams.ts
+++ b/packages/kokoas-client/src/pages/projRegisterV2/hooks/useResolveParams.ts
@@ -33,13 +33,37 @@ export const useResolveParams = () => {
 
     if (projIdFromURL && projRec && custGroupRec && contracts) {
 
+      const {
+        cocoAG1,
+        cocoAG2,
+        yumeAG1,
+        yumeAG2,
+        ...restOfProjData
+      } = convertProjToForm(projRec);
+
+      const {
+        cocoAG1: custCocoAG1,
+        cocoAG2: custCocoAG2,
+        yumeAG1: custYumeAG1,
+        yumeAG2: custYumeAG2,
+        ...restOfCustGroupData
+      } = convertCustGroupToForm(custGroupRec);
+
 
       setNewFormVal({
         ...initialValues,
         hasContract: !!hasContract,
         hasCompletedContract: !!completed,
-        ...convertProjToForm(projRec),
-        ...convertCustGroupToForm(custGroupRec),
+
+        ...restOfProjData,
+        ...restOfCustGroupData,
+
+        //　空の場合はcustGroupRecの値を入れる
+        cocoAG1: custCocoAG1 || cocoAG1 || '',
+        cocoAG2: custCocoAG2 || cocoAG2 || '',
+        yumeAG1: custYumeAG1 || yumeAG1 || '',
+        yumeAG2: custYumeAG2 || yumeAG2 || '',
+
       });
 
     } else if (custGroupIdFromURL && !projIdFromURL && custGroupRec) {

--- a/packages/kokoas-client/src/pages/projRegisterV2/hooks/useResolveParams.ts
+++ b/packages/kokoas-client/src/pages/projRegisterV2/hooks/useResolveParams.ts
@@ -59,10 +59,10 @@ export const useResolveParams = () => {
         ...restOfCustGroupData,
 
         //　空の場合はcustGroupRecの値を入れる
-        cocoAG1: custCocoAG1 || cocoAG1 || '',
-        cocoAG2: custCocoAG2 || cocoAG2 || '',
-        yumeAG1: custYumeAG1 || yumeAG1 || '',
-        yumeAG2: custYumeAG2 || yumeAG2 || '',
+        cocoAG1: cocoAG1 || custCocoAG1 || '',
+        cocoAG2: cocoAG2 || custCocoAG2 || '',
+        yumeAG1: yumeAG1 || custYumeAG1 || '',
+        yumeAG2: yumeAG2 || custYumeAG2 || '',
 
       });
 

--- a/packages/kokoas-client/src/pages/projRegisterV2/schema.ts
+++ b/packages/kokoas-client/src/pages/projRegisterV2/schema.ts
@@ -4,12 +4,16 @@ import { z } from 'zod';
 
 z.setErrorMap(zodErrorMapJA());
 
+const nonEmptyDropdown = z.string().nonempty({
+  message: '選択してください。',
+});
+
 export const schema = z.object({
   projId: z.string().optional(),
   projTypeName: z.string(),
-  projTypeId: z.string().nonempty({
-    message: '工事種別を選択してください。',
-  }),
+
+  projTypeId: nonEmptyDropdown,
+  
   projName: z.string().nonempty(),
   projDataId: z.string(),
   createdDate: z.string(),
@@ -23,14 +27,10 @@ export const schema = z.object({
   cocoConst1: z.string(),
   cocoConst2: z.string(),
 
-  yumeAG1: z.string().nonempty({
-    message: 'ゆめてつAG1を選択してください。',
-  }),
+  yumeAG1: nonEmptyDropdown,
   yumeAG2: z.string(),
 
-  cocoAG1: z.string().nonempty({
-    message: 'ここすもAG1を選択してください。',
-  }),
+  cocoAG1: nonEmptyDropdown,
   cocoAG2: z.string(),
 
   postal: z.string(),

--- a/packages/kokoas-client/src/pages/projRegisterV2/schema.ts
+++ b/packages/kokoas-client/src/pages/projRegisterV2/schema.ts
@@ -23,10 +23,14 @@ export const schema = z.object({
   cocoConst1: z.string(),
   cocoConst2: z.string(),
 
-  yumeAG1: z.string(),
+  yumeAG1: z.string().nonempty({
+    message: 'ゆめてつAG1を選択してください。',
+  }),
   yumeAG2: z.string(),
 
-  cocoAG1: z.string(),
+  cocoAG1: z.string().nonempty({
+    message: 'ここすもAG1を選択してください。',
+  }),
   cocoAG2: z.string(),
 
   postal: z.string(),

--- a/packages/kokoas-client/src/pages/projRegisterV2/schema.ts
+++ b/packages/kokoas-client/src/pages/projRegisterV2/schema.ts
@@ -23,6 +23,12 @@ export const schema = z.object({
   cocoConst1: z.string(),
   cocoConst2: z.string(),
 
+  yumeAG1: z.string(),
+  yumeAG2: z.string(),
+
+  cocoAG1: z.string(),
+  cocoAG2: z.string(),
+
   postal: z.string(),
   address1: z.string().nonempty(),
   address2: z.string().nonempty(),

--- a/packages/kokoas-client/src/pages/projRegisterV2/sections/officersInput/CocoAGSelect.tsx
+++ b/packages/kokoas-client/src/pages/projRegisterV2/sections/officersInput/CocoAGSelect.tsx
@@ -6,8 +6,10 @@ import { fieldMapJa } from '../../api/fieldMapJa';
 
 export const CocoAGSelect = ({
   name,
+  required,
 }:{
   name: KForm,
+  required?: boolean,
 }) => {
   const { control } = useTypedFormContext();
 
@@ -28,6 +30,7 @@ export const CocoAGSelect = ({
             value={value as string}
             onChange={onChange}
             onBlur={onBlur}
+            required={required}
             filter={{
               affiliation: ['ここすも'],
               roles:[ 

--- a/packages/kokoas-client/src/pages/projRegisterV2/sections/officersInput/CocoAGSelect.tsx
+++ b/packages/kokoas-client/src/pages/projRegisterV2/sections/officersInput/CocoAGSelect.tsx
@@ -2,12 +2,11 @@ import { EmployeeSelector } from 'kokoas-client/src/components';
 import { useTypedFormContext } from '../../hooks/useTypedRHF';
 import { KForm } from '../../schema';
 import { Controller } from 'react-hook-form';
+import { fieldMapJa } from '../../api/fieldMapJa';
 
-export const CocoConstSelect = ({
-  label,
+export const CocoAGSelect = ({
   name,
 }:{
-  label: string,
   name: KForm,
 }) => {
   const { control } = useTypedFormContext();
@@ -25,7 +24,7 @@ export const CocoConstSelect = ({
       }) => {
         return (
           <EmployeeSelector
-            label={label}
+            label={fieldMapJa[name]}
             value={value as string}
             onChange={onChange}
             onBlur={onBlur}
@@ -38,7 +37,6 @@ export const CocoConstSelect = ({
                 '主任', 
                 '工務', 
                 '営業',
-    
               ],
             }}
           />

--- a/packages/kokoas-client/src/pages/projRegisterV2/sections/officersInput/CocoAGSelect.tsx
+++ b/packages/kokoas-client/src/pages/projRegisterV2/sections/officersInput/CocoAGSelect.tsx
@@ -1,8 +1,6 @@
-import { EmployeeSelector } from 'kokoas-client/src/components';
-import { useTypedFormContext } from '../../hooks/useTypedRHF';
+
 import { KForm } from '../../schema';
-import { Controller } from 'react-hook-form';
-import { fieldMapJa } from '../../api/fieldMapJa';
+import { ControlledEmployeeSelector } from './ControlledEmployeeSelector';
 
 export const CocoAGSelect = ({
   name,
@@ -11,40 +9,12 @@ export const CocoAGSelect = ({
   name: KForm,
   required?: boolean,
 }) => {
-  const { control } = useTypedFormContext();
 
   return (
-    <Controller 
+    <ControlledEmployeeSelector
       name={name}
-      control={control}
-      render={({
-        field: {
-          value,
-          onChange,
-          onBlur,
-        },
-      }) => {
-        return (
-          <EmployeeSelector
-            label={fieldMapJa[name]}
-            value={value as string}
-            onChange={onChange}
-            onBlur={onBlur}
-            required={required}
-            filter={{
-              affiliation: ['ここすも'],
-              roles:[ 
-                '店長', 
-                '店長代理', 
-                '取締役',
-                '主任', 
-                '工務', 
-                '営業',
-              ],
-            }}
-          />
-        );
-      }}
+      affiliation={['ここすも']}
+      required={required}
     />
     
   );

--- a/packages/kokoas-client/src/pages/projRegisterV2/sections/officersInput/CocoAGSelect.tsx
+++ b/packages/kokoas-client/src/pages/projRegisterV2/sections/officersInput/CocoAGSelect.tsx
@@ -46,3 +46,5 @@ export const CocoAGSelect = ({
     
   );
 };
+
+

--- a/packages/kokoas-client/src/pages/projRegisterV2/sections/officersInput/CocoAGSelectSet.tsx
+++ b/packages/kokoas-client/src/pages/projRegisterV2/sections/officersInput/CocoAGSelectSet.tsx
@@ -6,6 +6,7 @@ export const CocoAGSelectSet = () => {
     <Stack direction={'row'} spacing={2}>
       <CocoAGSelect 
         name='cocoAG1'
+        required
       />
       <CocoAGSelect 
         name='cocoAG2'

--- a/packages/kokoas-client/src/pages/projRegisterV2/sections/officersInput/CocoAGSelectSet.tsx
+++ b/packages/kokoas-client/src/pages/projRegisterV2/sections/officersInput/CocoAGSelectSet.tsx
@@ -1,16 +1,30 @@
 import { Stack } from '@mui/material';
 import { CocoAGSelect } from './CocoAGSelect';
+import { useTypedWatch } from '../../hooks';
 
 export const CocoAGSelectSet = () => {
+  const [
+    cocoAG1,
+    cocoAG2,
+  ] = useTypedWatch({
+    name: [
+      'cocoAG1',
+      'cocoAG2',
+    ],
+  });
+
+
   return (
     <Stack direction={'row'} spacing={2}>
       <CocoAGSelect 
         name='cocoAG1'
         required
       />
+      {(cocoAG1 || cocoAG2) && (
       <CocoAGSelect 
         name='cocoAG2'
-      />
+      />)}
+  
     </Stack>
 
   );

--- a/packages/kokoas-client/src/pages/projRegisterV2/sections/officersInput/CocoAGSelectSet.tsx
+++ b/packages/kokoas-client/src/pages/projRegisterV2/sections/officersInput/CocoAGSelectSet.tsx
@@ -1,0 +1,16 @@
+import { Stack } from '@mui/material';
+import { CocoAGSelect } from './CocoAGSelect';
+
+export const CocoAGSelectSet = () => {
+  return (
+    <Stack direction={'row'} spacing={2}>
+      <CocoAGSelect 
+        name='cocoAG1'
+      />
+      <CocoAGSelect 
+        name='cocoAG2'
+      />
+    </Stack>
+
+  );
+}; 

--- a/packages/kokoas-client/src/pages/projRegisterV2/sections/officersInput/CocoConstSelect.tsx
+++ b/packages/kokoas-client/src/pages/projRegisterV2/sections/officersInput/CocoConstSelect.tsx
@@ -1,0 +1,48 @@
+import { EmployeeSelector } from 'kokoas-client/src/components';
+import { useTypedFormContext } from '../../hooks/useTypedRHF';
+import { KForm } from '../../schema';
+import { Controller } from 'react-hook-form';
+import { fieldMapJa } from '../../api/fieldMapJa';
+
+export const CocoConstSelect = ({
+  name,
+}:{
+  name: KForm,
+}) => {
+  const { control } = useTypedFormContext();
+
+  return (
+    <Controller 
+      name={name}
+      control={control}
+      render={({
+        field: {
+          value,
+          onChange,
+          onBlur,
+        },
+      }) => {
+        return (
+          <EmployeeSelector
+            label={fieldMapJa[name]}
+            value={value as string}
+            onChange={onChange}
+            onBlur={onBlur}
+            filter={{
+              affiliation: ['ここすも'],
+              roles:[ 
+                '店長', 
+                '店長代理', 
+                '取締役',
+                '主任', 
+                '工務', 
+                '営業',
+              ],
+            }}
+          />
+        );
+      }}
+    />
+    
+  );
+};

--- a/packages/kokoas-client/src/pages/projRegisterV2/sections/officersInput/CocoConstSelect.tsx
+++ b/packages/kokoas-client/src/pages/projRegisterV2/sections/officersInput/CocoConstSelect.tsx
@@ -1,47 +1,17 @@
-import { EmployeeSelector } from 'kokoas-client/src/components';
-import { useTypedFormContext } from '../../hooks/useTypedRHF';
+
 import { KForm } from '../../schema';
-import { Controller } from 'react-hook-form';
-import { fieldMapJa } from '../../api/fieldMapJa';
+import { ControlledEmployeeSelector } from './ControlledEmployeeSelector';
 
 export const CocoConstSelect = ({
   name,
 }:{
   name: KForm,
 }) => {
-  const { control } = useTypedFormContext();
 
   return (
-    <Controller 
+    <ControlledEmployeeSelector
       name={name}
-      control={control}
-      render={({
-        field: {
-          value,
-          onChange,
-          onBlur,
-        },
-      }) => {
-        return (
-          <EmployeeSelector
-            label={fieldMapJa[name]}
-            value={value as string}
-            onChange={onChange}
-            onBlur={onBlur}
-            filter={{
-              affiliation: ['ここすも'],
-              roles:[ 
-                '店長', 
-                '店長代理', 
-                '取締役',
-                '主任', 
-                '工務', 
-                '営業',
-              ],
-            }}
-          />
-        );
-      }}
+      affiliation={['ここすも']}
     />
     
   );

--- a/packages/kokoas-client/src/pages/projRegisterV2/sections/officersInput/CocoConstSelectSet.tsx
+++ b/packages/kokoas-client/src/pages/projRegisterV2/sections/officersInput/CocoConstSelectSet.tsx
@@ -1,0 +1,16 @@
+import { Stack } from '@mui/material';
+import { CocoConstSelect } from './CocoConstSelect';
+
+export const CocoConstSelectSet = () => {
+  return (
+    <Stack direction={'row'} spacing={2}>
+      <CocoConstSelect 
+        name='cocoConst1'
+      />
+      <CocoConstSelect 
+        name='cocoConst2'
+      />
+    </Stack>
+
+  );
+}; 

--- a/packages/kokoas-client/src/pages/projRegisterV2/sections/officersInput/CocoConstSelectSet.tsx
+++ b/packages/kokoas-client/src/pages/projRegisterV2/sections/officersInput/CocoConstSelectSet.tsx
@@ -1,15 +1,30 @@
 import { Stack } from '@mui/material';
 import { CocoConstSelect } from './CocoConstSelect';
+import { useTypedWatch } from '../../hooks';
 
 export const CocoConstSelectSet = () => {
+  const [
+    cocoConst1,
+    cocoConst2,
+  ] = useTypedWatch({
+    name: [
+      'cocoConst1',
+      'cocoConst2',
+    ],
+  });
+
+
   return (
     <Stack direction={'row'} spacing={2}>
       <CocoConstSelect 
         name='cocoConst1'
       />
+      {(cocoConst1 || cocoConst2) && (
       <CocoConstSelect 
         name='cocoConst2'
       />
+      )}
+
     </Stack>
 
   );

--- a/packages/kokoas-client/src/pages/projRegisterV2/sections/officersInput/ControlledEmployeeSelector.tsx
+++ b/packages/kokoas-client/src/pages/projRegisterV2/sections/officersInput/ControlledEmployeeSelector.tsx
@@ -1,0 +1,62 @@
+import { EmployeeSelector } from 'kokoas-client/src/components';
+import { useTypedFormContext } from '../../hooks/useTypedRHF';
+import { KForm } from '../../schema';
+import { Controller } from 'react-hook-form';
+import { fieldMapJa } from '../../api/fieldMapJa';
+import { EmpAffiliations } from 'types';
+
+export const ControlledEmployeeSelector = ({
+  name,
+  affiliation,
+  required,
+}:{
+  name: KForm,
+  affiliation: EmpAffiliations[]
+  required?: boolean,
+}) => {
+  const { control } = useTypedFormContext();
+
+  return (
+    <Controller 
+      name={name}
+      control={control}
+      render={({
+        field: {
+          value,
+          onChange,
+          onBlur,
+        },
+        fieldState: {
+          isTouched,
+          error,
+        },
+      }) => {
+        const showError = isTouched && !!error;
+
+        return (
+          <EmployeeSelector
+            label={fieldMapJa[name]}
+            value={value as string}
+            onChange={onChange}
+            onBlur={onBlur}
+            error={showError}
+            helperText={error?.message}
+            required={required}
+            filter={{
+              affiliation: affiliation,
+              roles:[ 
+                '店長', 
+                '店長代理', 
+                '取締役',
+                '主任', 
+                '工務', 
+                '営業',
+              ],
+            }}
+          />
+        );
+      }}
+    />
+    
+  );
+};

--- a/packages/kokoas-client/src/pages/projRegisterV2/sections/officersInput/ControlledEmployeeSelector.tsx
+++ b/packages/kokoas-client/src/pages/projRegisterV2/sections/officersInput/ControlledEmployeeSelector.tsx
@@ -21,24 +21,26 @@ export const ControlledEmployeeSelector = ({
       name={name}
       control={control}
       render={({
-        field: {
-          value,
-          onChange,
-          onBlur,
-        },
+        field,
         fieldState: {
           isTouched,
           error,
         },
+        formState: {
+          submitCount,
+        },
       }) => {
-        const showError = isTouched && !!error;
+        const {
+          value,
+          ...fieldRest
+        } = field;
+        const showError = (isTouched || !!submitCount) && !!error;
 
         return (
           <EmployeeSelector
+            {...fieldRest}
             label={fieldMapJa[name]}
             value={value as string}
-            onChange={onChange}
-            onBlur={onBlur}
             error={showError}
             helperText={error?.message}
             required={required}

--- a/packages/kokoas-client/src/pages/projRegisterV2/sections/officersInput/OfficersInput.tsx
+++ b/packages/kokoas-client/src/pages/projRegisterV2/sections/officersInput/OfficersInput.tsx
@@ -1,38 +1,17 @@
 import { Stack } from '@mui/material';
-import { CocoConstSelect } from './CocoConstSelect';
-import { YumeAGSelect } from './YumeAGSelect';
-import { CocoAGSelect } from './CocoAGSelect';
+import { CocoAGSelectSet } from './CocoAGSelectSet';
+import { YumeAGSelectSet } from './YumeAGSelectSet';
+import { CocoConstSelectSet } from './CocoConstSelectSet';
 
 export const OfficersInput = () => {
   return (
     <Stack spacing={2}>
 
-      <Stack direction={'row'} spacing={2}>
-        <YumeAGSelect 
-          name='yumeAG1'
-        />
-        <YumeAGSelect 
-          name='yumeAG2'
-        />
-      </Stack>
+      <CocoAGSelectSet />
 
-      <Stack direction={'row'} spacing={2}>
-        <CocoAGSelect 
-          name='cocoAG1'
-        />
-        <CocoAGSelect 
-          name='cocoAG2'
-        />
-      </Stack>
+      <YumeAGSelectSet />
 
-      <Stack direction={'row'} spacing={2}>
-        <CocoConstSelect 
-          name='cocoConst1'
-        />
-        <CocoConstSelect 
-          name='cocoConst2'
-        />
-      </Stack>
+      <CocoConstSelectSet />
 
     </Stack>
   );

--- a/packages/kokoas-client/src/pages/projRegisterV2/sections/officersInput/OfficersInput.tsx
+++ b/packages/kokoas-client/src/pages/projRegisterV2/sections/officersInput/OfficersInput.tsx
@@ -1,0 +1,39 @@
+import { Stack } from '@mui/material';
+import { CocoConstSelect } from './CocoConstSelect';
+import { YumeAGSelect } from './YumeAGSelect';
+import { CocoAGSelect } from './CocoAGSelect';
+
+export const OfficersInput = () => {
+  return (
+    <Stack spacing={2}>
+
+      <Stack direction={'row'} spacing={2}>
+        <YumeAGSelect 
+          name='yumeAG1'
+        />
+        <YumeAGSelect 
+          name='yumeAG2'
+        />
+      </Stack>
+
+      <Stack direction={'row'} spacing={2}>
+        <CocoAGSelect 
+          name='cocoAG1'
+        />
+        <CocoAGSelect 
+          name='cocoAG2'
+        />
+      </Stack>
+
+      <Stack direction={'row'} spacing={2}>
+        <CocoConstSelect 
+          name='cocoConst1'
+        />
+        <CocoConstSelect 
+          name='cocoConst2'
+        />
+      </Stack>
+
+    </Stack>
+  );
+};

--- a/packages/kokoas-client/src/pages/projRegisterV2/sections/officersInput/YumeAGSelect.tsx
+++ b/packages/kokoas-client/src/pages/projRegisterV2/sections/officersInput/YumeAGSelect.tsx
@@ -35,7 +35,6 @@ export const YumeAGSelect = ({
                 '店長代理', 
                 '取締役',
                 '主任', 
-                '工務', 
                 '営業',
               ],
             }}

--- a/packages/kokoas-client/src/pages/projRegisterV2/sections/officersInput/YumeAGSelect.tsx
+++ b/packages/kokoas-client/src/pages/projRegisterV2/sections/officersInput/YumeAGSelect.tsx
@@ -1,8 +1,6 @@
-import { EmployeeSelector } from 'kokoas-client/src/components';
-import { useTypedFormContext } from '../../hooks/useTypedRHF';
+
 import { KForm } from '../../schema';
-import { Controller } from 'react-hook-form';
-import { fieldMapJa } from '../../api/fieldMapJa';
+import { ControlledEmployeeSelector } from './ControlledEmployeeSelector';
 
 export const YumeAGSelect = ({
   name,
@@ -11,39 +9,12 @@ export const YumeAGSelect = ({
   name: KForm,
   required?: boolean,
 }) => {
-  const { control } = useTypedFormContext();
 
   return (
-    <Controller 
+    <ControlledEmployeeSelector
       name={name}
-      control={control}
-      render={({
-        field: {
-          value,
-          onChange,
-          onBlur,
-        },
-      }) => {
-        return (
-          <EmployeeSelector
-            label={fieldMapJa[name]}
-            value={value as string}
-            onChange={onChange}
-            onBlur={onBlur}
-            required={required}
-            filter={{
-              affiliation: ['ゆめてつ'],
-              roles:[ 
-                '店長', 
-                '店長代理', 
-                '取締役',
-                '主任', 
-                '営業',
-              ],
-            }}
-          />
-        );
-      }}
+      affiliation={['ゆめてつ']}
+      required={required}
     />
     
   );

--- a/packages/kokoas-client/src/pages/projRegisterV2/sections/officersInput/YumeAGSelect.tsx
+++ b/packages/kokoas-client/src/pages/projRegisterV2/sections/officersInput/YumeAGSelect.tsx
@@ -1,0 +1,48 @@
+import { EmployeeSelector } from 'kokoas-client/src/components';
+import { useTypedFormContext } from '../../hooks/useTypedRHF';
+import { KForm } from '../../schema';
+import { Controller } from 'react-hook-form';
+import { fieldMapJa } from '../../api/fieldMapJa';
+
+export const YumeAGSelect = ({
+  name,
+}:{
+  name: KForm,
+}) => {
+  const { control } = useTypedFormContext();
+
+  return (
+    <Controller 
+      name={name}
+      control={control}
+      render={({
+        field: {
+          value,
+          onChange,
+          onBlur,
+        },
+      }) => {
+        return (
+          <EmployeeSelector
+            label={fieldMapJa[name]}
+            value={value as string}
+            onChange={onChange}
+            onBlur={onBlur}
+            filter={{
+              affiliation: ['ゆめてつ'],
+              roles:[ 
+                '店長', 
+                '店長代理', 
+                '取締役',
+                '主任', 
+                '工務', 
+                '営業',
+              ],
+            }}
+          />
+        );
+      }}
+    />
+    
+  );
+};

--- a/packages/kokoas-client/src/pages/projRegisterV2/sections/officersInput/YumeAGSelect.tsx
+++ b/packages/kokoas-client/src/pages/projRegisterV2/sections/officersInput/YumeAGSelect.tsx
@@ -6,8 +6,10 @@ import { fieldMapJa } from '../../api/fieldMapJa';
 
 export const YumeAGSelect = ({
   name,
+  required,
 }:{
   name: KForm,
+  required?: boolean,
 }) => {
   const { control } = useTypedFormContext();
 
@@ -28,6 +30,7 @@ export const YumeAGSelect = ({
             value={value as string}
             onChange={onChange}
             onBlur={onBlur}
+            required={required}
             filter={{
               affiliation: ['ゆめてつ'],
               roles:[ 

--- a/packages/kokoas-client/src/pages/projRegisterV2/sections/officersInput/YumeAGSelectSet.tsx
+++ b/packages/kokoas-client/src/pages/projRegisterV2/sections/officersInput/YumeAGSelectSet.tsx
@@ -1,16 +1,30 @@
 import { Stack } from '@mui/material';
 import { YumeAGSelect } from './YumeAGSelect';
+import { useTypedWatch } from '../../hooks';
 
 export const YumeAGSelectSet = () => {
+  const [
+    yumeAG1,
+    yumeAG2,
+  ] = useTypedWatch({
+    name: [
+      'yumeAG1',
+      'yumeAG2',
+    ],
+  });
+
   return (
     <Stack direction={'row'} spacing={2}>
       <YumeAGSelect 
         name='yumeAG1'
         required
       />
+      {(yumeAG1 || yumeAG2) && (
       <YumeAGSelect 
         name='yumeAG2'
       />
+      )}
+
     </Stack>
 
   );

--- a/packages/kokoas-client/src/pages/projRegisterV2/sections/officersInput/YumeAGSelectSet.tsx
+++ b/packages/kokoas-client/src/pages/projRegisterV2/sections/officersInput/YumeAGSelectSet.tsx
@@ -1,0 +1,16 @@
+import { Stack } from '@mui/material';
+import { YumeAGSelect } from './YumeAGSelect';
+
+export const YumeAGSelectSet = () => {
+  return (
+    <Stack direction={'row'} spacing={2}>
+      <YumeAGSelect 
+        name='yumeAG1'
+      />
+      <YumeAGSelect 
+        name='yumeAG2'
+      />
+    </Stack>
+
+  );
+}; 

--- a/packages/kokoas-client/src/pages/projRegisterV2/sections/officersInput/YumeAGSelectSet.tsx
+++ b/packages/kokoas-client/src/pages/projRegisterV2/sections/officersInput/YumeAGSelectSet.tsx
@@ -6,6 +6,7 @@ export const YumeAGSelectSet = () => {
     <Stack direction={'row'} spacing={2}>
       <YumeAGSelect 
         name='yumeAG1'
+        required
       />
       <YumeAGSelect 
         name='yumeAG2'

--- a/packages/kokoas-client/src/pages/projRegisterV2/sections/projectInformation/ProjectInformation.tsx
+++ b/packages/kokoas-client/src/pages/projRegisterV2/sections/projectInformation/ProjectInformation.tsx
@@ -1,7 +1,6 @@
 import { ProjectType } from './ProjectType';
 import { Stack } from '@mui/material';
 import { ControlledTextField } from '../../fields/ControlledTextField';
-import { CocoConstSelect } from './CocoConstSelect';
 import { useTypedWatch } from '../../hooks';
 import { BuildingType } from '../../fields/BuildingType';
 
@@ -29,16 +28,7 @@ export const ProjectInformation = () => {
         disabled={hasContract}
         required
       />
-      <Stack direction={'row'} spacing={2}>
-        <CocoConstSelect 
-          label={'工事担当者１'}
-          name='cocoConst1'
-        />
-        <CocoConstSelect 
-          label={'工事担当者２'}
-          name='cocoConst2'
-        />
-      </Stack>
+
 
     </Stack>
   );


### PR DESCRIPTION
## 変更

1. EmployeeSelectorをforwardRefでラップしました。
2. EmployeeSelectorのエラー状態の表示を修正しました。
3. 空のゆめてつAGおよびここすも営業担当者のフォールバックロジックを追加しました。
4. 新しいフィールドを含めた保存プロセスを更新しました。

## 理由

1. refが必要なコンポーネント(ToolTip)とRHFの自動フォーカスの機能を採用するため。
2. 前は最低限の実装で、エラーステートの表示はなかったため。
3. 既存データは空になるので、顧客情報から引っ張る。
4. 新フィールドはDBに反映するため