### PR TITLE
K182-顧客一覧を「引き渡し日」と「支払い日」の絞りフィールドを追加しました。

### DIFF
--- a/packages/kokoas-client/src/pages/projSearch/form.ts
+++ b/packages/kokoas-client/src/pages/projSearch/form.ts
@@ -23,6 +23,12 @@ export const initialForm : TypeOfForm = {
   contractDateFrom: null,
   contractDateTo: null,
 
+  deliveryDateFrom: null,
+  deliveryDateTo: null,
+
+  paidDateFrom: null,
+  paidDateTo: null,
+
   completionDateFrom: null,
   completionDateTo: null,
 

--- a/packages/kokoas-client/src/pages/projSearch/hooks/useParseQuery.ts
+++ b/packages/kokoas-client/src/pages/projSearch/hooks/useParseQuery.ts
@@ -6,6 +6,8 @@ import { useMemo } from 'react';
 import { initialForm } from '../form';
 import { parseISO } from 'date-fns';
 
+const resolveDate = <T = unknown>(date: T) => typeof date === 'string' ? parseISO(date) : null;
+
 
 export const useParseQuery = (): TypeOfForm => {
   const {
@@ -31,11 +33,18 @@ export const useParseQuery = (): TypeOfForm => {
 
       yumeAG,
 
+      contractDateFrom,
+      contractDateTo,
+
+      deliveryDateFrom,
+      deliveryDateTo,
+
+      paidDateFrom,
+      paidDateTo,
+
       completionDateFrom,
       completionDateTo,
 
-      contractDateFrom,
-      contractDateTo,
       order,
       orderBy,
     } = parsedQuery;
@@ -54,10 +63,19 @@ export const useParseQuery = (): TypeOfForm => {
       includeDeleted: typeof includeDeleted === 'string' && includeDeleted === 'true',
       cocoAG: ([] as string[]).concat(cocoAG ?? []),
       yumeAG: ([] as string[]).concat(yumeAG ?? []),
-      completionDateFrom: completionDateFrom ? parseISO(completionDateFrom as string) : null,
-      completionDateTo: completionDateTo ? parseISO(completionDateTo as string) : null,
-      contractDateFrom: contractDateFrom ? parseISO(contractDateFrom as string) : null,
-      contractDateTo: contractDateTo ? parseISO(contractDateTo as string) : null,
+
+      contractDateFrom: resolveDate(contractDateFrom),
+      contractDateTo: resolveDate(contractDateTo),
+
+      completionDateFrom: resolveDate(completionDateFrom),
+      completionDateTo: resolveDate(completionDateTo),
+
+      deliveryDateFrom: resolveDate(deliveryDateFrom),
+      deliveryDateTo: resolveDate(deliveryDateTo),
+
+      paidDateFrom: resolveDate(paidDateFrom),
+      paidDateTo: resolveDate(paidDateTo),
+
     };
   }, [
     search,

--- a/packages/kokoas-client/src/pages/projSearch/hooks/useSearchResult.ts
+++ b/packages/kokoas-client/src/pages/projSearch/hooks/useSearchResult.ts
@@ -33,8 +33,16 @@ export const useSearchResult =  () => {
     yumeAG,
     contractDateFrom,
     contractDateTo,
+
     completionDateFrom,
     completionDateTo,
+
+    deliveryDateFrom,
+    deliveryDateTo,
+
+    paidDateFrom,
+    paidDateTo,
+
     order,
     orderBy = 'storeSortNumber',
     includeDeleted,
@@ -164,10 +172,16 @@ export const useSearchResult =  () => {
         const isMatchProjType = !selectedProjTypeIds?.length || selectedProjTypeIds.includes(projTypeId.value);
         const isMatchCocoNames = !cocoAG?.length || !!intersection(cocoAG, [...cocoAGIds, ...cocoConstIds]).length;
         const isMatchYumeNames = !yumeAG?.length || !!intersection(yumeAG, yumeAGIds).length;
+        
         const isMatchcontractDateFrom = !contractDateFrom || (contractDateFrom && contractDate?.value && contractDateFrom <= parseISO(contractDate?.value));
         const isMatchcontractDateTo = !contractDateTo || (contractDateTo && contractDate?.value && contractDateTo >= parseISO(contractDate?.value));
         const isMatchcompletionDateFrom = !completionDateFrom || (completionDateFrom && projFinDate?.value && completionDateFrom <= parseISO(projFinDate?.value));
         const isMatchcompletionDateTo = !completionDateTo || (completionDateTo && projFinDate?.value && completionDateTo >= parseISO(projFinDate?.value));
+        const isMatchDeliveryDateFrom = !deliveryDateFrom || (deliveryDateFrom && deliveryDate?.value && deliveryDateFrom <= parseISO(deliveryDate?.value));
+        const isMatchDeliveryDateTo = !deliveryDateTo || (deliveryDateTo && deliveryDate?.value && deliveryDateTo >= parseISO(deliveryDate?.value));
+        const isMatchPaidDateFrom = !paidDateFrom || (paidDateFrom && payFinDate?.value && paidDateFrom <= parseISO(payFinDate?.value));
+        const isMatchPaidDateTo = !paidDateTo || (paidDateTo && payFinDate?.value && paidDateTo >= parseISO(payFinDate?.value));
+
         const isIncludeDeleted = includeDeleted ? (isProjectDeleted || isCustGroupDeleted) : !(isProjectDeleted || isCustGroupDeleted);
 
         if (!parsedQuery
@@ -182,6 +196,10 @@ export const useSearchResult =  () => {
             && isMatchcontractDateTo
             && isMatchcompletionDateFrom
             && isMatchcompletionDateTo
+            && isMatchDeliveryDateFrom
+            && isMatchDeliveryDateTo
+            && isMatchPaidDateFrom
+            && isMatchPaidDateTo
             && isIncludeDeleted
           )
         ) {

--- a/packages/kokoas-client/src/pages/projSearch/schema.ts
+++ b/packages/kokoas-client/src/pages/projSearch/schema.ts
@@ -46,6 +46,18 @@ const schema = z.object({
   /** 契約日　To */
   contractDateTo : dateType,
 
+  /** 引き渡し日　From */
+  deliveryDateFrom : dateType,
+
+  /** 引き渡し日　To */
+  deliveryDateTo : dateType,
+
+  /** 支払い完了日 From */
+  paidDateFrom : dateType,
+
+  /** 支払い完了日 To */
+  paidDateTo : dateType,
+
   /** 完工日　From */
   completionDateFrom : dateType,
 

--- a/packages/kokoas-client/src/pages/projSearch/sections/filter/filterForm/FilterDialog.tsx
+++ b/packages/kokoas-client/src/pages/projSearch/sections/filter/filterForm/FilterDialog.tsx
@@ -38,6 +38,16 @@ export const FilterDialog = ({
             label='契約日'
           />
           <DateRange 
+            fromName='deliveryDateFrom'
+            toName='deliveryDateTo'
+            label='引き渡し日'
+          />
+          <DateRange 
+            fromName='paidDateFrom'
+            toName='paidDateTo'
+            label='支払完了日'
+          />
+          <DateRange 
             fromName='completionDateFrom'
             toName='completionDateTo'
             label='完工日'


### PR DESCRIPTION
## 変更

1. 顧客一覧を「引き渡し日」と「支払い日」の絞りフィールドを追加しました。

## 理由

1. [変更理由](https://rdmuhwtt6gx7.cybozu.com/k/236/show#record=182)

