### PR TITLE
会議資料用 店舗ソート完了

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -123,7 +123,7 @@
         "@jest/globals": "^29.5.0",
         "@kintone/customize-uploader": "^7.0.2",
         "@kintone/dts-gen": "^7.0.4",
-        "@nrwl/nx-cloud": "*",
+        "@nrwl/nx-cloud": "latest",
         "@tsconfig/node16": "^16.1.0",
         "@types/big.js": "^6.1.6",
         "@types/docusign-esign": "^5.6.2",
@@ -33878,7 +33878,7 @@
     },
     "packages/api-openAI": {
       "name": "api-openai",
-      "version": "0.0.1",
+      "version": "0.0.0",
       "dependencies": {
         "config": "*",
         "helpers": "*",

--- a/packages-kintone-customize/app-229-contracts/jsedit/api/getAllStoresMeeting.ts
+++ b/packages-kintone-customize/app-229-contracts/jsedit/api/getAllStoresMeeting.ts
@@ -1,0 +1,14 @@
+
+
+import { ktRecord } from 'api-kintone';
+import { AppIds } from 'config';
+import { IStores } from 'types';
+
+
+
+export const getAllStoresMeeting = async () => {
+  return (await ktRecord()).getRecords({
+    app: AppIds.stores, 
+    query: 'meetingNumber > 0 order by meetingNumber desc', 
+  }).then(({ records }) => records as unknown as IStores[]);
+};

--- a/packages-kintone-customize/app-229-contracts/jsedit/api/getCachedStores.ts
+++ b/packages-kintone-customize/app-229-contracts/jsedit/api/getCachedStores.ts
@@ -1,6 +1,6 @@
-import { getAllStores } from 'api-kintone';
 import { isEmpty } from 'lodash';
 import { IStores } from 'types';
+import { getAllStoresMeeting } from './getAllStoresMeeting';
 
 let storeRecords: IStores[] = Object.create(null);
 
@@ -13,7 +13,7 @@ let storeRecords: IStores[] = Object.create(null);
  */
 export const getCachedStores = async () => {
   if (isEmpty(storeRecords)) {
-    storeRecords = await getAllStores();
+    storeRecords = await getAllStoresMeeting();
   }
   return storeRecords;
 };


### PR DESCRIPTION
## 変更

1. 変更内容

## 理由

1. 変更理由
ココアスとは別に、ゆめてつとの共有会議資料の順番を店舗リストに追加。
フィールド名：会議資料用 順番　フィールドコード：meetingNumber
会議資料関係の順番は以降こちらを使用します。
ファイル名：getAllStoresMeeting.ts

## テスト

- 実行方法
