### PR TITLE
hotfix-runtime error when selecting yumeAG

### DIFF
--- a/packages/kokoas-client/src/pages/projRegisterV2/hooks/useUpdateCommRate.ts
+++ b/packages/kokoas-client/src/pages/projRegisterV2/hooks/useUpdateCommRate.ts
@@ -34,11 +34,16 @@ export const useUpdateCommRate = () => {
     },
   }) => {
     console.log('starting to calculate');
-    const selectedYumeAG = produce(getValues('yumeAG'), (draft) => {
-      if (newYumeAG) {
+    
+    // Deep copy, as we don't want to mutate the original value
+    let selectedYumeAG: TForm['yumeAG'] = JSON.parse(JSON.stringify(getValues('yumeAG')));
+
+    if (newYumeAG) {
+      selectedYumeAG = produce(selectedYumeAG, draft => {
         draft[newYumeAG.index] = newYumeAG.value;
-      }
-    });
+      });
+    }
+
     const selectedProjTypeId = newProjTypeId || getValues('projTypeId');
 
     if (selectedYumeAG.some(({ empName }) => empName === 'ここすも')


### PR DESCRIPTION
## 変更

1. Deep copy yumeAG from the form.

## 理由

1. This is to avoid attempts to mutate the original object that is locked by RHF, causing runtime errors.
