### PR TITLE
736-請求アラートの実施条件に関わる処理を修正しました

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8137,6 +8137,10 @@
       "resolved": "packages-automation/auto-andpadPaymentBackup",
       "link": true
     },
+    "node_modules/autoinvoicealert": {
+      "resolved": "packages-automation/auto-invoiceAlert",
+      "link": true
+    },
     "node_modules/autopaymentalert": {
       "resolved": "packages-automation/auto-paymentAlert",
       "link": true
@@ -31742,6 +31746,17 @@
       },
       "devDependencies": {}
     },
+    "packages-automation/auto-invoiceAlert": {
+      "version": "0.0.0",
+      "dependencies": {
+        "api-andpad": "*",
+        "api-kintone": "*",
+        "auto-common": "*",
+        "config": "*",
+        "types": "*"
+      },
+      "devDependencies": {}
+    },
     "packages-automation/auto-kintone": {
       "version": "0.0.0",
       "dependencies": {
@@ -37489,6 +37504,16 @@
     },
     "autoandpadpaymentbackup": {
       "version": "file:packages-automation/auto-andpadPaymentBackup",
+      "requires": {
+        "api-andpad": "*",
+        "api-kintone": "*",
+        "auto-common": "*",
+        "config": "*",
+        "types": "*"
+      }
+    },
+    "autoinvoicealert": {
+      "version": "file:packages-automation/auto-invoiceAlert",
       "requires": {
         "api-andpad": "*",
         "api-kintone": "*",

--- a/packages-automation/auto-invoiceAlert/src/api-kintone/getInvoiceRemindersByAlertDate.test.ts
+++ b/packages-automation/auto-invoiceAlert/src/api-kintone/getInvoiceRemindersByAlertDate.test.ts
@@ -6,7 +6,7 @@ import { getInvoiceRemindersByAlertDate } from './getInvoiceRemindersByAlertDate
 
 
 describe('getInvoiceRemindersByAlertDate', () => {
-  it('通知対象日の請求書用リマインダーのレコードを取得します', async () => {
+  it('指定日以前に通知予定の請求書用リマインダーレコードを取得します', async () => {
     const result = await getInvoiceRemindersByAlertDate(new Date());
 
     expect(result).toBeInstanceOf(Array);

--- a/packages-automation/auto-invoiceAlert/src/api-kintone/getInvoiceRemindersByAlertDate.ts
+++ b/packages-automation/auto-invoiceAlert/src/api-kintone/getInvoiceRemindersByAlertDate.ts
@@ -2,13 +2,17 @@ import format from 'date-fns/format';
 import { getAllInvoiceReminder } from './getAllInvoiceReminder';
 
 
-
+/**
+ * 通知予定日が指定日以前の請求リマインダーレコードを取得します
+ * @param date 上記、指定日
+ * @returns 
+ */
 export const getInvoiceRemindersByAlertDate = (date: Date) => {
   const dateStr = format(date, 'yyyy-MM-dd');
 
   console.log('dateStr', dateStr);
 
   return getAllInvoiceReminder({
-    condition: `scheduledAlertDate = "${dateStr}" and alertState != "0"`,
+    condition: `scheduledAlertDate <= "${dateStr}" and alertState != "0"`,
   });
 };

--- a/packages-automation/auto-invoiceAlert/src/helpers/calcAlertDate.ts
+++ b/packages-automation/auto-invoiceAlert/src/helpers/calcAlertDate.ts
@@ -1,6 +1,5 @@
 import { addMonths, parseISO } from 'date-fns';
 import { TgtProjType } from '../../config';
-import format from 'date-fns/format';
 
 export const calcAlertDate = ({
   contractDateStr,
@@ -38,6 +37,7 @@ export const calcAlertDate = ({
     }
   }
 
-  return format(billingDate, 'yyyy-MM-dd');
+  //return format(billingDate, 'yyyy-MM-dd');
+  return billingDate;
 
 };

--- a/packages-automation/auto-invoiceAlert/src/helpers/convertContractsToJson.ts
+++ b/packages-automation/auto-invoiceAlert/src/helpers/convertContractsToJson.ts
@@ -3,7 +3,6 @@ import { ContractRecordType } from '../../config';
 import { InvoiceReminder } from '../../types/InvoiceReminder';
 import { getMyOrders } from 'api-andpad';
 import { chatworkRoomIdSetting } from '../notificationFunc/chatworkRoomIdSetting';
-//import { getEarliestDateOfContract } from './getEarliestDateOfContract';
 import { getYumeAgNames } from './getYumeAgNames';
 
 

--- a/packages-automation/auto-invoiceAlert/src/helpers/convertReminderToJson.ts
+++ b/packages-automation/auto-invoiceAlert/src/helpers/convertReminderToJson.ts
@@ -5,6 +5,12 @@ import { IAndpadpayments, Territory } from 'types';
 
 
 
+/**
+ * リマインダーアプリのレコードを通知用のJSON型へ変換する
+ * @param param0 reminder: 請求リマインダーアプリのレコード配列
+ *               andpadPayments: andpad入金情報アプリのレコード配列
+ * @returns InvoiceReminder[]
+ */
 export const convertReminderToJson = ({
   reminder,
   andpadPayments,

--- a/packages-automation/auto-invoiceAlert/src/helpers/convertReminderToJson.ts
+++ b/packages-automation/auto-invoiceAlert/src/helpers/convertReminderToJson.ts
@@ -7,8 +7,8 @@ import { IAndpadpayments, Territory } from 'types';
 
 /**
  * リマインダーアプリのレコードを通知用のJSON型へ変換する
- * @param param0 reminder: 請求リマインダーアプリのレコード配列
- *               andpadPayments: andpad入金情報アプリのレコード配列
+ * @param params.reminder 請求リマインダーアプリのレコード配列
+ * @param params.andpadPayments andpad入金情報アプリのレコード配列
  * @returns InvoiceReminder[]
  */
 export const convertReminderToJson = ({

--- a/packages-automation/auto-invoiceAlert/src/helpers/filterContractsToAlertTarget.test.ts
+++ b/packages-automation/auto-invoiceAlert/src/helpers/filterContractsToAlertTarget.test.ts
@@ -5,23 +5,15 @@ import format from 'date-fns/format';
 import { filterContractsToAlertTarget } from './filterContractsToAlertTarget';
 import { getAllAndpadPayments } from 'api-kintone';
 import { ContractRecordType } from '../../config';
-import addMonths from 'date-fns/addMonths';
+//import addMonths from 'date-fns/addMonths';
 import { getAllInvoiceReminder } from '../api-kintone';
 
 
 describe('filterContractsToAlertTarget', () => {
   it('should return alert date', async () => {
 
-    const testId = '87bfde1a-81a1-4fc9-8c54-979ca61f9766';
-
-    // set output file of filterContractsByTargetProjType.test.ts
     const contractsPath = path.join(__dirname, './__TEST__/contracts.json');
     const contracts = JSON.parse(fs.readFileSync(contractsPath, 'utf8')) as ContractRecordType[];
-
-    const newDate = addMonths(new Date(), -3);
-    const idx = contracts.findIndex(({ uuid }) => uuid.value === testId);
-    contracts[idx].contractDate.value = format(newDate, 'yyyy-MM-dd');
-
 
     const [
       allAndpadPayments,


### PR DESCRIPTION
## 変更

1. アラートを解除する要件を実装します
2. アラート対象を、今日より以前にアラート条件を迎えたものに修正します

## 理由

1. #719 チェックリストより
3. 通知予定日にアラートし忘れた際のリカバリができなかったため、対策処理を織り込みます

## テスト

- filterContractsToAlertTarget.test.ts
- getInvoiceRemindersByAlertDate.test.ts

## 関連情報

- #736 より派生