### PR TITLE
K137- 補助金の横にある「工事に含む」と「顧客に返金」のラジオボタンを削除しました

### DIFF
--- a/packages/kokoas-client/src/pages/projContractV2/api/convertContractToForm.ts
+++ b/packages/kokoas-client/src/pages/projContractV2/api/convertContractToForm.ts
@@ -38,7 +38,7 @@ export const convertContractToForm = (
 
     hasSubsidy,
     subsidyAmt,
-    subsidyMethod,
+    //subsidyMethod,
 
     payMethod,
     payDestination,
@@ -114,7 +114,7 @@ export const convertContractToForm = (
     hasSubsidy: hasSubsidy.value === 'はい',
     subsidyAmt: +subsidyAmt.value,
 
-    subsidyMethod: subsidyMethod.value as TypeOfForm['subsidyMethod'],
+    //subsidyMethod: subsidyMethod.value as TypeOfForm['subsidyMethod'],
     payMethod: payMethod.value as TypeOfForm['payMethod'],
 
     payDestination: payDestination.value,

--- a/packages/kokoas-client/src/pages/projContractV2/api/convertToKintone.ts
+++ b/packages/kokoas-client/src/pages/projContractV2/api/convertToKintone.ts
@@ -39,7 +39,7 @@ export const convertToKintone = ({
 
   hasSubsidy,
   subsidyAmt,
-  subsidyMethod,
+  //subsidyMethod,
 
   payMethod,
   payDestination,
@@ -88,7 +88,7 @@ export const convertToKintone = ({
 
     hasSubsidy: { value: hasSubsidy ? 'はい' : 'いいえ' },
     subsidyAmt: { value: (hasSubsidy ? subsidyAmt : 0).toString() },
-    subsidyMethod: { value: subsidyMethod },
+    //subsidyMethod: { value: subsidyMethod },
 
     payMethod: { value: payMethod },
     payDestination: { value: payDestination ?? '' },

--- a/packages/kokoas-client/src/pages/projContractV2/form.ts
+++ b/packages/kokoas-client/src/pages/projContractV2/form.ts
@@ -42,7 +42,7 @@ export const initialForm : TypeOfForm = {
 
   hasSubsidy: false,
   subsidyAmt: 0,
-  subsidyMethod: '顧客に返金',
+  //subsidyMethod: '顧客に返金',
   
   payMethod: '振込',
   payDestination: '豊田信用金庫　朝日支店',

--- a/packages/kokoas-client/src/pages/projContractV2/parts/SubsidyAmount.tsx
+++ b/packages/kokoas-client/src/pages/projContractV2/parts/SubsidyAmount.tsx
@@ -1,6 +1,6 @@
-import { Checkbox, FormControl, FormControlLabel, Radio, RadioGroup, Stack } from '@mui/material';
-import { Controller, useFormContext, useWatch } from 'react-hook-form';
-import { TypeOfForm, subsidyMethods } from '../schema';
+import { Checkbox, FormControlLabel, Stack } from '@mui/material';
+import { useFormContext, useWatch } from 'react-hook-form';
+import { TypeOfForm } from '../schema';
 import { ControlledCurrencyInput } from '../fields/ControlledCurrencyInput';
 
 export const SubsidyAmount = () => {
@@ -40,7 +40,7 @@ export const SubsidyAmount = () => {
       />
 
       {/* uncontrolledのやり方だと null　になるので、controlledにする */}
-      <Controller
+      {/* <Controller
         name={'subsidyMethod'}
         control={control}
         render={({
@@ -70,7 +70,7 @@ export const SubsidyAmount = () => {
             </FormControl>
           );
         }}
-      />
+      /> */}
     </Stack>
   );
 };

--- a/packages/kokoas-client/src/pages/projContractV2/schema.tsx
+++ b/packages/kokoas-client/src/pages/projContractV2/schema.tsx
@@ -101,8 +101,10 @@ const schema = z.object({
   /** 補助金 */
   subsidyAmt: z.number(),
   
-  /** 補助種類 */
-  subsidyMethod: z.enum(subsidyMethods),
+  /** 補助種類 
+   * Removed at K137
+  */
+  // subsidyMethod: z.enum(subsidyMethods),
   
   /** 支払い方法 */
   payMethod: z.enum(payMethods),


### PR DESCRIPTION
## 変更

1. 補助金の横にある「工事に含む」と「顧客に返金」のラジオボタンを削除しました

## 理由

1. 依頼