### PR TITLE
hotfix-顧客一覧の工事データに店舗名が出ない 

### DIFF
--- a/packages/kokoas-client/src/pages/projSearch/sections/result/details/projectDetails/OfficerDetails.tsx
+++ b/packages/kokoas-client/src/pages/projSearch/sections/result/details/projectDetails/OfficerDetails.tsx
@@ -16,6 +16,7 @@ export const OfficerDetails = ({
     custGroupId,
     commissionRate,
     territory,
+    store,
   } = recProj || {};
 
   const { 
@@ -40,7 +41,7 @@ export const OfficerDetails = ({
   const agentDetails: IDetail[] = [
     {
       label: '店舗',
-      value: territory.value,
+      value: `${territory.value} - ${store.value}`,
     },
     {
       label: 'ゆめてつAG',

--- a/packages/kokoas-client/src/pages/projSearch/sections/result/details/projectDetails/OfficerDetails.tsx
+++ b/packages/kokoas-client/src/pages/projSearch/sections/result/details/projectDetails/OfficerDetails.tsx
@@ -4,6 +4,7 @@ import { IProjects } from 'types';
 import { DetailSection } from '../common/DetailSection';
 import { useCustGroupById } from 'kokoas-client/src/hooksQuery';
 import { getAgentNamesByType } from 'api-kintone/src/custgroups/helpers/getAgentNamesByType';
+import { Tooltip, Typography } from '@mui/material';
 
 export const OfficerDetails = ({
   recProj,
@@ -25,6 +26,8 @@ export const OfficerDetails = ({
 
   const {
     agents: custGroupAgents,
+    storeName: custGrpStoreName,
+    territory: custGroupTerritory,
   }  = recCustGroup || {};
   const yumeAGNames =  projGetAgentNamesByType(agents, 'yumeAG') 
   || (custGroupAgents && getAgentNamesByType(custGroupAgents, 'yumeAG')) 
@@ -41,7 +44,12 @@ export const OfficerDetails = ({
   const agentDetails: IDetail[] = [
     {
       label: '店舗',
-      value: `${territory.value} - ${store.value}`,
+      value: (
+        <Tooltip title={`${territory.value || custGroupTerritory?.value} - ${store.value ? '工事データ' : '顧客データ'}`}>
+          <Typography noWrap>
+            {store.value || custGrpStoreName?.value}
+          </Typography>
+        </Tooltip>),
     },
     {
       label: 'ゆめてつAG',


### PR DESCRIPTION
## 変更

1. 店舗名出るようになりました。

## 理由

1. 不具合報告
