### PR TITLE
perf-Agent names 

### DIFF
--- a/packages/api-kintone/src/custgroups/helpers/groupAgentNamesByType.ts
+++ b/packages/api-kintone/src/custgroups/helpers/groupAgentNamesByType.ts
@@ -1,0 +1,29 @@
+import { TAgents } from 'types';
+import { RecordType } from '../config';
+
+export const groupAgentNamesByType = (agents: RecordType['agents'] | undefined) => {
+
+  const initial: Record<TAgents, string> =  {
+    yumeAG: '',
+    cocoAG: '',
+    cocoConst: '',
+  };
+
+  if (!agents) return initial;
+
+  return agents?.value.reduce(
+    (acc, cur) => {
+      const { agentType } = cur.value;
+      const type = agentType.value as TAgents;
+      const agentName = cur.value.employeeName.value;
+      if (acc[type]) {
+        acc[type] += agentName ? `、${agentName}` : '' ;
+      } else {
+        acc[type] = agentName;
+      }
+      return acc;
+    }, 
+    initial,
+  );
+  
+};

--- a/packages/kokoas-client/src/pages/projContractSearchV2/hooks/useFilteredContracts.ts
+++ b/packages/kokoas-client/src/pages/projContractSearchV2/hooks/useFilteredContracts.ts
@@ -9,6 +9,7 @@ import { getCurrentContractStep } from '../helpers/getCurrentContractStep';
 import { useCallback } from 'react';
 import { parseISODateToFormat, parseISOTimeToFormat } from 'kokoas-client/src/lib';
 import { useTypedURLParams } from './useTypedHooks';
+import { groupAgentNamesByType } from 'api-kintone/src/custgroups/helpers/groupAgentNamesByType';
 
 export interface ContractRow {
   category: string,
@@ -78,7 +79,7 @@ export const useFilteredContracts = () => {
     enabled: !!projData && !!custGroupData && !!custData,
     select: useCallback((d) => {
 
-      if (!projData || !custGroupData) return;
+      if (!projData || !custGroupData || !projData) return;
 
       let minAmount = 0;
       let maxAmount = 0;
@@ -122,15 +123,19 @@ export const useFilteredContracts = () => {
           custGroupId,
           dataId,
           projTypeName,
+          store: storeName,
         } = projData.find((projRec) => projRec.uuid.value === projId.value ) || {};
 
         /* 顧客情報 */
         const {
-          cocoAGNames,
-          yumeAGNames,
-          storeName,
+          agents,
           members,
         } = custGroupData.find((custGroupRec) => custGroupRec.uuid.value === custGroupId?.value ) || {};
+
+        const {
+          cocoAG,
+          yumeAG,
+        } = groupAgentNamesByType(agents);
 
         /* 顧客名 */
         const custIds = members?.value?.map(({ value: { custId } }) => custId.value) || [];
@@ -186,8 +191,8 @@ export const useFilteredContracts = () => {
           custGroupId: custGroupId?.value || '',
           projId: projId.value,
           projDataId: formatDataId(dataId?.value || ''),
-          cocoAG: cocoAGNames?.value || '-',
-          yumeAG: yumeAGNames?.value || '-',
+          cocoAG: cocoAG || '-',
+          yumeAG: yumeAG || '-',
           contractDate:  parseISODateToFormat(contractDate?.value)  || '-',
 
           refundAmt: +refundAmt.value,

--- a/packages/kokoas-client/src/pages/projContractV2/sections/CustomerSummary.tsx
+++ b/packages/kokoas-client/src/pages/projContractV2/sections/CustomerSummary.tsx
@@ -23,13 +23,13 @@ export const CustomerSummary = () => {
     const {
       storeName,
       members,
-      cocoAGNames,
-      yumeAGNames,
     } = data || {};
+
 
     const custNames = members.value
       .map(({ value: { customerName } }) => customerName.value )
-      .join(', ');
+      .join('、 ');
+
     const {
       postal,
       address1,
@@ -46,8 +46,6 @@ export const CustomerSummary = () => {
       { label: '店舗', value: storeName?.value },
       { label: '顧客名', value: custNames },
       { label: '現住所', value: address },
-      { label: 'ここすも営業担当者', value: cocoAGNames.value },
-      { label: 'ゆめてつAG', value: yumeAGNames.value },
     ];
 
   }, [

--- a/packages/kokoas-client/src/pages/projContractV2/sections/ProjectSummary.tsx
+++ b/packages/kokoas-client/src/pages/projContractV2/sections/ProjectSummary.tsx
@@ -5,9 +5,10 @@ import { TypeOfForm } from '../schema';
 import { useAndpadOrderByProjId, useProjById } from 'kokoas-client/src/hooksQuery';
 import { ComponentProps, useMemo } from 'react';
 import { addressBuilder } from 'libs';
-import { TAgents } from 'types';
 import { pages } from '../../Router';
 import { Link } from '@mui/material';
+import { getAgentNamesByType } from 'api-kintone/src/projects/helpers/getAgentNamesByType';
+
 
 export const ProjectSummary = () => {
   const projId = useWatch<TypeOfForm>({
@@ -31,14 +32,16 @@ export const ProjectSummary = () => {
       address2,
       agents,
       forceLinkedAndpadSystemId,
+      store: storeName,
     } = data;
 
     const parsedAndpadSystemId = forceLinkedAndpadSystemId.value || systemId;
 
-    const cocoConstNames = agents.value
+    /*    const cocoConstNames = agents.value
       .filter(({ value: { agentType } }) => (agentType.value as TAgents) === 'cocoConst')
       .map(({ value: { agentName } }) => agentName.value)
-      .join(', ');
+      .join(', '); */
+
     
     const address = addressBuilder({
       postal: postal.value,
@@ -48,7 +51,10 @@ export const ProjectSummary = () => {
  
     return [
       { label: '工事名', value: projName.value },
-      { label: '工事担当者', value: cocoConstNames },
+      { label: '店舗', value: storeName.value },
+      { label: 'ゆめてつAG', value: getAgentNamesByType(agents, 'yumeAG') || '-' },
+      { label: 'ここすも営業担当', value: getAgentNamesByType(agents, 'cocoAG') || '-' },
+      { label: '工事担当者', value: getAgentNamesByType(agents, 'cocoConst') || '-' },
       { label: '工事住所', value: address },
       { label: 'AndpadシステムID', value: parsedAndpadSystemId 
         ? ( 

--- a/packages/kokoas-client/src/pages/projRegisterV2/sections/customersSummary/CustomerSummary.tsx
+++ b/packages/kokoas-client/src/pages/projRegisterV2/sections/customersSummary/CustomerSummary.tsx
@@ -11,6 +11,7 @@ import { useNavigate } from 'react-router-dom';
 import { StaticContentContainer } from 'kokoas-client/src/components/ui/information/StaticContentContainer';
 import { StaticContentInfos } from 'kokoas-client/src/components/ui/information/StaticContentInfos';
 import { StaticContentActions } from 'kokoas-client/src/components/ui/information/StaticContentActions';
+import { groupAgentsByType } from 'api-kintone/src/custgroups/helpers/groupAgentsByType';
 
 
 export const CustomerSummary = () => {
@@ -44,17 +45,21 @@ export const CustomerSummary = () => {
 
     const {
       storeName,
-      cocoAGNames,
-      yumeAGNames,
+      agents,
     } = data || {};
+
+    const {
+      yumeAG,
+      cocoAG,
+    } = groupAgentsByType(agents);
   
     const custData = [
       { label: '店舗', value: storeName?.value },
     ];
 
     const officerData = [
-      { label: 'ゆめてつAG', value: yumeAGNames.value },
-      { label: 'ここすも営業担当者', value: cocoAGNames.value },
+      { label: 'ゆめてつAG', value: yumeAG.map(({ value:{ employeeName } }) => employeeName.value ).join('、') },
+      { label: 'ここすも営業担当者', value: cocoAG.map(({ value:{ employeeName } }) => employeeName.value ).join('、')  },
       //{ label: '工事担当者', value: constructionOfficers || '' },
     ];
 


### PR DESCRIPTION
## 変更

- yumeAgentNamesへの依存を減らしました。
- 名前を取得する処理を最適化しました。

## 理由

- ルークアップに参照出来るように、実装しましたが、保守性を考えると、安定しないので、廃止するフィールドです。
- レコードが増えてきているので、重くなっている。