### PR TITLE
779-ランクの選択肢に「設計契約」を追加しました。

### DIFF
--- a/packages/kokoas-client/src/pages/projContractV2/hooks/useSubmitHandler.ts
+++ b/packages/kokoas-client/src/pages/projContractV2/hooks/useSubmitHandler.ts
@@ -32,6 +32,7 @@ export const useSubmitHandler = () => {
           projId: data.projId,
           record: { 
             planApplicationDate: kintoneRecord.contractDate, 
+            rank: { value: '設契済' },
           }, 
         });
       }

--- a/packages/kokoas-client/src/pages/projProspectSearchV2/filter/filterForm/RankField.tsx
+++ b/packages/kokoas-client/src/pages/projProspectSearchV2/filter/filterForm/RankField.tsx
@@ -25,7 +25,7 @@ export const RankField = () => {
             direction={'row'}
             justifyContent={'space-between'}
           >
-            {ranks.map((r) => {
+            {[...ranks, ''].map((r) => {
 
               return (
                 <FormControlLabel

--- a/packages/kokoas-client/src/pages/projProspectSearchV2/hooks/useSearchResult.ts
+++ b/packages/kokoas-client/src/pages/projProspectSearchV2/hooks/useSearchResult.ts
@@ -227,9 +227,18 @@ export const useSearchResult =  () => {
               : dateB.getTime() - dateA.getTime();
           case 'rank': 
             // rank is string, but empty string should be treated as the lowest rank
+            // if rank = '設計契約' should be the highest rank
+        
             const rankA = a[parseOrderBy] || 'Z';
             const rankB = b[parseOrderBy] || 'Z';
-            return q.order === 'asc' 
+            
+            if (rankA === '設計契約' || rankB === '設計契約') {
+              // multiply the result by 1 or -1 based on the order.
+              return (rankA === '設計契約' ? -1 : 1) * (q.order === 'asc' ? 1 : -1);
+            }
+            
+
+            return q.order === 'asc'
               ? rankA.localeCompare(rankB)
               : rankB.localeCompare(rankA);
             

--- a/packages/kokoas-client/src/pages/projProspectSearchV2/result/ResultRow.tsx
+++ b/packages/kokoas-client/src/pages/projProspectSearchV2/result/ResultRow.tsx
@@ -14,15 +14,18 @@ export const ResultRow = (props: RowLayoutProps) => {
   
   const navigate = useNavigateWithQuery();
 
+  const rankIsLong = (rank as string).length > 1;
+
   return  (
     <RowLayout 
       schedContractAmt={schedContractAmt?.toLocaleString()}
       rank={(
         <Typography 
-          fontSize={24} 
+          fontSize={rankIsLong ? 12 :  24} 
           color={grey[500]} 
           fontWeight={'bold'}
-          p={1}
+          py={rankIsLong ? 2 : 1}
+          px={1}
           border={4}
           borderRadius={4}
           borderColor={grey[100]}

--- a/packages/kokoas-client/src/pages/projRegisterV2/api/rankingValues.ts
+++ b/packages/kokoas-client/src/pages/projRegisterV2/api/rankingValues.ts
@@ -1,4 +1,5 @@
 export const rankingValues = [
+  '設計契約',
   'A',
   'B',
   'C',

--- a/packages/kokoas-client/src/pages/projRegisterV2/api/rankingValues.ts
+++ b/packages/kokoas-client/src/pages/projRegisterV2/api/rankingValues.ts
@@ -1,7 +1,0 @@
-export const rankingValues = [
-  '設計契約',
-  'A',
-  'B',
-  'C',
-  'D',
-];

--- a/packages/kokoas-client/src/pages/projRegisterV2/sections/prospect/Rank.tsx
+++ b/packages/kokoas-client/src/pages/projRegisterV2/sections/prospect/Rank.tsx
@@ -2,7 +2,7 @@ import { Controller } from 'react-hook-form';
 import { useTypedFormContext } from '../../hooks';
 import { FormControl, FormHelperText, InputLabel, MenuItem, Select } from '@mui/material';
 import { fieldMapJa } from '../../api/fieldMapJa';
-import { rankingValues } from '../../api/rankingValues';
+import { ranks } from 'types';
 
 const name = 'rank';
 const label = fieldMapJa[name];
@@ -54,7 +54,7 @@ export const Rank = () => {
                 </em>
               </MenuItem>
               {
-                rankingValues.map((v) => (
+                ranks.map((v) => (
                   <MenuItem 
                     key={v}
                     value={v}

--- a/packages/types/src/common/customers.ts
+++ b/packages/types/src/common/customers.ts
@@ -10,7 +10,7 @@ export type KFlatCustGroup =
 | KCustGroupAgents;
 
 
-export const ranks = ['設計契約', 'A', 'B', 'C', 'D' ] as const;
+export const ranks = ['設契済', 'A', 'B', 'C', 'D' ] as const;
 export type TProjRank = typeof ranks[number];
 export type TContact = 'email' | 'tel';
 

--- a/packages/types/src/common/customers.ts
+++ b/packages/types/src/common/customers.ts
@@ -10,7 +10,7 @@ export type KFlatCustGroup =
 | KCustGroupAgents;
 
 
-export const ranks = ['A', 'B', 'C', 'D', ''] as const;
+export const ranks = ['設計契約', 'A', 'B', 'C', 'D' ] as const;
 export type TProjRank = typeof ranks[number];
 export type TContact = 'email' | 'tel';
 


### PR DESCRIPTION
## 変更内容

1. ランクの選択肢に「設計契約」を追加しました。
2. 見込み一覧のソートで「設計契約」は「A」より上に行くよう調整しました。

## 理由

- https://rdmuhwtt6gx7.cybozu.com/k/236/show#record=229
- 流れ的にAの方が上と思います。