### PR TITLE
hotfix-請求アラートのリマインダー設定用URLのパスを修正します

### DIFF
--- a/packages-automation/auto-invoiceAlert/src/helpers/convertReminderToJson.ts
+++ b/packages-automation/auto-invoiceAlert/src/helpers/convertReminderToJson.ts
@@ -60,7 +60,7 @@ export const convertReminderToJson = ({
 
 
     // kintoneのリマインダーURLを設定する
-    const reminderUrl = `${kintoneBaseUrl}/k/${reminderAppId}/show#record=${$id.value}&mode=edit`;
+    const reminderUrl = `${kintoneBaseUrl}k/${reminderAppId}/show#record=${$id.value}&mode=edit`;
 
     // 請求書が発行されているかどうかを確認する
     let hasInvoice = false;


### PR DESCRIPTION
## 変更

1. タイトルの通り

## 理由

1. パスのミスにより、ページカスタマイズの設定が適用されていなかったため

## テスト

 エンドポイントにて確認
- 修正前：https://rdmuhwtt6gx7.cybozu.com//k/269/show#record=14
- 修正後：https://rdmuhwtt6gx7.cybozu.com/k/269/show#record=14
