### PR TITLE
hotfix-新規顧客を作成して、もう一回保存すると、新規データが登録される。

### DIFF
--- a/packages/kokoas-client/src/pages/custGroup/hooks/useSubmitHandler.tsx
+++ b/packages/kokoas-client/src/pages/custGroup/hooks/useSubmitHandler.tsx
@@ -45,6 +45,9 @@ export const useSubmitHandler = () => {
         handleYes: ()=>navigate('projEditV2', {
           custGroupId: id,
         }),
+        handleNo: ()=>navigate('custGroupEditV2', {
+          custGroupId: id,
+        }),
       });
       
     },


### PR DESCRIPTION
## 変更

1. 新規の際、保存後、「工事情報を登録しますか。」の確認が出て、`いいえ`を押すと、urlのパラメターに新規の顧客グループidを渡す

## 理由

1.　そうさせないと、新規としてみなしてしまいます。
