### PR TITLE
K246-契約一覧の出力の住所と金額を修正しました。

### DIFF
--- a/packages/kokoas-client/src/pages/projProspectSearchV2/hooks/useSearchResult.ts
+++ b/packages/kokoas-client/src/pages/projProspectSearchV2/hooks/useSearchResult.ts
@@ -64,13 +64,11 @@ export const useSearchResult =  () => {
         } = curr; // 工事情報;
 
         const projAddress = addressBuilder({
-          postal: postal.value,
           address1: address1.value,
           address2: address2.value,
         });
 
         const projAddressConfirmed = addressBuilder({
-          postal: finalPostal.value,
           address1: finalAddress1.value,
           address2: finalAddress2.value,
         });
@@ -139,9 +137,19 @@ export const useSearchResult =  () => {
           fullNames,
           fullNameReadings,
           custTels,
-          addresses,
-
         } = groupCustContacts(relCustomers);
+
+        const {
+          postalCode: custPostalCode,
+          address1: custAddress1,
+          address2: custAddress2,
+        } = relCustomers?.[0] || {};
+
+        const custAddress = addressBuilder({
+          address1: custAddress1?.value,
+          address2: custAddress2?.value,
+        });
+
 
         /**　
          * 含めるかどうか判定。重くなったら、改修。
@@ -224,8 +232,11 @@ export const useSearchResult =  () => {
             updateDate: format(parseISO(updateDate.value), 'yyyy-MM-dd HH:mm'),
 
             tel: custTels?.[0] || '-',
-            custAddress: addresses?.[0] || '-',
+            custPostalCode: custPostalCode?.value || '-',
+            custAddress: custAddress || '-',
+            projPostalCode: postal.value || '-',
             projAddress: projAddress,
+            projPostalCodeConfirmed: finalPostal.value || '-',
             projAddressConfirmed: projAddressConfirmed,
             
 

--- a/packages/kokoas-client/src/pages/projProspectSearchV2/result/DownloadResult.tsx
+++ b/packages/kokoas-client/src/pages/projProspectSearchV2/result/DownloadResult.tsx
@@ -29,8 +29,8 @@ export const DownloadResult = ({
         顧客住所: d.custAddress,
 
         // K246 工事確定住所が入力されている工事は、工事確定住所を工事住所として表示してほしい
-        工事郵便番号: d.projAddress ? d.projPostalCode : d.projPostalCodeConfirmed,
-        工事住所: d.projAddress || d.projAddressConfirmed,
+        工事郵便番号: d.projPostalCodeConfirmed ? d.projPostalCodeConfirmed :  d.projPostalCode,
+        工事住所: d.projAddressConfirmed || d.projAddress,
         
         
         夢てつAG: d.yumeAG,

--- a/packages/kokoas-client/src/pages/projProspectSearchV2/result/DownloadResult.tsx
+++ b/packages/kokoas-client/src/pages/projProspectSearchV2/result/DownloadResult.tsx
@@ -25,8 +25,14 @@ export const DownloadResult = ({
         '顧客名（連名）': d.custNames,
         電話番号: d.tel,
         工事名: d.projName,
+        顧客郵便番号: d.custPostalCode,
         顧客住所: d.custAddress,
-        工事住所: d.projAddress,
+
+        // K246 工事確定住所が入力されている工事は、工事確定住所を工事住所として表示してほしい
+        工事郵便番号: d.projAddress ? d.projPostalCode : d.projPostalCodeConfirmed,
+        工事住所: d.projAddress || d.projAddressConfirmed,
+        
+        
         夢てつAG: d.yumeAG,
         ここすも営業担当: d.cocoAG,
         ここすも工事担当: d.cocoConst,

--- a/packages/kokoas-client/src/pages/projProspectSearchV2/types.ts
+++ b/packages/kokoas-client/src/pages/projProspectSearchV2/types.ts
@@ -11,11 +11,20 @@ export interface ISearchResult {
   /** 電話番号 */
   tel: string,
 
+  /** 顧客郵便番号 */
+  custPostalCode: string,
+
   /** 顧客住所 */
   custAddress: string,
 
+  /** 工事郵便番号 */
+  projPostalCode: string,
+
   /** 工事住所　*/
   projAddress: string,
+
+  /** 工事確定郵便番号 */
+  projPostalCodeConfirmed: string,
 
   /** 工事確定住所 */
   projAddressConfirmed: string,

--- a/packages/kokoas-client/src/pages/projSearch/hooks/useSearchResult.ts
+++ b/packages/kokoas-client/src/pages/projSearch/hooks/useSearchResult.ts
@@ -94,14 +94,15 @@ export const useSearchResult = () => {
         } = curr; // 工事情報;
 
         const isProjectDeleted = projCancelStatus.value !== ''; // 削除、中止などあり
+        
+        const projPostalCode = postal.value;
         const projAddress = addressBuilder({
-          postal: postal.value,
           address1: address1.value,
           address2: address2.value,
         });
 
+        const projPostalCodeConfirmed = finalPostal?.value;
         const projAddressConfirmed = addressBuilder({
-          postal: finalPostal?.value,
           address1: finalAddress1?.value,
           address2: finalAddress2?.value,
         });
@@ -114,7 +115,7 @@ export const useSearchResult = () => {
         const contracts = recContracts?.filter(({ projId: _prodId }) => projId.value === _prodId.value);
         
         const {
-          契約金額税込: totalContractAmtIncTax,
+          合計受注金額税込: totalContractAmtIncTax,
         } = getContractsSummary(contracts || []);
         const firstContract = contracts?.[0];
 
@@ -159,6 +160,17 @@ export const useSearchResult = () => {
           fullNames,
           fullNameReadings,
         } = groupCustContacts(relCustomers);
+
+        const {
+          postalCode: custPostalCode,
+          address1: custAddress1,
+          address2: custAddress2,
+        } = relCustomers?.[0] || {};
+
+        const custAddress = addressBuilder({
+          address1: custAddress1?.value,
+          address2: custAddress2?.value,
+        });
 
         /**　
          * 含めるかどうか判定。重くなったら、改修。
@@ -241,13 +253,16 @@ export const useSearchResult = () => {
             custName: `${fullNames[0]}${fullNames.length > 1 ? `${fullNames.length - 1}` : ''}`,
             custNames: fullNames.join('、'),
             custNameKana: `${fullNameReadings[0]}`,
-            custAddress: `${addresses[0]}`,
+            custPostalCode: custPostalCode.value || '-',
+            custAddress: `${custAddress}`,
             tel: custTels[0],
             telRelation: custTelRelation[0],
             storeName: `${storeName.value}`,
             uuid: projId.value,
             projName: projName.value,
+            projPostalCode: projPostalCode,
             projAddress: projAddress,
+            projPostalCodeConfirmed: projPostalCodeConfirmed,
             projAddressConfirmed: projAddressConfirmed,
             contractDate: contractDate?.value ? contractDate.value : '-',
             deliveryDate: deliveryDate?.value ? deliveryDate.value : '-',

--- a/packages/kokoas-client/src/pages/projSearch/hooks/useSearchResult.ts
+++ b/packages/kokoas-client/src/pages/projSearch/hooks/useSearchResult.ts
@@ -115,8 +115,12 @@ export const useSearchResult = () => {
         const contracts = recContracts?.filter(({ projId: _prodId }) => projId.value === _prodId.value);
         
         const {
-          合計受注金額税込: totalContractAmtIncTax,
+          契約金額税込,
+          追加金額税込,
         } = getContractsSummary(contracts || []);
+
+        const totalContractAmtIncTax = 契約金額税込 + 追加金額税込;
+        
         const firstContract = contracts?.[0];
 
         const {

--- a/packages/kokoas-client/src/pages/projSearch/sections/result/DownloadResult.tsx
+++ b/packages/kokoas-client/src/pages/projSearch/sections/result/DownloadResult.tsx
@@ -27,8 +27,13 @@ export const DownloadResult = ({
         '顧客名（連名）': d.custNames,
         電話番号: d.tel,
         工事名: d.projName,
+        顧客郵便番号: d.custPostalCode,
         顧客住所: d.custAddress,
-        工事住所: d.projAddress,
+
+        // K246 工事確定住所が入力されている工事は、工事確定住所を工事住所として表示してほしい
+        工事郵便番号: d.projAddress ? d.projPostalCode : d.projPostalCodeConfirmed,
+        工事住所: d.projAddress || d.projAddressConfirmed,
+
         夢てつAG: d.yumeAG,
         ここすも営業担当: d.cocoAG,
         ここすも工事担当: d.cocoConst,

--- a/packages/kokoas-client/src/pages/projSearch/sections/result/DownloadResult.tsx
+++ b/packages/kokoas-client/src/pages/projSearch/sections/result/DownloadResult.tsx
@@ -31,8 +31,8 @@ export const DownloadResult = ({
         顧客住所: d.custAddress,
 
         // K246 工事確定住所が入力されている工事は、工事確定住所を工事住所として表示してほしい
-        工事郵便番号: d.projAddress ? d.projPostalCode : d.projPostalCodeConfirmed,
-        工事住所: d.projAddress || d.projAddressConfirmed,
+        工事郵便番号: d.projPostalCodeConfirmed? d.projPostalCodeConfirmed : d.projPostalCode,
+        工事住所: d.projAddressConfirmed || d.projAddress,
 
         夢てつAG: d.yumeAG,
         ここすも営業担当: d.cocoAG,

--- a/packages/kokoas-client/src/pages/projSearch/types.ts
+++ b/packages/kokoas-client/src/pages/projSearch/types.ts
@@ -17,13 +17,16 @@ export interface SearchResult {
   /** 全顧客 */
   custNames: string;
   custNameKana: string;
+  custPostalCode: string;
   custAddress: string;
   tel: string;
   telRelation: string;
   storeName: string;
   contractDate: string;
   deliveryDate: string;
+  projPostalCode: string;
   projAddress: string;
+  projPostalCodeConfirmed: string;
   projAddressConfirmed: string;
   projFinDate: string;
   payFinDate: string;


### PR DESCRIPTION
## 変更

1. 郵便番号と住所をそれぞれの配列に分けました。
2. ついでに契約金額を修正しました。

## 理由

1. [変更理由](https://rdmuhwtt6gx7.cybozu.com/k/236/show#record=246)
2. fix #813
3. `契約金額税込`は`追加契約`も入ってると思い込んでしまいました。現在、合算していますが、#814 はマージされたら、`合計契約金額`に変更します。
