### PR TITLE
K151-K150-原価管理表のテンプレートファイルを修正しました

### DIFF
--- a/packages/kokoas-server/src/handleRequest/reqCostManagement/createCostMngExcel/createCostMngXlsx.ts
+++ b/packages/kokoas-server/src/handleRequest/reqCostManagement/createCostMngExcel/createCostMngXlsx.ts
@@ -43,7 +43,7 @@ export const createCostMngXlsx = async (costManagement: GetCostMgtData) => {
   const costMngFilePath = getFilePath({
     fileName: '原価見積',
     fileType: 'xlsx',
-    version: '20230808',
+    version: '20230823',
   });
 
   // Read excel file.


### PR DESCRIPTION
## 変更

1. 原価管理表のテンプレートファイルを修正しました

## 理由

1. セルの書式修正のため
2. ページの印刷設定修正のため

## テスト

- reqCostManagement/createCostMngExcel/createCostMngXlsx.test.ts を実行
