### PR TITLE
請求アラートで担当者名が空文字列の時にグループ通知されてしまうことへの対策

### DIFF
--- a/packages-automation/auto-invoiceAlert/src/helpers/getYumeAgNames.test.ts
+++ b/packages-automation/auto-invoiceAlert/src/helpers/getYumeAgNames.test.ts
@@ -6,7 +6,7 @@ import { getYumeAgNames } from './getYumeAgNames';
 describe('getYumeAgNames', () => {
   it('getYumeAgNames', async () => {
 
-    const projcts = await getProjById('1d5236c7-ee92-47dc-8a10-4db2055b2358');
+    const projcts = await getProjById('66bc6fc7-0ace-45b8-9b58-84ba5da195d0');
 
     const result = getYumeAgNames({
       agents: projcts.agents,

--- a/packages-automation/auto-invoiceAlert/src/helpers/getYumeAgNames.test.ts
+++ b/packages-automation/auto-invoiceAlert/src/helpers/getYumeAgNames.test.ts
@@ -4,7 +4,7 @@ import { getYumeAgNames } from './getYumeAgNames';
 
 
 describe('getYumeAgNames', () => {
-  it('getYumeAgNames', async () => {
+  it('should return \'取得に失敗しました\' when no names are resolved', async () => {
 
     const projcts = await getProjById('66bc6fc7-0ace-45b8-9b58-84ba5da195d0');
 

--- a/packages-automation/auto-invoiceAlert/src/helpers/getYumeAgNames.ts
+++ b/packages-automation/auto-invoiceAlert/src/helpers/getYumeAgNames.ts
@@ -7,14 +7,10 @@ export const getYumeAgNames = ({
   agents: RecordType['agents'] | undefined,
 }) => {
 
-  const yumeAgents = agents?.value.filter(({ value }) => {
-    const {
-      agentType,
-      agentName,
-    } = value;
-
-    return (agentType.value === 'yumeAG' as TAgents) && agentName.value !== '';
-  });
+  const yumeAgents = agents?.value
+    .filter(({ value: { agentType, agentName } }) => {
+      return (agentType.value === 'yumeAG' as TAgents) && agentName.value !== '';
+    });
 
   if (yumeAgents?.length) {
     return yumeAgents.map(({ value }) => value.agentName.value).join(', ');

--- a/packages-automation/auto-invoiceAlert/src/helpers/getYumeAgNames.ts
+++ b/packages-automation/auto-invoiceAlert/src/helpers/getYumeAgNames.ts
@@ -10,9 +10,10 @@ export const getYumeAgNames = ({
   const yumeAgents = agents?.value.filter(({ value }) => {
     const {
       agentType,
+      agentName,
     } = value;
 
-    return agentType.value === 'yumeAG' as TAgents;
+    return (agentType.value === 'yumeAG' as TAgents) && agentName.value !== '';
   });
 
   if (yumeAgents?.length) {

--- a/packages-automation/auto-invoiceAlert/src/notificationFunc/chatworkRoomIdSetting.ts
+++ b/packages-automation/auto-invoiceAlert/src/notificationFunc/chatworkRoomIdSetting.ts
@@ -14,7 +14,11 @@ export const chatworkRoomIdSetting = ({
 }) => {
 
   const chatworkRoomIds = agents?.value.filter(({ value }) => {
-    return value.agentType.value === 'cocoAG';
+    const {
+      agentType,
+      agentName,
+    } = value;
+    return (agentType.value === 'cocoAG') && (agentName.value !== '');
   }).map(({ value: {
     agentId,
     agentName,
@@ -31,7 +35,7 @@ export const chatworkRoomIdSetting = ({
   });
 
 
-  return chatworkRoomIds || [{ 
+  return chatworkRoomIds || [{
     cwRoomId: chatworkRooms.cocoasGroup,
     agentId: '',
     agentName: '取得に失敗しました',


### PR DESCRIPTION
## 変更

1. 請求アラートの工事担当者の取得の条件を修正する
2. エージェントの取得条件も同様に修正する

## 理由

1. closes #867 

## テスト

- chatworkRoomIdSetting.test.ts
- getYumeAgNames.test.ts
