### PR TITLE
hotfix-印刷する際、layoutのオプションが出ない

### DIFF
--- a/packages-kintone-customize/app-229-contracts/src/view/indexShow/renderContractList/sections/result/Result.module.css
+++ b/packages-kintone-customize/app-229-contracts/src/view/indexShow/renderContractList/sections/result/Result.module.css
@@ -1,7 +1,7 @@
 @media print {
   @page {
    
-    size: A3 landscape;  /* 297 x 420 mm */
+    size: A3 auto;  /* 297 x 420 mm */
     margin: 25mm 25mm 25mm 25mm;
   }
   .print {

--- a/packages-kintone-customize/app-229-contracts/src/view/indexShow/renderSchedule/sections/results/Results.module.css
+++ b/packages-kintone-customize/app-229-contracts/src/view/indexShow/renderSchedule/sections/results/Results.module.css
@@ -1,7 +1,7 @@
 @media print {
 
   @page {
-    size: A3 landscape;
+    size: A3 auto;
     margin: 10mm;
   }
   .printNode {


### PR DESCRIPTION
## 変更

1. `landscape`を　`auto`に変えました。

## 理由

1. 印刷するとき、layoutがなくなる原因とみられます。

## 備考

- スタイルするとき、cssのクラス名を考えるなど困らないように、reactの標準のmoduleを利用していますが、`at-directives`は他ページにも反映していると分かりました。 今度のリファクタリングで、module.cssの場合、グロバルの記述を廃止します。
