### PR TITLE
hotfix-本契約が存在していても、新規契約の場合、カテゴリーを「追加」出来ない

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -91,7 +91,7 @@ module.exports = {
       'error',
       { 
         props: true, 
-        ignorePropertyModificationsFor: ['draft', 'acc'],
+        ignorePropertyModificationsFor: ['draft', 'acc', 'res'],
       },
     ],
   },

--- a/packages/kokoas-client/src/pages/projContractV2/hooks/useHasMainContract.ts
+++ b/packages/kokoas-client/src/pages/projContractV2/hooks/useHasMainContract.ts
@@ -20,15 +20,17 @@ export const useHasMainContract = () => {
     ...others
   } = useContractsByProjIdV2(projId);
 
-  const isNewContract = !contractId; // Check if it's a new contract
+  /** 新規契約かどうか */
+  const isNewContract = !contractId; 
 
   return {
     data: !!contracts?.length && contracts
       .some((contract) => {
 
-        const isNotCurrentContract = contract.uuid.value !== contractId; // Check if it's a different contract than the one currently open
+        /** 開いている契約以外の契約かどうか */
+        const isNotCurrentContract = contract.uuid.value !== contractId; 
 
-        return contract.contractType.value === '契約' // Check if it's a main contract
+        return contract.contractType.value === '契約' // 本契約かどうか
           && (
             isNotCurrentContract
             || isNewContract 

--- a/packages/kokoas-client/src/pages/projContractV2/hooks/useHasMainContract.ts
+++ b/packages/kokoas-client/src/pages/projContractV2/hooks/useHasMainContract.ts
@@ -20,9 +20,21 @@ export const useHasMainContract = () => {
     ...others
   } = useContractsByProjIdV2(projId);
 
+  const isNewContract = !contractId; // Check if it's a new contract
+
   return {
-    data: contracts
-      .some((contract) => contract.contractType.value === '契約' && contract.uuid.value !== contractId),
+    data: !!contracts?.length && contracts
+      .some((contract) => {
+
+        const isNotCurrentContract = contract.uuid.value !== contractId; // Check if it's a different contract than the one currently open
+
+        return contract.contractType.value === '契約' // Check if it's a main contract
+          && (
+            isNotCurrentContract
+            || isNewContract 
+          ) 
+        ;
+      }),
     ...others,
   };
 };

--- a/packages/kokoas-client/src/pages/projContractV2/sections/contractType/ContractType.tsx
+++ b/packages/kokoas-client/src/pages/projContractV2/sections/contractType/ContractType.tsx
@@ -25,6 +25,7 @@ export const ContractType = () => {
   
       <Collapse 
         in={contractType === '追加'}
+        unmountOnExit
       >
         <SubInputContainer>
           <AdditionalContract />

--- a/packages/kokoas-e2e/cypress/e2e/contractPreview2/helpers/checkContractAddStatus.ts
+++ b/packages/kokoas-e2e/cypress/e2e/contractPreview2/helpers/checkContractAddStatus.ts
@@ -1,0 +1,28 @@
+import { produce } from 'immer';
+import { IContracts } from 'types';
+
+export const checkContractAddStatus = (mockHasContract: boolean, shouldBeEnabled: boolean) => {
+  cy.intercept('GET', '**/k/v1/records.json?app=231&query=projId*', (req) => {
+    req.continue((res) => {
+      const modifiedBody = produce(res.body as { records: IContracts[] }, (draft) => {
+        if (mockHasContract) {
+          draft.records[0].contractType.value = '契約';
+        } else {
+          draft.records = [];
+        }
+      });
+
+      res.send({ 
+        body: modifiedBody, 
+      });
+    });
+  }).as('getContracts');
+        
+  cy.wait('@getContracts');
+
+  cy.getRadiosByValue('追加')
+    .scrollIntoView({ offset: { top: -200, left: 0 } })
+    .should(shouldBeEnabled ? 'be.enabled' : 'be.disabled');
+
+  cy.screenshot();
+};

--- a/packages/kokoas-e2e/cypress/e2e/contractPreview2/inputNew.cy.ts
+++ b/packages/kokoas-e2e/cypress/e2e/contractPreview2/inputNew.cy.ts
@@ -3,8 +3,7 @@ import { correctInputData, labelMap } from './testData';
 import format from 'date-fns/format';
 import addMonths from 'date-fns/addMonths';
 import { calculateAmount, roundTo } from 'libs';
-import { produce } from 'immer';
-import { IContracts } from 'types';
+import { checkContractAddStatus } from './helpers/checkContractAddStatus';
 
 describe(
   '入力挙動', 
@@ -280,49 +279,16 @@ describe(
     });
 
 
-
-    const checkContractStatus = (mockHasContract: boolean, shouldBeEnabled: boolean) => {
-      cy.intercept('GET', '**/k/v1/records.json?app=231&query=projId*', (req) => {
-        req.continue((res) => {
-          const modifiedBody = produce(res.body as { records: IContracts[] }, (draft) => {
-            if (mockHasContract) {
-              draft.records[0].contractType.value = '契約';
-            } else {
-              draft.records = [];
-            }
-          });
-    
-          res.send({ 
-            body: modifiedBody, 
-          });
-        });
-      }).as('getContracts');
-            
-      cy.wait('@getContracts');
-    
-      cy.getRadiosByValue('追加')
-        .scrollIntoView({ offset: { top: -300, left: 0 } })
-        .should(shouldBeEnabled ? 'be.enabled' : 'be.disabled');
-
-      cy.screenshot();
-    };
-
-
     it.only('本契約がある場合、「追加」は有効状態にになる', () => {
 
-      checkContractStatus(true, true);
-
-     
+      checkContractAddStatus(true, true);
     });
 
     it.only('本契約がない場合、「追加」は無効状態になる', () => {
 
-      checkContractStatus(false, false);
+      checkContractAddStatus(false, false);
 
     });
-
-
-    
   
   },
 );

--- a/packages/kokoas-e2e/cypress/e2e/contractPreview2/inputNew.cy.ts
+++ b/packages/kokoas-e2e/cypress/e2e/contractPreview2/inputNew.cy.ts
@@ -228,6 +228,8 @@ describe(
         .parent() // actual input element is hidden, so scroll to parent
         .scrollIntoView();
 
+      cy.screenshot();
+
       cy.getCheckboxesByLabel('返金').check();
 
 
@@ -279,12 +281,12 @@ describe(
     });
 
 
-    it.only('本契約がある場合、「追加」は有効状態にになる', () => {
+    it('本契約がある場合、「追加」は有効状態にになる', () => {
 
       checkContractAddStatus(true, true);
     });
 
-    it.only('本契約がない場合、「追加」は無効状態になる', () => {
+    it('本契約がない場合、「追加」は無効状態になる', () => {
 
       checkContractAddStatus(false, false);
 

--- a/packages/kokoas-e2e/cypress/e2e/contractPreview2/save.cy.ts
+++ b/packages/kokoas-e2e/cypress/e2e/contractPreview2/save.cy.ts
@@ -9,7 +9,7 @@ describe('保存処理', { scrollBehavior: 'center' }, () => {
   const correctInput = correctInputData();
   beforeEach(() => {
     cy.login();
-    cy.visit(`/project/contract/preview/v2?projId=${testProjId}`);
+    cy.visit(`/project/contract/preview/v2?projId=${testProjId}`); 
   });
 
   it('新規保存できること', () => {
@@ -80,7 +80,5 @@ describe('保存処理', { scrollBehavior: 'center' }, () => {
 
   });
 
-  it.only('本契約があって、新規契約の場合、', () => {
-    
-  });
+ 
 });

--- a/packages/kokoas-e2e/cypress/e2e/contractPreview2/save.cy.ts
+++ b/packages/kokoas-e2e/cypress/e2e/contractPreview2/save.cy.ts
@@ -79,4 +79,8 @@ describe('保存処理', { scrollBehavior: 'center' }, () => {
     cy.get('@date').should('have.value', futureDate);
 
   });
+
+  it.only('本契約があって、新規契約の場合、', () => {
+    
+  });
 });

--- a/packages/kokoas-e2e/cypress/support/commands.ts
+++ b/packages/kokoas-e2e/cypress/support/commands.ts
@@ -26,6 +26,10 @@ Cypress.Commands.add('login', () => {
   });
 
   Cypress.Commands.add('getCheckboxesByLabel', (label: string) => {
+    cy.contains('label', label).then(el => {
+      console.log('el', el);
+    });
+    
     cy.contains('label', label)
       .find('input[type="checkbox"]');
   });

--- a/packages/kokoas-e2e/cypress/support/commands.ts
+++ b/packages/kokoas-e2e/cypress/support/commands.ts
@@ -26,10 +26,7 @@ Cypress.Commands.add('login', () => {
   });
 
   Cypress.Commands.add('getCheckboxesByLabel', (label: string) => {
-    cy.contains('label', label).then(el => {
-      console.log('el', el);
-    });
-    
+
     cy.contains('label', label)
       .find('input[type="checkbox"]');
   });


### PR DESCRIPTION
## 変更

1. 本契約があるかどうかの条件に新規契約を追加しました。

## 理由

1. 修正のため。

## テスト

録画あり。
`nx cy:run kokoas-e2e -- --spec 'cypress/e2e/contractPreview2/inputNew.cy.ts'`

「追加」の挙動に関するテストは、スクショあり。(カテゴリからずれる可能性)