### PR TITLE
hotfix-genkakanri are not loaded

### DIFF
--- a/packages/api-andpad/src/@get/getBudgetBySystemId.test.ts
+++ b/packages/api-andpad/src/@get/getBudgetBySystemId.test.ts
@@ -7,12 +7,13 @@ import path from 'path';
 describe('getBudgetBySystemId', () => {
 
   it('should return data', async () => {
-    const result = await getBudgetBySystemId(11487098);
+    const testSystemId = 11648284;
+    const result = await getBudgetBySystemId(testSystemId);
 
     console.log(result.data[0]);
 
 
-    fs.writeFileSync(path.resolve(__dirname, '__TEST__', './getBudgetBySystemId.json'), JSON.stringify(result, null, 2));
+    fs.writeFileSync(path.join(__dirname, `__TEST__/getBudgetBySystemId_${testSystemId}.json`), JSON.stringify(result, null, 2));
 
   }, 50000);
 });

--- a/packages/api-andpad/src/@get/getMonthlyProcurementBySystemId.test.ts
+++ b/packages/api-andpad/src/@get/getMonthlyProcurementBySystemId.test.ts
@@ -5,14 +5,15 @@ import path from 'path';
 
 describe('getMonthlyProcurementBySystemId', () => {
   it('should get data by systemId', async () => {
+    const testSystemId = 11648284;
 
-    const result = await getMonthlyProcurementBySystemId(11908295);
+    const result = await getMonthlyProcurementBySystemId(testSystemId);
 
     console.log(result.data.months);
 
     expect(result).toBeDefined();
 
-    fs.writeFileSync(path.resolve(__dirname, '__TEST__', './getMonthlyProcurementBySystemId.json'), JSON.stringify(result, null, 2));
+    fs.writeFileSync(path.resolve(__dirname, '__TEST__', `./getMonthlyProcurementBySystemId_${testSystemId}.json`), JSON.stringify(result, null, 2));
   }, 60000);
 
 });

--- a/packages/api-kintone/src/andpadProcurement/calculation/calcProfitability.ts
+++ b/packages/api-kintone/src/andpadProcurement/calculation/calcProfitability.ts
@@ -24,17 +24,7 @@ export interface CostManagement {
 }
 
 
-export const calcProfitability = ({
-  orderAmountAfterTax,
-  additionalAmountAfterTax,
-  purchaseAmount,
-  paymentAmount,
-  depositAmount,
-  yumeCommFeeRate,
-  tax,
-  hasRefund,
-  subsidyAmt = 0,
-}: {
+export const calcProfitability = (params: {
   orderAmountAfterTax: number // 受注金額(税込)
   additionalAmountAfterTax: number // 追加金額(税込)
   purchaseAmount: number // 実行予算金額
@@ -45,6 +35,20 @@ export const calcProfitability = ({
   hasRefund: boolean // 返金有無(0: なし, 1: あり)
   subsidyAmt?: number // 補助金額
 }): CostManagement => {
+
+  console.log('CalcProfitability params', params);
+
+  const {
+    orderAmountAfterTax,
+    additionalAmountAfterTax,
+    purchaseAmount,
+    paymentAmount,
+    depositAmount,
+    yumeCommFeeRate,
+    tax,
+    hasRefund,
+    subsidyAmt = 0,
+  } = params;
 
   const taxForCalc = Big(tax).add(1);
 
@@ -71,16 +75,22 @@ export const calcProfitability = ({
     .toNumber();
 
   /** 予定利益率 */
-  const plannedProfitMargin = Big(plannedProfit).div(orderTotalBeforeTax)
-    .mul(100)
-    .round(2, 1)
-    .toNumber();
+  const plannedProfitMargin = orderTotalBeforeTax 
+    ? Big(plannedProfit)
+      .div(orderTotalBeforeTax)
+      .mul(100)
+      .round(2, 1)
+      .toNumber()
+    : 0;
 
   /** 実利益率 */
-  const actualProfitMargin = Big(actualProfit).div(orderTotalBeforeTax)
-    .mul(100)
-    .round(2, 1)
-    .toNumber();
+  const actualProfitMargin = orderTotalBeforeTax 
+    ?  Big(actualProfit)
+      .div(orderTotalBeforeTax)
+      .mul(100)
+      .round(2, 1)
+      .toNumber()
+    : 0;
 
   /** 実利益税抜_夢てつ */
   const yumeActualProfit = Big(actualProfit).mul(yumeCommFeeRate)

--- a/packages/api-kintone/src/andpadProcurement/getAndpadProcurementByAndpadProjId.test.ts
+++ b/packages/api-kintone/src/andpadProcurement/getAndpadProcurementByAndpadProjId.test.ts
@@ -5,7 +5,7 @@ import path from 'path';
 
 describe('getAndpadProcurementByAndpadProjId.test', () => {
   it('should get andpad orders by andpadProjId', async () => {
-    const systemId = '11908295';
+    const systemId = '11648284';
     const result = await getAndpadProcurementByAndpadProjId(systemId);
 
     console.log(result);

--- a/packages/kokoas-server/src/handleRequest/reqCostManagement/getCostMgtDataByProjIdV4.test.ts
+++ b/packages/kokoas-server/src/handleRequest/reqCostManagement/getCostMgtDataByProjIdV4.test.ts
@@ -7,7 +7,7 @@ import { getCostMgtDataByProjIdV4 } from './getCostMgtDataByProjIdV4';
 
 describe('getCostMgtDataV4', () => {
   it('should get andpad orders by AndpadProjId', async () => {
-    const projId = '055c2aca-cbdd-42ab-be2a-e4cd6dd362de';
+    const projId = '3db572e5-8953-476b-a827-16725a7a99d7';
 
     const result = await getCostMgtDataByProjIdV4(projId);
 

--- a/packages/kokoas-server/src/handleRequest/reqCostManagement/getCostMgtDataByProjIdV4.ts
+++ b/packages/kokoas-server/src/handleRequest/reqCostManagement/getCostMgtDataByProjIdV4.ts
@@ -63,6 +63,7 @@ export const getCostMgtDataByProjIdV4 = async (
   const andpadProcurements = await getAndpadProcurementByAndpadProjId(andpadSystemId); // 発注実績
 
   // 発注会社ごとにデータを整形する
+  console.log('Converting andpadbudgets') ;
   const costManagemenList = convertMonthlyProcurementV3(andpadBudgetExecution, andpadProcurements);
 
 
@@ -75,12 +76,14 @@ export const getCostMgtDataByProjIdV4 = async (
 
   // 取得したデータを整形する
 
+  console.log('Retrieving Payment Data...');
   /** 入金 */
   const depositAmount = (await getAndpadPaymentsBySystemId(andpadSystemId)) // andpad入金情報：入金額総額
     .reduce((acc, { paymentAmount }) => {
       return acc + +paymentAmount.value;
     }, 0);
 
+  console.log('Retrieving Contracts Data...');
   const contracts = (await getContractsByProjId(projId))
     .reduce((acc, {
       contractType,
@@ -114,7 +117,7 @@ export const getCostMgtDataByProjIdV4 = async (
       補助金: 0,
     });
 
-
+  console.log('Calculating Profitability...');
   const {
     orderAmountBeforeTax,
     additionalAmountBeforeTax,

--- a/packages/kokoas-server/src/handleRequest/reqCostManagement/helpers/convertMonthlyProcurementV3.test.ts
+++ b/packages/kokoas-server/src/handleRequest/reqCostManagement/helpers/convertMonthlyProcurementV3.test.ts
@@ -22,6 +22,8 @@ describe('convertMonthlyProcurement', () => {
 
     const result = convertMonthlyProcurementV3(testDataBE, testDataAP);
 
-    console.log(JSON.stringify(result, null, 2));
+    const savePath = path.join(__dirname, '__TEST__/convertMonthlyProcurementV3.json');
+    fs.writeFileSync(savePath, JSON.stringify(result, null, 2));
+
   }, 50000);
 });


### PR DESCRIPTION
## 変更

- ココアス上、契約データがなくて、ゼロで割るエラーが発生しました。契約無くても、表示するよう修正しました。
- 発注に「請負承認待ち」しかないので、年月の生成の処理にエラーがありました。現在、支払い欄に含まない状態の一つのものです。
年月の生成処理は発注状態に関係なく行うようにして、修正しました。
