### PR TITLE
720-請求アラートメッセージ内容の修正

### DIFF
--- a/packages-automation/auto-invoiceAlert/src/helpers/convertContractsToJson.ts
+++ b/packages-automation/auto-invoiceAlert/src/helpers/convertContractsToJson.ts
@@ -35,6 +35,7 @@ export const convertContractsToJson = ({
     projName,
     totalContractAmt,
     contractDate,
+    storeName,
     //contractAmtDate,
     //contractAmt,
     //initialAmtDate,
@@ -106,6 +107,7 @@ export const convertContractsToJson = ({
       cwRoomIds: chatworkRoomIds,
       andpadInvoiceUrl: andpadInvoiceUrl,
       expectedCreateInvoiceDate: '',
+      storeName: storeName.value,
     });
   });
 

--- a/packages-automation/auto-invoiceAlert/src/helpers/convertReminderToJson.ts
+++ b/packages-automation/auto-invoiceAlert/src/helpers/convertReminderToJson.ts
@@ -26,6 +26,7 @@ export const convertReminderToJson = ({
     notificationSettings,
     expectedCreateInvoiceDate,
     yumeAG,
+    store,
   }): InvoiceReminder => {
 
     // 通知先情報(chatwork)を設定する
@@ -65,6 +66,7 @@ export const convertReminderToJson = ({
       cwRoomIds: cwRoomIds,
       andpadInvoiceUrl: andpadUrl.value,
       expectedCreateInvoiceDate: expectedCreateInvoiceDate.value,
+      storeName: store.value,
     });
   });
 

--- a/packages-automation/auto-invoiceAlert/src/helpers/convertReminderToKintone.ts
+++ b/packages-automation/auto-invoiceAlert/src/helpers/convertReminderToKintone.ts
@@ -28,6 +28,7 @@ export const convertReminderToKintone = ({
     territory,
     totalContractAmount,
     yumeAG,
+    storeName,
   }) => {
 
     const cwRoomIdsKintone = cwRoomIds.map(({ agentName, agentId, cwRoomId }) => {
@@ -54,6 +55,7 @@ export const convertReminderToKintone = ({
       andpadDepositAmount: { value: '0' }, //TODO string ->numberに合わせて、要処理修正
       area: { value: territory },
       projName: { value: projName },
+      store: { value: storeName },
       //lastAlertDate: { value: '' }, //このタイミングではまだ通知はしていないため登録しない
       andpadUrl: { value: andpadInvoiceUrl },
       contractId: { value: contractId },

--- a/packages-automation/auto-invoiceAlert/src/notificationFunc/generateMessage.ts
+++ b/packages-automation/auto-invoiceAlert/src/notificationFunc/generateMessage.ts
@@ -21,8 +21,8 @@ export const generateMessage = (reminderJson: InvoiceReminder) => {
 
   const agentNames = cwRoomIds.map(({ agentName }) => agentName).join(', ');
 
-  const message = `契約から一定期間お客さまからの入金がない契約に対して案内しています。
-本連絡と前後してお客さまから入金がされている場合はご容赦ください。
+  const message = `契約から一定期間、お客さまへの請求書作成がされていない案件に対して案内しています。
+本連絡と前後して処理されている場合はご容赦ください。
 `;
 
   const content = `契約日  : ${format(parseISO(contractDate), 'yyyy年M月d日')}
@@ -31,10 +31,10 @@ export const generateMessage = (reminderJson: InvoiceReminder) => {
 担当者  : ${agentNames}
 夢てつAG: ${yumeAG}`;
 
-  const link = `[info][title]ANDPAD入金ページ[/title]
+  const link = `[info][title]ANDPAD引合粗利管理[入金](請求書作成ページ)[/title]
 ${andpadInvoiceUrl === '' ? '取得に失敗しました' : andpadInvoiceUrl}[/info]`;
 
-  const reminder = `[info][title]下記リンク先より、再通知日${expectedCreateInvoiceDate ? '' : 'と入金予定日'}を設定してください[/title]
+  const reminder = `[info][title]下記リンク先より、再通知日${expectedCreateInvoiceDate ? '' : 'と請求書発行予定日'}を設定してください[/title]
 ${reminderUrl === '' ? '取得に失敗しました' : reminderUrl}[/info]`;
 
 

--- a/packages-automation/auto-invoiceAlert/src/notificationFunc/generateMessage.ts
+++ b/packages-automation/auto-invoiceAlert/src/notificationFunc/generateMessage.ts
@@ -17,7 +17,7 @@ export const generateMessage = (reminderJson: InvoiceReminder) => {
 
   console.log('parseISO(contractDate)', parseISO(contractDate));
 
-  const title = '[title]【ココアス】お客さまからの入金が確認できていません[/title]';
+  const title = '[title]【ココアス】お客さまへの請求書の作成が確認できていません[/title]';
 
   const agentNames = cwRoomIds.map(({ agentName }) => agentName).join(', ');
 

--- a/packages-automation/auto-invoiceAlert/src/notificationFunc/generateMessageForManager.ts
+++ b/packages-automation/auto-invoiceAlert/src/notificationFunc/generateMessageForManager.ts
@@ -9,10 +9,16 @@ export const generateMessageForManager = (invoiceReminder: InvoiceReminder[]) =>
   const contractSummary = invoiceReminder.map(({
     projName,
     cwRoomIds,
+    storeName,
+    contractDate,
+    totalContractAmount,
   }, idx) => {
     const agentNames = cwRoomIds.map(({ agentName }) => agentName).join(', ');
 
-    return `${idx + 1}件目: 工事名 = ${projName},  担当者 = ${agentNames}`;
+    return `${idx + 1}件目
+${storeName}　${projName}
+契約日:${contractDate}　契約金額 ￥${(+totalContractAmount).toLocaleString()}　担当者:${agentNames}
+[hr]`;
   });
 
 

--- a/packages-automation/auto-invoiceAlert/types/InvoiceReminder.ts
+++ b/packages-automation/auto-invoiceAlert/types/InvoiceReminder.ts
@@ -14,6 +14,7 @@ export interface InvoiceReminder {
   projId: string
   projName: string
   projType: string
+  storeName: string
   contractDate: string
   territory: Territory
   expectedCreateInvoiceDate: string | null

--- a/packages-automation/auto-invoiceAlert/types/kintone.data.d.ts
+++ b/packages-automation/auto-invoiceAlert/types/kintone.data.d.ts
@@ -11,6 +11,7 @@ declare namespace DBInvoiceReminder {
     andpadDepositAmount: kintone.fieldTypes.Number;
     area: kintone.fieldTypes.SingleLineText;
     projName: kintone.fieldTypes.SingleLineText;
+    store: kintone.fieldTypes.SingleLineText;
     expectedCreateInvoiceDate: kintone.fieldTypes.Date;
     lastAlertDate: kintone.fieldTypes.Date;
     andpadUrl: kintone.fieldTypes.Link;


### PR DESCRIPTION
## 変更

1. アラートメッセージ内容を請求書アラート用に修正します

## 理由

1. #719 

## テスト

- notifyInvoiceAlertToChatwork.test.tsの実行

## 関連情報

#720 からの派生です
