### PR TITLE
837 顧客グループの検索処理を作成する

### DIFF
--- a/packages/api-kintone/src/custgroups/config.ts
+++ b/packages/api-kintone/src/custgroups/config.ts
@@ -1,5 +1,9 @@
 import { AppIds } from 'config';
-import { ICustgroups } from 'types';
+import { ICustgroups, KCustgroups } from 'types';
 
 export const appId = AppIds.custGroups;
+
 export type RecordType = ICustgroups;
+
+export type RecordKey =  KCustgroups 
+| keyof ICustgroups['members']['value'][number]['value'];

--- a/packages/api-kintone/src/custgroups/searchCustGroupByKeyword.test.ts
+++ b/packages/api-kintone/src/custgroups/searchCustGroupByKeyword.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from '@jest/globals';
+import { searchCustGroupByKeyword } from './searchCustGroupByKeyword';
+
+describe('searchCustGroupByKeyword', () => {
+  it('should return an array of customer groups that match the keyword', async () => {
+    const result = await searchCustGroupByKeyword({ keyword: 'テスト' });
+    expect(Array.isArray(result)).toBe(true);
+    expect(result.length).toBeGreaterThan(0);
+
+    result.forEach((group) => {
+      console.log(JSON.stringify(group.members.value, null, 2));
+      expect(JSON.stringify(group.members.value)).toContain('テスト');
+    });
+
+    console.log('Result length:', result.length);
+  });
+
+  it('should return an empty array if no customer groups match the keyword', async () => {
+    const result = await searchCustGroupByKeyword({ keyword: 'nonexistent' });
+    expect(Array.isArray(result)).toBe(true);
+    expect(result.length).toBe(0);
+  });
+});

--- a/packages/api-kintone/src/custgroups/searchCustGroupByKeyword.ts
+++ b/packages/api-kintone/src/custgroups/searchCustGroupByKeyword.ts
@@ -1,8 +1,23 @@
+import { RecordKey } from './config';
+import { getAllCustGroups } from './getAllCustGroups';
+
+
 export const searchCustGroupByKeyword = async ({
   keyword,
 }:{
   keyword: string
 }) => {
 
-  console.log(keyword);
+  const keywordKeys : RecordKey[] = [
+    'customerName',
+    'custNameReading',
+  ];
+   
+
+  return getAllCustGroups({
+    condition: keywordKeys
+      .map((field) => `${field} like "${keyword}"`)
+      .join(' or '),
+  });
+  
 };

--- a/packages/api-kintone/src/custgroups/searchCustGroupByKeyword.ts
+++ b/packages/api-kintone/src/custgroups/searchCustGroupByKeyword.ts
@@ -2,6 +2,12 @@ import { RecordKey } from './config';
 import { getAllCustGroups } from './getAllCustGroups';
 
 
+/**
+ * Searches for customer groups by keyword.
+ * @param params - The options object.
+ * @param params.keyword - The keyword to search for.
+ * @returns  A promise that resolves to an array of customer groups.
+ */
 export const searchCustGroupByKeyword = async ({
   keyword,
 }:{

--- a/packages/api-kintone/src/custgroups/searchCustGroupByKeyword.ts
+++ b/packages/api-kintone/src/custgroups/searchCustGroupByKeyword.ts
@@ -7,6 +7,9 @@ import { getAllCustGroups } from './getAllCustGroups';
  * @param params - The options object.
  * @param params.keyword - The keyword to search for.
  * @returns  A promise that resolves to an array of customer groups.
+ * 
+ * ただし、kintoneの制限により、一文字で検索するとヒットしない場合がある。
+ * @see https://www.ait-labo.com/kintone-basic/2690/
  */
 export const searchCustGroupByKeyword = async ({
   keyword,

--- a/packages/api-kintone/src/custgroups/searchCustGroupByKeyword.ts
+++ b/packages/api-kintone/src/custgroups/searchCustGroupByKeyword.ts
@@ -1,0 +1,8 @@
+export const searchCustGroupByKeyword = async ({
+  keyword,
+}:{
+  keyword: string
+}) => {
+
+  console.log(keyword);
+};

--- a/packages/kokoas-client/src/pages/custGroup/sections/OBSearch/SearchDialogContent.tsx
+++ b/packages/kokoas-client/src/pages/custGroup/sections/OBSearch/SearchDialogContent.tsx
@@ -10,7 +10,7 @@ export const SearchDialogContent = () => {
 
   return (
     <DialogContent>
-      <Stack mt={1}>
+      <Stack mt={1} spacing={2}>
         <Alert severity='info'>
           開発段階です。しばらくお待ちください。
           提案がありましたら、気楽にお声がけください。


### PR DESCRIPTION
## 派生元

#838　に依存しています。それを先にマージが必要です。 

## 変更

1. キーワードで顧客を検索出来る関数を追加しました。

## 理由

1. closes #837 


## 備考

kintoneの制限により、ヒットしない場合があります。ユーザに説明し、どうしても、一文字などの検索が可能にしてほしいなら、キャッシュを利用します。ただし、データが増えるにつれて、クライエント側にますます負担がかかると大きなデメリットです。

サーバ側処理にするのも手ですが、それも解決策の分岐点があるので、要相談です。