### PR TITLE
hotfix-ホームの更新情報にタイトルが空の依頼も表示される

### DIFF
--- a/packages/api-kintone/src/ticketSystem/getCompletedTickets.ts
+++ b/packages/api-kintone/src/ticketSystem/getCompletedTickets.ts
@@ -4,11 +4,13 @@ import { appId, RecordKey, RecordType } from './config';
 export const getCompletedTickets = async () => {
   const orderByField: RecordKey = 'completedTime';
   const scope: RecordKey = 'scope';  
+  const announcementTitle: RecordKey = 'announcementTitle';
   const status = '完了';
 
   const conditions = [
     `ステータス="${status}"`,
     `${scope} in ("ここあす")`,
+    `${announcementTitle} != ""`,
   ].join(' and ');
 
   return getAllRecords<RecordType>({


### PR DESCRIPTION
## 変更

1. 依頼レコードの「見出し」が空だと、表示させないように。

## 理由

1. ユーザ視点に関係ない依頼は見出しは空です。
よって、独立して完成させて、リリースことができると望ましいです。


## 修正前

![image](https://github.com/Lorenzras/yumecoco-monorepo/assets/2501255/271b1c17-01c7-4233-bbfc-5341cbbecf7a)

