### PR TITLE
K211-顧客登録の「続柄」の選択肢に「親」を追加しました

### DIFF
--- a/packages/types/src/common/customers.ts
+++ b/packages/types/src/common/customers.ts
@@ -15,7 +15,19 @@ export type TProjRank = typeof ranks[number];
 export type TContact = 'email' | 'tel';
 
 
-export const relations = ['契約者', '配偶者', '婚約者', '家「固定電話」', '子', '祖父母', '兄弟姉妹', '同居人', '会社（固定電話）', '法人担当者', 'その他'] as const;
+export const relations = [
+  '契約者',
+  '配偶者',
+  '婚約者',
+  '家「固定電話」',
+  '親',
+  '子',
+  '祖父母',
+  '兄弟姉妹',
+  '同居人',
+  '会社（固定電話）',
+  '法人担当者',
+  'その他'] as const;
 export type TRelation = typeof relations[number];
 
 export const getCustGroupKey = (k: KFlatCustGroup) => k;


### PR DESCRIPTION
## 変更

1. 件名通り

## 理由

1. [変更理由](https://rdmuhwtt6gx7.cybozu.com/k/236/show#record=211)
