### PR TITLE
入金確認アラートの解除要件を修正します

### DIFF
--- a/packages-automation/auto-paymentAlert/src/helpers/convertReminderToKintone.ts
+++ b/packages-automation/auto-paymentAlert/src/helpers/convertReminderToKintone.ts
@@ -52,7 +52,7 @@ export const convertReminderToKintone = ({
       scheduledAlertDate: { value: format(new Date(), 'yyyy-MM-dd') },
       alertState: { value: '1' },
       //reminderDate: { value: '' }, //再通知日はこのタイミングでは設定しない
-      andpadDepositAmount: { value: '0' }, //TODO string ->numberに合わせて、要処理修正
+      andpadDepositAmount: { value: '0' }, //TODO  入金金額の総額を取得する処理を実装する
       area: { value: territory },
       projName: { value: projName },
       //lastAlertDate: { value: '' }, //このタイミングではまだ通知はしていないため登録しない

--- a/packages-automation/auto-paymentAlert/src/helpers/convertReminderToKintoneUpdate.ts
+++ b/packages-automation/auto-paymentAlert/src/helpers/convertReminderToKintoneUpdate.ts
@@ -33,6 +33,7 @@ export const convertReminderToKintoneUpdate = ({
     yumeAG,
   }) => {
 
+
     return ({
       updateKey: {
         field: 'projId',
@@ -48,7 +49,7 @@ export const convertReminderToKintoneUpdate = ({
         scheduledAlertDate: { value: alertDate },
         alertState: { value: alertState ? '1' : '0' },
         // reminderDate: { value: '' }, ユーザーがプルダウンから選択するため、対象外とする
-        andpadDepositAmount: { value: '0' }, // TODO 入金金額の総額を取得する処理を実装する
+        andpadDepositAmount: { value: '0' }, // TODO 　入金金額の総額を取得する処理を実装する
         area: { value: territory },
         projName: { value: projName },
         lastAlertDate: { value: lastAlertDate },


### PR DESCRIPTION
## 変更

1. 入金確認アラートの解除要件を、"全額入金が確認できた際"に変更します

## 理由

1. [k204](https://rdmuhwtt6gx7.cybozu.com/k/236/show#record=204)による

## テスト

- 手動
