### PR TITLE
ファイルのキャッシュを修正しました。

### DIFF
--- a/packages/api-kintone/src/@file/downloadFileBase64.ts
+++ b/packages/api-kintone/src/@file/downloadFileBase64.ts
@@ -1,5 +1,8 @@
 import { downloadFile } from './downloadFile';
 
+/**
+ * @deprecated useKintoneFileBase64 でキャッシュを利用し、変換することになりました。
+ */
 export const downloadFileBase64 = async (fk: string) => {
 
   const arrayBuffer = await downloadFile(fk);

--- a/packages/kokoas-client/src/hooksQuery/useKintoneFile.ts
+++ b/packages/kokoas-client/src/hooksQuery/useKintoneFile.ts
@@ -7,13 +7,13 @@ import { downloadFile } from 'api-kintone';
  * @param fileKey
  * @returns {ArrayBuffer}
  */
-export const useKintoneFile = (fileKey: string) => {
+export const useKintoneFile = (fileKey: string, enabled = true) => {
   return useQuery(
 
     ['kintone', fileKey],
     () => downloadFile(fileKey),
     {
-      enabled: !!fileKey,
+      enabled: !!fileKey && enabled,
     },
   );
 };

--- a/packages/kokoas-client/src/hooksQuery/useKintoneFileBase64.ts
+++ b/packages/kokoas-client/src/hooksQuery/useKintoneFileBase64.ts
@@ -15,7 +15,7 @@ export const useKintoneFileBase64 = (fileKey: string, enabled = true ) => {
     {
       enabled: !!fileKey && enabled,
       cacheTime: 5000,
-      staleTime: 5000,
+      staleTime: 0,
     },
   );
 };

--- a/packages/kokoas-client/src/hooksQuery/useKintoneFileBase64.ts
+++ b/packages/kokoas-client/src/hooksQuery/useKintoneFileBase64.ts
@@ -1,5 +1,5 @@
-import { useQuery } from '@tanstack/react-query';
-import { downloadFileBase64 } from 'api-kintone/src/@file/downloadFileBase64';
+
+import { useKintoneFile } from './useKintoneFile';
 
 /**
  * Download kintone file by file key.
@@ -8,14 +8,16 @@ import { downloadFileBase64 } from 'api-kintone/src/@file/downloadFileBase64';
  * @returns {string} // base64
  */
 export const useKintoneFileBase64 = (fileKey: string, enabled = true ) => {
-  return useQuery(
 
-    ['kintone', fileKey],
-    () => downloadFileBase64(fileKey),
-    {
-      enabled: !!fileKey && enabled,
-      cacheTime: 5000,
-      staleTime: 0,
-    },
-  );
+  const { data, ...others } = useKintoneFile(fileKey, enabled);
+
+  return {
+    ...others,
+    data: data ? window.btoa(new Uint8Array(data).reduce(
+      function (d, byte) {
+        return d + String.fromCharCode(byte);
+      },
+      '',
+    )) : undefined,
+  };
 };

--- a/packages/kokoas-client/src/pages/projContractV2/parts/preview/ContractDialog.tsx
+++ b/packages/kokoas-client/src/pages/projContractV2/parts/preview/ContractDialog.tsx
@@ -36,9 +36,7 @@ export const ContractDialog = ({
   useEffect(() => {
     if (envDocFileKeys?.value?.length) {
       setSelectedFileKey(envDocFileKeys?.value?.[0]?.fileKey);
-    } else {
-      setSelectedFileKey(null);
-    }
+    } 
   }, [
     envDocFileKeys,
   ]);
@@ -47,17 +45,19 @@ export const ContractDialog = ({
   const hasContractFiles = !!envDocFileKeys?.value.length;
   const isFileKeyIncluded = envDocFileKeys?.value?.some(({ fileKey }) => fileKey === selectedFileKey);
 
-  const { data: fileData } = useContractFilesById({ 
-    id: contractId, 
-    revision: $revision?.value || '',
-    enabled: !isFileKeyIncluded && open, // disable when selectedFileKey is not included in envDocFileKeys
-  });
-
-  
   const { data: fileB64 } = useKintoneFileBase64(
     selectedFileKey || '', 
     isFileKeyIncluded && open,
   );
+
+  const { data: fileData } = useContractFilesById({ 
+    id: contractId, 
+    revision: $revision?.value || '',
+    enabled: open && !envDocFileKeys?.value?.length, // Only fetch when there is no contract files
+  });
+
+  
+
 
 
   const {

--- a/packages/kokoas-client/src/pages/projContractV2/parts/preview/ContractDialog.tsx
+++ b/packages/kokoas-client/src/pages/projContractV2/parts/preview/ContractDialog.tsx
@@ -4,7 +4,7 @@ import { PreviewHeader } from './PreviewHeader';
 import { useContractById, useContractFilesById, useKintoneFileBase64 } from 'kokoas-client/src/hooksQuery';
 import { useWatch } from 'react-hook-form';
 import { TypeOfForm } from '../../schema';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { DialogCloseButton } from 'kokoas-client/src/components';
 import { ContractActionMenu } from './menu/ContractActionMenu';
 
@@ -30,17 +30,9 @@ export const ContractDialog = ({
     envelopeStatus,
   } = contractData || {};
 
-  const [selectedFileKey, setSelectedFileKey] = useState<string | null>(null);
-  const [selectedFileIndex, setSelectedFileIndex] = useState(0);
-  
-  useEffect(() => {
-    if (envDocFileKeys?.value?.length) {
-      setSelectedFileKey(envDocFileKeys?.value?.[0]?.fileKey);
-    } 
-  }, [
-    envDocFileKeys,
-  ]);
 
+  const [selectedFileKey, setSelectedFileKey] = useState<string | null>(envDocFileKeys?.value?.[0]?.fileKey || null);
+  const [selectedFileIndex, setSelectedFileIndex] = useState(0);
   
   const hasContractFiles = !!envDocFileKeys?.value.length;
   const isFileKeyIncluded = envDocFileKeys?.value?.some(({ fileKey }) => fileKey === selectedFileKey);


### PR DESCRIPTION
## 変更

1.　base64への変換はKintoneファイル取得フックに移行しました。

## 理由

1.　当フックにバイナリーデータがあるので、利用します。

**備考**

バイナリーデータを取得フックとbase64を取得フックの処理は重なっているだけじゃなく、キーも重なっていて。混在してしまいました。

キャッシュの問題だと思いましたが、キーの問題でした。