### PR TITLE
hotfix-複写で顧客（個人）ひもづいたままになっていました

### DIFF
--- a/packages/kokoas-client/src/pages/custGroup/api/convertToForm.ts
+++ b/packages/kokoas-client/src/pages/custGroup/api/convertToForm.ts
@@ -3,12 +3,12 @@ import { v4 as uuidV4 } from 'uuid';
 import { TForm } from '../schema';
 
 /**
- * Converts the given customer group data into a form object.
+ * Kintoneデータをフォームに変換する。
  * 
- * @param recCustGroup - The customer group data.
- * @param recsCustomers - The list of customers.
+ * @param recCustGroup - 顧客グループのレコード。
+ * @param recsCustomers - 顧客のレコードのリスト。
  * @param isNew - 新規として扱うかどうか。
- * @returns The form object.
+ * @returns フォームの値。
  */
 export const convertToForm = (
   recCustGroup: ICustgroups,
@@ -69,7 +69,7 @@ export const convertToForm = (
 
         return {
           key: uuidV4(),
-          
+
           // 複写又は新規の場合は、custIdを空にする
           custId: isNew ? '' : custId?.value || '',
           index: cust.index.value || '',

--- a/packages/kokoas-client/src/pages/custGroup/api/convertToForm.ts
+++ b/packages/kokoas-client/src/pages/custGroup/api/convertToForm.ts
@@ -5,6 +5,7 @@ import { TForm } from '../schema';
 export const convertToForm = (
   recCustGroup: ICustgroups,
   recsCustomers: ICustomers[],
+  isNew: boolean,
 ) : TForm => {
 
   /* Get main record */
@@ -30,58 +31,61 @@ export const convertToForm = (
   /* Map the result to the form */
   return {
     memo: memo.value,
-    custGroupId: uuid.value,
-    isDeleted: Boolean(+isDeleted.value),
+    custGroupId: isNew ? '' : uuid.value,
+    isDeleted: isNew ? false : Boolean(+isDeleted.value),
     store: storeId.value,
     cocoAG1: Ags?.cocoAGs?.[0] || '',
     cocoAG2: Ags?.cocoAGs?.[1] || '',
     yumeAG1: Ags?.yumeAGs?.[0] || '',
     yumeAG2: Ags?.yumeAGs?.[1] || '',
-    customers: members?.value.map(({ value: cust }) => {
-      const custRec = recsCustomers.find((c) => c.uuid.value === cust.custId.value);
-      const {
-        uuid: custId,
-        $revision: custRevision,
-        fullName, fullNameReading, gender, birthYear, birthDay, birthMonth,
-        postalCode, address1, address2,
-        contacts,
-      } = custRec || {};
+    customers: members?.value
+      .map(({ value: cust }) => {
+        const custRec = recsCustomers.find((c) => c.uuid.value === cust.custId.value);
 
 
-      const tels = contacts?.value.filter(c => c.value.contactType.value === 'tel');
-      const email = contacts?.value.find(c => c.value.contactType.value === 'email');
+        const {
+          uuid: custId,
+          $revision: custRevision,
+          fullName, fullNameReading, gender, birthYear, birthDay, birthMonth,
+          postalCode, address1, address2,
+          contacts,
+        } = custRec || {};
 
-      return {
-        key: uuidV4(),
-        custId: custId?.value || '',
-        index: cust.index.value || '',
-        revision: custRevision?.value  || '',
-        custName: fullName?.value || '',
-        custNameReading: fullNameReading?.value || '',
-        gender: gender?.value || '',
-        birthYear: birthYear?.value || '',
-        birthMonth: birthMonth?.value || '',
-        birthDay: birthDay?.value || '',
-        postal: postalCode?.value || '',
-        address1: address1?.value || '',
-        address2: address2?.value || '',
 
-        phone1: tels?.[0]?.value.contactValue.value || '',
-        phone1Rel: tels?.[0]?.value.relation.value || '',
-        phone1Name: tels?.[0]?.value.contactName.value || '',
+        const tels = contacts?.value.filter(c => c.value.contactType.value === 'tel');
+        const email = contacts?.value.find(c => c.value.contactType.value === 'email');
+
+        return {
+          key: uuidV4(),
+          custId: isNew ? '' : custId?.value || '',
+          index: cust.index.value || '',
+          revision: custRevision?.value  || '',
+          custName: fullName?.value || '',
+          custNameReading: fullNameReading?.value || '',
+          gender: gender?.value || '',
+          birthYear: birthYear?.value || '',
+          birthMonth: birthMonth?.value || '',
+          birthDay: birthDay?.value || '',
+          postal: postalCode?.value || '',
+          address1: address1?.value || '',
+          address2: address2?.value || '',
+
+          phone1: tels?.[0]?.value.contactValue.value || '',
+          phone1Rel: tels?.[0]?.value.relation.value || '',
+          phone1Name: tels?.[0]?.value.contactName.value || '',
         
 
-        phone2: tels?.[1]?.value.contactValue.value || '',
-        phone2Rel: tels?.[1]?.value.relation.value || '',
-        phone2Name: tels?.[1]?.value.contactName.value || '',
+          phone2: tels?.[1]?.value.contactValue.value || '',
+          phone2Rel: tels?.[1]?.value.relation.value || '',
+          phone2Name: tels?.[1]?.value.contactName.value || '',
 
-        email: email?.value.contactValue.value || '',
-        emailRel: email?.value.relation.value || '',
-        emailName: email?.value.contactName.value || '',
+          email: email?.value.contactValue.value || '',
+          emailRel: email?.value.relation.value || '',
+          emailName: email?.value.contactName.value || '',
 
-        isSameAddress: Boolean(+cust.isSameAsMain.value),
+          isSameAddress: Boolean(+cust.isSameAsMain.value),
         
-      };
-    }),
+        };
+      }),
   };
 };

--- a/packages/kokoas-client/src/pages/custGroup/api/convertToForm.ts
+++ b/packages/kokoas-client/src/pages/custGroup/api/convertToForm.ts
@@ -2,6 +2,14 @@ import { ICustgroups, ICustomers } from 'types';
 import { v4 as uuidV4 } from 'uuid';
 import { TForm } from '../schema';
 
+/**
+ * Converts the given customer group data into a form object.
+ * 
+ * @param recCustGroup - The customer group data.
+ * @param recsCustomers - The list of customers.
+ * @param isNew - 新規として扱うかどうか。
+ * @returns The form object.
+ */
 export const convertToForm = (
   recCustGroup: ICustgroups,
   recsCustomers: ICustomers[],
@@ -31,8 +39,12 @@ export const convertToForm = (
   /* Map the result to the form */
   return {
     memo: memo.value,
+
+    // 複写又は新規の場合は、uuidを空にする
     custGroupId: isNew ? '' : uuid.value,
-    isDeleted: isNew ? false : Boolean(+isDeleted.value),
+
+    // 削除フラグは、新規の場合はfalse、既存の場合はisDeletedの値をそのまま使う
+    isDeleted: isNew ? false : Boolean(+isDeleted.value), 
     store: storeId.value,
     cocoAG1: Ags?.cocoAGs?.[0] || '',
     cocoAG2: Ags?.cocoAGs?.[1] || '',
@@ -57,6 +69,8 @@ export const convertToForm = (
 
         return {
           key: uuidV4(),
+          
+          // 複写又は新規の場合は、custIdを空にする
           custId: isNew ? '' : custId?.value || '',
           index: cust.index.value || '',
           revision: custRevision?.value  || '',

--- a/packages/kokoas-client/src/pages/custGroup/hooks/useResolveParams.ts
+++ b/packages/kokoas-client/src/pages/custGroup/hooks/useResolveParams.ts
@@ -25,12 +25,9 @@ export const useResolveParams = () => {
 
     if (recCustGroup && recsCustomers) {
 
-      const newForm = convertToForm(recCustGroup, recsCustomers);
-      setFormValues({
-        ...newForm,
-        custGroupId: isNew ? '' : newForm.custGroupId,
-        isDeleted: isNew ? false : newForm.isDeleted,
-      });
+      const newForm = convertToForm(recCustGroup, recsCustomers, !!isNew);
+      console.log('newForm', newForm);
+      setFormValues(newForm);
     } else if (!custGroupId ) {
       setFormValues(initialValues);
     }

--- a/packages/kokoas-client/src/pages/custGroup/hooks/useResolveParams.ts
+++ b/packages/kokoas-client/src/pages/custGroup/hooks/useResolveParams.ts
@@ -26,7 +26,6 @@ export const useResolveParams = () => {
     if (recCustGroup && recsCustomers) {
 
       const newForm = convertToForm(recCustGroup, recsCustomers, !!isNew);
-      console.log('newForm', newForm);
       setFormValues(newForm);
     } else if (!custGroupId ) {
       setFormValues(initialValues);

--- a/packages/kokoas-client/src/pages/custGroup/sections/actions/Actions.tsx
+++ b/packages/kokoas-client/src/pages/custGroup/sections/actions/Actions.tsx
@@ -25,8 +25,6 @@ export const Actions = () => {
 
   const handleReset  = useReset();
 
-  console.log(custGroupId);
-
   return (
     <Stack
       spacing={1}


### PR DESCRIPTION
## 変更

1. 複写の場合、custIdもクリアするようになりました。

## 理由

1. https://rdmuhwtt6gx7.cybozu.com/k/236/show#record=279