### PR TITLE
工事情報の担当者情報の更新スクリプトを修正します

### DIFF
--- a/packages/api-kintone/scripts/batch/updateProjectsConstMembers.test.ts
+++ b/packages/api-kintone/scripts/batch/updateProjectsConstMembers.test.ts
@@ -6,5 +6,5 @@ describe('updateProjectsConstMembers', ()=>{
     const result = await updateProjectsConstMembers();
 
     expect(result).toBeDefined();
-  }, 8000);
+  }, 100000);
 });

--- a/packages/api-kintone/scripts/batch/updateProjectsConstMembers.ts
+++ b/packages/api-kintone/scripts/batch/updateProjectsConstMembers.ts
@@ -54,8 +54,12 @@ export const updateProjectsConstMembers = async () => {
       }
 
       const addConstMembers = cgRec.agents.value.reduce((acc, cur) => {
-        const isExist = agents.value.some(({ value: { agentId } }) =>
-          agentId.value === cur.value.employeeId.value);
+        const isExist = agents.value.some(({
+          value: {
+            agentId,
+            agentType,
+          },
+        }) => (agentId.value === cur.value.employeeId.value) && (agentType.value === cur.value.agentType.value));
 
         if (isExist) return acc;
 


### PR DESCRIPTION
## 変更

1. タイトルの通り

## 理由

1. 種別コードの照合処理が抜けていたため

