### PR TITLE
入金一覧バックアップ処理を、ブラウザのタブ1つで動かす

### DIFF
--- a/packages-automation/auto-andpadPaymentBackup/src/preparePaymentAlert.ts
+++ b/packages-automation/auto-andpadPaymentBackup/src/preparePaymentAlert.ts
@@ -1,4 +1,4 @@
-import { headFullBrowser } from 'auto-common';
+import { getPageFromBrowser, headFullBrowser } from 'auto-common';
 import { login } from './login/login';
 import { downloadPaymentfile } from './downloadPaymentsData/downloadPaymentsData';
 import { uploadSingleCSV } from '../../auto-kintone/src/uploadCSV';
@@ -10,9 +10,11 @@ export const preparePaymentAlert = async () => {
 
   // ブラウザを開く
   const browser = await headFullBrowser();
-  const page = await browser.newPage();
+  const page = await getPageFromBrowser(browser);
+  // TODO クッキーの存在を確認
 
   await login(page); // andpadログイン
+  // TODO ログインに成功したら、クッキーの保存
 
   await downloadPaymentfile(page);
 


### PR DESCRIPTION
## 変更

1. 入金一覧のバックアップ処理を、新しいタブを開かずにタブ1つのみで操作します

## 理由

1. 新しいタブを開いて処理すると、エラーになってしまうことがあるため

