### PR TITLE
hotfix-K206-契約済で工事種別が空だとバリデーションのエラーが出ます

### DIFF
--- a/packages/kokoas-client/src/pages/projRegisterV2/api/convertToKintone.ts
+++ b/packages/kokoas-client/src/pages/projRegisterV2/api/convertToKintone.ts
@@ -72,7 +72,7 @@ export const convertToKintone = (
   return {
     ...(custGroupId ? { custGroupId: { value: custGroupId } } : undefined),
 
-    projTypeId: { value: projTypeId },
+    projTypeId: { value: projTypeId || '' },
     projName: { value: projName },
     otherProjType: { value: otherProjType || '' },
     

--- a/packages/kokoas-client/src/pages/projRegisterV2/schema.ts
+++ b/packages/kokoas-client/src/pages/projRegisterV2/schema.ts
@@ -12,12 +12,12 @@ export const schema = z.object({
   projId: z.string().optional(),
   projTypeName: z.string(),
 
-  projTypeId: z.string(),
-  projName: z.string(),
+  projTypeId: nonEmptyDropdown,
+  projName: z.string().nonempty(),
   otherProjType: z.string().optional(),
 
-  projDataId: nonEmptyDropdown,
-  createdDate: z.string().nonempty(),
+  projDataId: z.string(),
+  createdDate: z.string(),
   storeCode: z.string(),
 
   custGroupId: z.string().nullable(),
@@ -78,7 +78,6 @@ export const schema = z.object({
       isShowFinalAddress,
       finalAddress1,
       finalAddress2,
-
       projTypeName,
       otherProjType,
 

--- a/packages/kokoas-client/src/pages/projRegisterV2/schema.ts
+++ b/packages/kokoas-client/src/pages/projRegisterV2/schema.ts
@@ -16,8 +16,8 @@ export const schema = z.object({
   projName: z.string(),
   otherProjType: z.string().optional(),
 
-  projDataId: z.string(),
-  createdDate: z.string(),
+  projDataId: nonEmptyDropdown,
+  createdDate: z.string().nonempty(),
   storeCode: z.string(),
 
   custGroupId: z.string().nullable(),
@@ -79,7 +79,6 @@ export const schema = z.object({
       finalAddress1,
       finalAddress2,
 
-      projTypeId,
       projTypeName,
       otherProjType,
 
@@ -102,16 +101,6 @@ export const schema = z.object({
           code: z.ZodIssueCode.custom,
           message: '住所を入力してください。',
           path: ['finalAddress2'],
-        });
-      }
-    }
-
-    if (!hasContract) {
-      if (!projTypeId) {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          message: '工事種別を入力してください。',
-          path: ['projTypeId'],
         });
       }
     }

--- a/packages/kokoas-client/src/pages/projRegisterV2/schema.ts
+++ b/packages/kokoas-client/src/pages/projRegisterV2/schema.ts
@@ -78,6 +78,7 @@ export const schema = z.object({
       isShowFinalAddress,
       finalAddress1,
       finalAddress2,
+      
       projTypeName,
       otherProjType,
 

--- a/packages/kokoas-client/src/pages/projRegisterV2/schema.ts
+++ b/packages/kokoas-client/src/pages/projRegisterV2/schema.ts
@@ -12,8 +12,8 @@ export const schema = z.object({
   projId: z.string().optional(),
   projTypeName: z.string(),
 
-  projTypeId: nonEmptyDropdown,
-  projName: z.string().nonempty(),
+  projTypeId: z.string(),
+  projName: z.string(),
   otherProjType: z.string().optional(),
 
   projDataId: z.string(),
@@ -79,6 +79,7 @@ export const schema = z.object({
       finalAddress1,
       finalAddress2,
 
+      projTypeId,
       projTypeName,
       otherProjType,
 
@@ -101,6 +102,16 @@ export const schema = z.object({
           code: z.ZodIssueCode.custom,
           message: '住所を入力してください。',
           path: ['finalAddress2'],
+        });
+      }
+    }
+
+    if (!hasContract) {
+      if (!projTypeId) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: '工事種別を入力してください。',
+          path: ['projTypeId'],
         });
       }
     }

--- a/packages/kokoas-client/src/pages/projRegisterV2/sections/projectInformation/OtherProjType.tsx
+++ b/packages/kokoas-client/src/pages/projRegisterV2/sections/projectInformation/OtherProjType.tsx
@@ -2,11 +2,7 @@ import { Controller } from 'react-hook-form';
 import { useTypedFormContext, useTypedWatch } from '../../hooks';
 import { TextField } from '@mui/material';
 
-export const OtherProjType = ({
-  disabled,
-}:{
-  disabled?: boolean
-}) => {
+export const OtherProjType = () => {
   const {
     control,
     setValue,
@@ -56,7 +52,7 @@ export const OtherProjType = ({
               setValue('projName', `${custName}様邸　${newValue || projTypeName}`);
             }}
             {...otherField}
-            disabled={disabled}
+            //disabled={disabled}
             size='small'
             error={showError} 
             helperText={error?.message}

--- a/packages/kokoas-client/src/pages/projRegisterV2/sections/projectInformation/ProjectInformation.tsx
+++ b/packages/kokoas-client/src/pages/projRegisterV2/sections/projectInformation/ProjectInformation.tsx
@@ -20,7 +20,7 @@ export const ProjectInformation = () => {
       <BuildingType disabled={hasContract} />
 
 
-      <ProjectType disabled={hasContract} />
+      <ProjectType />
 
       <ControlledTextField
         label='工事名称'

--- a/packages/kokoas-client/src/pages/projRegisterV2/sections/projectInformation/ProjectType.tsx
+++ b/packages/kokoas-client/src/pages/projRegisterV2/sections/projectInformation/ProjectType.tsx
@@ -1,6 +1,6 @@
 import { FormControl, FormHelperText, InputLabel, MenuItem, Select, Stack } from '@mui/material';
 import { useProjTypes } from 'kokoas-client/src/hooksQuery';
-import { useTypedFormContext, useTypedWatch } from '../../hooks/useTypedRHF';
+import { useTypedFormContext } from '../../hooks/useTypedRHF';
 import { Controller } from 'react-hook-form';
 import { useEffect } from 'react';
 import { OtherProjType } from './OtherProjType';

--- a/packages/kokoas-client/src/pages/projRegisterV2/sections/projectInformation/ProjectType.tsx
+++ b/packages/kokoas-client/src/pages/projRegisterV2/sections/projectInformation/ProjectType.tsx
@@ -62,7 +62,7 @@ export const ProjectType = ({
               }}
               placeholder='工事種別'
               error={showError}
-              disabled={disabled}
+              //disabled={disabled}
               required
             >
               <InputLabel>

--- a/packages/kokoas-client/src/pages/projRegisterV2/sections/projectInformation/ProjectType.tsx
+++ b/packages/kokoas-client/src/pages/projRegisterV2/sections/projectInformation/ProjectType.tsx
@@ -111,7 +111,7 @@ export const ProjectType = ({
             </FormControl>
 
             
-            <OtherProjType disabled={disabled} />
+            <OtherProjType />
             
   
           </Stack>

--- a/packages/kokoas-client/src/pages/projRegisterV2/sections/projectInformation/ProjectType.tsx
+++ b/packages/kokoas-client/src/pages/projRegisterV2/sections/projectInformation/ProjectType.tsx
@@ -6,11 +6,7 @@ import { useEffect } from 'react';
 import { OtherProjType } from './OtherProjType';
 
 
-export const ProjectType = ({
-  disabled,
-}:{
-  disabled?: boolean;
-}) => {
+export const ProjectType = () => {
   const { control, setValue, register, getValues } = useTypedFormContext();
 
   const { data: projTypeOptions } = useProjTypes({

--- a/packages/kokoas-client/src/pages/projRegisterV2/sections/projectInformation/ProjectType.tsx
+++ b/packages/kokoas-client/src/pages/projRegisterV2/sections/projectInformation/ProjectType.tsx
@@ -76,10 +76,10 @@ export const ProjectType = () => {
                   const custName = getValues('custName');
                   const hasContract = getValues('hasContract');
 
+                  setValue('projTypeName', newProjTypeName);
                   
                   if (!hasContract) {
                     // 契約がないときのみ、工事名称を変更する
-                    setValue('projTypeName', newProjTypeName);
                     setValue('projName', `${custName}様邸　${newProjTypeName}`);
                   }
                 

--- a/packages/kokoas-client/src/pages/projRegisterV2/sections/projectInformation/ProjectType.tsx
+++ b/packages/kokoas-client/src/pages/projRegisterV2/sections/projectInformation/ProjectType.tsx
@@ -1,6 +1,6 @@
 import { FormControl, FormHelperText, InputLabel, MenuItem, Select, Stack } from '@mui/material';
 import { useProjTypes } from 'kokoas-client/src/hooksQuery';
-import { useTypedFormContext } from '../../hooks/useTypedRHF';
+import { useTypedFormContext, useTypedWatch } from '../../hooks/useTypedRHF';
 import { Controller } from 'react-hook-form';
 import { useEffect } from 'react';
 import { OtherProjType } from './OtherProjType';
@@ -78,9 +78,16 @@ export const ProjectType = ({
                     ?.label || '';
 
                   const custName = getValues('custName');
+                  const hasContract = getValues('hasContract');
+
+                  
+                  if (!hasContract) {
+                    // 契約がないときのみ、工事名称を変更する
+                    setValue('projTypeName', newProjTypeName);
+                    setValue('projName', `${custName}様邸　${newProjTypeName}`);
+                  }
                 
-                  setValue('projTypeName', newProjTypeName);
-                  setValue('projName', `${custName}様邸　${newProjTypeName}`);
+                  
                   onChange(e.target.value);
                 }}
               >


### PR DESCRIPTION
## 変更

1. 契約後でも工事種別が編集出来るようになりました。

## 理由

1. 紹介料に関わるため。