### PR TITLE
K270 契約累積表で月ごとにレコードがないと、「なし」を表示させたい

### DIFF
--- a/packages-kintone-customize/app-229-contracts/src/view/indexShow/renderCumulative/sections/results/fiscalMonths/fiscalMonthTable/FiscalMonthTable.tsx
+++ b/packages-kintone-customize/app-229-contracts/src/view/indexShow/renderCumulative/sections/results/fiscalMonths/fiscalMonthTable/FiscalMonthTable.tsx
@@ -1,4 +1,4 @@
-import { Stack, Table, TableBody, TableHead, Typography } from '@mui/material';
+import { Stack, Table, TableBody, TableCell, TableHead, TableRow, Typography } from '@mui/material';
 import { ReactNode } from 'react';
 import style from './FiscalMonthTable.module.css';
 import { TableRowLayout } from './TableRowLayout';
@@ -71,6 +71,13 @@ export const FiscalMonthTable = ({
                 agent={<FitText content={agents.length ?  agents.join('、 ') : 'ここすも'} />}
               />);
           })}
+          {!records.length && (
+            <TableRow>
+              <TableCell colSpan={10} align='center'>
+                なし
+              </TableCell>
+            </TableRow>
+          )}
         </TableBody>
       </Table>
     </Stack>


### PR DESCRIPTION
## 変更前

![image](https://github.com/Lorenzras/yumecoco-monorepo/assets/2501255/c134c100-e5ed-49fc-99ff-0a52813b9194)
https://rdmuhwtt6gx7.cybozu.com/k/229/?view=6343118

## 変更後

![image](https://github.com/Lorenzras/yumecoco-monorepo/assets/2501255/d51677e4-0a56-4a57-839a-c96aa45d0909)

## 理由

1. [変更理由](https://rdmuhwtt6gx7.cybozu.com/k/236/show#record=270&mode=show)
