### PR TITLE
工事内容に「andpadSystemId」を追加しました。

### DIFF
--- a/packages/api-kintone/scripts/batch/updateProjSystemIds.test.ts
+++ b/packages/api-kintone/scripts/batch/updateProjSystemIds.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, it } from '@jest/globals';
 import { getAllAndpadOrders } from 'api-andpad';
-import { getAllRecords } from 'api-kintone/src';
+import { getAllRecords, updateAllRecords } from 'api-kintone/src';
 import { AppIds } from 'config';
 import { IProjects } from 'types';
+import path from 'path';
+import fs from 'fs';
+import { KintoneClientBasicAuth } from './settings';
 
 /*
  システムIDを一括更新処理です。
@@ -15,28 +18,64 @@ import { IProjects } from 'types';
 describe('updateProjSystemIds', () => {
   it('should update project system ids', async () => {
 
+    const projAppId = AppIds.projects;
+
     const [
       projectsWithoutForcedLinkedSystemIds,
       allAndpadOrders,
     ] = await Promise.all([
       getAllRecords<IProjects>({
-        app: AppIds.projects,
-        condition: 'forceLinkedAndpadSystemId = ""', // Andpadへ強制接続以外の案件
+        app: projAppId,
+        condition:  'forceLinkedAndpadSystemId = ""', // Andpadへ強制接続以外の案件
       }),
       getAllAndpadOrders({
         q: '案件管理ID IS EXIST', // ココアスによって登録された案件のみ（標準接続）
       }),
     ]);
 
-    
-
-    
-    console.log('Length', allAndpadOrders.data.objects.length, allAndpadOrders.data.total);
-
     expect(
       projectsWithoutForcedLinkedSystemIds
         .every(({ forceLinkedAndpadSystemId }) => !forceLinkedAndpadSystemId.value),
     ).toBeTruthy();
+
+    const projectsWithSystemId = projectsWithoutForcedLinkedSystemIds
+      .reduce((acc, cur) => {
+        
+        const andpadOrder = allAndpadOrders.data.objects
+          .find(({ 案件管理ID }) => 案件管理ID === cur.uuid.value);
+
+        if (andpadOrder) {
+          acc.push({
+            id: cur.$id.value,
+            record: {
+              andpadSystemId: {
+                value: String(andpadOrder.システムID),
+              },
+            } as Partial<IProjects>,
+          });
+        }
+
+        return acc;
+      }, [] as Parameters<typeof updateAllRecords>[0]['records']);
+
+    const dir = path.join(__dirname, '__TEST__');
+    fs.writeFileSync(
+      path.join(dir, `updateProjSystemIds_${new Date().getTime()}.json`),
+      JSON.stringify(projectsWithSystemId, null, 2),
+    );
+
+
+    const updateResult = await KintoneClientBasicAuth.record.updateAllRecords({
+      app: projAppId,
+      records: projectsWithSystemId,
+    })
+      .catch((e) => {
+        console.log(JSON.stringify(e, null, 2));
+        throw e;
+      });
+
+    console.log(updateResult);
+    
 
 
   }, 9000000);

--- a/packages/api-kintone/scripts/batch/updateProjSystemIds.test.ts
+++ b/packages/api-kintone/scripts/batch/updateProjSystemIds.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from '@jest/globals';
+import { getAllAndpadOrders } from 'api-andpad';
+import { getAllRecords } from 'api-kintone/src';
+import { AppIds } from 'config';
+import { IProjects } from 'types';
+
+/*
+ システムIDを一括更新バッチです。
+
+ 普段実行しませんが、修正や問題があったら、
+*/
+
+describe('updateProjSystemIds', () => {
+  it('should update project system ids', async () => {
+
+    const [
+      projectsWithoutForcedLinkedSystemIds,
+      allAndpadOrders,
+    ] = await Promise.all([
+      getAllRecords<IProjects>({
+        app: AppIds.projects,
+        condition: 'forceLinkedAndpadSystemId = ""',
+      }),
+      getAllAndpadOrders({ beforeInvoiceIssue: false }),
+    ]);
+
+    
+    console.log('Length', allAndpadOrders.data.objects.length, allAndpadOrders.data.total);
+
+    expect(
+      projectsWithoutForcedLinkedSystemIds
+        .every(({ forceLinkedAndpadSystemId }) => !forceLinkedAndpadSystemId.value),
+    ).toBeTruthy();
+
+
+  }, 9000000);
+});

--- a/packages/api-kintone/scripts/batch/updateProjSystemIds.test.ts
+++ b/packages/api-kintone/scripts/batch/updateProjSystemIds.test.ts
@@ -5,9 +5,11 @@ import { AppIds } from 'config';
 import { IProjects } from 'types';
 
 /*
- システムIDを一括更新バッチです。
+ システムIDを一括更新処理です。
 
- 普段実行しませんが、修正や問題があったら、
+ 普段実行しませんが、andpadSystemIdに修正や問題があったら、
+ 当関数を必用に応じて、調整し、実行してください。
+
 */
 
 describe('updateProjSystemIds', () => {
@@ -19,10 +21,14 @@ describe('updateProjSystemIds', () => {
     ] = await Promise.all([
       getAllRecords<IProjects>({
         app: AppIds.projects,
-        condition: 'forceLinkedAndpadSystemId = ""',
+        condition: 'forceLinkedAndpadSystemId = ""', // Andpadへ強制接続以外の案件
       }),
-      getAllAndpadOrders({ beforeInvoiceIssue: false }),
+      getAllAndpadOrders({
+        q: '案件管理ID IS EXIST', // ココアスによって登録された案件のみ（標準接続）
+      }),
     ]);
+
+    
 
     
     console.log('Length', allAndpadOrders.data.objects.length, allAndpadOrders.data.total);

--- a/packages/api-kintone/scripts/batch/updateProjSystemIds.test.ts
+++ b/packages/api-kintone/scripts/batch/updateProjSystemIds.test.ts
@@ -8,7 +8,7 @@ import fs from 'fs';
 import { KintoneClientBasicAuth } from './settings';
 
 /*
- システムIDを一括更新処理です。
+ 工事内容のandpadSystemIdを一括更新処理です。
 
  普段実行しませんが、andpadSystemIdに修正や問題があったら、
  当関数を必用に応じて、調整し、実行してください。

--- a/packages/kokoas-client/src/pages/projRegisterV2/parts/ForcedAndpadLink.tsx
+++ b/packages/kokoas-client/src/pages/projRegisterV2/parts/ForcedAndpadLink.tsx
@@ -22,6 +22,7 @@ export const ForcedAndpadLink = ({
       projId,
       record: {
         forceLinkedAndpadSystemId: { value: systemId },
+        andpadSystemId: { value: '' }, // 標準接続解除
       },
     });
   };

--- a/packages/kokoas-client/src/pages/projRegisterV2/parts/saveToAndpad/SaveToAndpadDialog.tsx
+++ b/packages/kokoas-client/src/pages/projRegisterV2/parts/saveToAndpad/SaveToAndpadDialog.tsx
@@ -25,31 +25,41 @@ export const SaveToAndpadDialog = ({
   );
 
   const { mutateAsync: mutateAndpad } = useSaveAndpadProject();
-  const { mutate: mutateLog } = useSaveProject();
+  const { mutate: mutateProj } = useSaveProject();
 
   const handleClick = async () => {
     if (data) {
       mutateAndpad(data)
-        .then(async () => {
+        .then(async ({
+          data:{
+            object: {
+              システムID: andpadSystemId,
+            },
+          },
+        }) => {
           const { 
             log,
           } = await getProjById(projId || '');
 
-          mutateLog({ projId, record: {
-            log: {
-              type: 'SUBTABLE',
-              value: [
-                {
-                  id: '',
-                  value: {
-                    logNote: { value: `Andpadへ${mode}` },
-                    logDateTime: { value: new Date().toISOString() },
+          mutateProj({ 
+            projId, 
+            record: {
+              andpadSystemId: { value: String(andpadSystemId) },
+              forceLinkedAndpadSystemId: { value: '' }, // 強制接続解除
+              log: {
+                type: 'SUBTABLE',
+                value: [
+                  {
+                    id: '',
+                    value: {
+                      logNote: { value: `Andpadへ${mode}` },
+                      logDateTime: { value: new Date().toISOString() },
+                    },
                   },
-                },
-                ...(log.value ?? []),
-              ],
-            },
-          } });
+                  ...(log.value ?? []),
+                ],
+              },
+            } });
 
         });
     }

--- a/packages/types/src/dtsgen/db.projects.d.ts
+++ b/packages/types/src/dtsgen/db.projects.d.ts
@@ -1,7 +1,6 @@
 declare namespace DBProjects {
   interface Data {
     schedContractDate: kintone.fieldTypes.Date;
-    forceLinkedAndpadSystemId_0: kintone.fieldTypes.SingleLineText;
     lastBillingDate: kintone.fieldTypes.Date;
     cancelStatus: kintone.fieldTypes.SingleLineText;
     memo: kintone.fieldTypes.SingleLineText;
@@ -11,6 +10,7 @@ declare namespace DBProjects {
     schedContractPrice: kintone.fieldTypes.Number;
     otherProjType: kintone.fieldTypes.SingleLineText;
     cocoAGNames: kintone.fieldTypes.SingleLineText;
+    forceLinkedAndpadSystemId: kintone.fieldTypes.SingleLineText;
     rank: kintone.fieldTypes.SingleLineText;
     estatePurchaseDate: kintone.fieldTypes.Date;
     realEstateStatus: kintone.fieldTypes.SingleLineText;

--- a/packages/types/src/dtsgen/db.projects.d.ts
+++ b/packages/types/src/dtsgen/db.projects.d.ts
@@ -1,6 +1,7 @@
 declare namespace DBProjects {
   interface Data {
     schedContractDate: kintone.fieldTypes.Date;
+    forceLinkedAndpadSystemId_0: kintone.fieldTypes.SingleLineText;
     lastBillingDate: kintone.fieldTypes.Date;
     cancelStatus: kintone.fieldTypes.SingleLineText;
     memo: kintone.fieldTypes.SingleLineText;
@@ -10,7 +11,6 @@ declare namespace DBProjects {
     schedContractPrice: kintone.fieldTypes.Number;
     otherProjType: kintone.fieldTypes.SingleLineText;
     cocoAGNames: kintone.fieldTypes.SingleLineText;
-    forceLinkedAndpadSystemId: kintone.fieldTypes.SingleLineText;
     rank: kintone.fieldTypes.SingleLineText;
     estatePurchaseDate: kintone.fieldTypes.Date;
     realEstateStatus: kintone.fieldTypes.SingleLineText;
@@ -30,6 +30,7 @@ declare namespace DBProjects {
     deliveryDate: kintone.fieldTypes.Date;
     payFinDate: kintone.fieldTypes.Date;
     isChkAddressKari: kintone.fieldTypes.Number;
+    andpadSystemId: kintone.fieldTypes.SingleLineText;
     planApplicationDate: kintone.fieldTypes.Date;
     address2: kintone.fieldTypes.SingleLineText;
     address1: kintone.fieldTypes.SingleLineText;


### PR DESCRIPTION
## 変更

1. 工事内容に「andpadSystemId」を追加しました。

## 仕様

工事内容の画面

1. 標準登録したら,　`andpadSystemId` にシステムIDを格納し、 `forceLinkedAndpadSystemId` はクリアされます。
2. 強制登録接続したら、`forceLinkedAndpadSystemId` にシステムIDを格納し、 `andpadSystemId` はクリアされます。

## 理由

1. Andpadの発注情報や請求情報などにはココアスの工事IDはなく、AndpadのシステムIDでしか抽出出来ないため。

## テスト

- スキーマ
`nx cy:int kokoas-e2e`

## 備考

- `script/batch`　の他のファイルと同様、 `updateProjSystemIds　`は普段実行しないものです。実行する前に、バックアップしてください。
- ココアスのシステムIDのフィールドを一体化するのも手ですが、変更箇所やリスクが増えるため、後回しにします。