### PR TITLE
hotfix-入金アラートのリマインダーURLと通知設定を修正します

### DIFF
--- a/packages-automation/auto-paymentAlertV2/src/helpers/convAlertDate.test.ts
+++ b/packages-automation/auto-paymentAlertV2/src/helpers/convAlertDate.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from '@jest/globals';
+import { convAlertDate } from './convAlertDate';
+
+
+describe('convAlertDate', () => {
+  it('通知予定日を返すこと', async () => {
+
+    const result = convAlertDate({
+      scheduledAlertDate: '2023-12-16',
+      expectedPaymentDate: '2023-04-30',
+    });
+
+    expect(result).toBe('2023-12-16');
+
+  }, 100000);
+
+
+  it('支払予定日を返すこと', async () => {
+    const result = convAlertDate({
+      scheduledAlertDate: '2023-12-16',
+      expectedPaymentDate: '2024-04-30',
+    });
+
+    expect(result).toBe('2024-04-30');
+
+  }, 100000);
+});

--- a/packages-automation/auto-paymentAlertV2/src/helpers/convAlertDate.ts
+++ b/packages-automation/auto-paymentAlertV2/src/helpers/convAlertDate.ts
@@ -1,0 +1,21 @@
+
+/**
+ * 通知予定日と支払予定日を比較し、遅い方の日付を次回の通知日に設定する
+ * @param param.scheduledAlertDate: 通知予定日
+ * @param param.expectedPaymentDate: 支払予定日
+ * @returns 
+ */
+export const convAlertDate = ({
+  scheduledAlertDate,
+  expectedPaymentDate,
+}: {
+  scheduledAlertDate: string
+  expectedPaymentDate: string | null
+}) => {
+
+  if (expectedPaymentDate && new Date(scheduledAlertDate) <= new Date(expectedPaymentDate)) {
+    return expectedPaymentDate;
+  }
+
+  return scheduledAlertDate;
+};

--- a/packages-automation/auto-paymentAlertV2/src/helpers/convertReminderToKintoneUpdate.ts
+++ b/packages-automation/auto-paymentAlertV2/src/helpers/convertReminderToKintoneUpdate.ts
@@ -2,6 +2,7 @@ import { IPaymentReminder } from '../../config';
 import { PaymentReminder } from '../../types/paymentReminder';
 import { UpdatePaymentReminders } from '../api-kintone';
 import { compileNotificationSettings } from './compileNotificationSettings';
+import { convAlertDate } from './convAlertDate';
 
 
 
@@ -52,6 +53,12 @@ export const convertReminderToKintoneUpdate = ({
       updateSettings: cwRoomIds,
     });
 
+    // 再通知日の更新
+    const newAlertDate = convAlertDate({
+      scheduledAlertDate: alertDate,
+      expectedPaymentDate: expectedPaymentDate,
+    });
+
     //console.log('通知先設定', JSON.stringify(existingSettings, null, 2));
 
     return ({
@@ -66,7 +73,7 @@ export const convertReminderToKintoneUpdate = ({
         expectedPaymentDate: { value: expectedPaymentDate ?? '' },
         projType: { value: projType },
         totalContractAmount: { value: totalContractAmount },
-        scheduledAlertDate: { value: alertDate },
+        scheduledAlertDate: { value: newAlertDate },
         alertState: { value: alertState ? '1' : '0' },
         // reminderDate: { value: '' }, ユーザーがプルダウンから選択するため、対象外とする
         area: { value: territory },

--- a/packages-automation/auto-paymentAlertV2/src/helpers/convertRemindersToJson.ts
+++ b/packages-automation/auto-paymentAlertV2/src/helpers/convertRemindersToJson.ts
@@ -87,7 +87,7 @@ export const convertRemindersToJson = ({
       tgtSystemId: systemId.value,
     });
 
-    const reminderUrl = `${kintoneBaseUrl}/k/${reminderAppId}/show#record=${$id.value}&mode=edit`;
+    const reminderUrl = `${kintoneBaseUrl}k/${reminderAppId}/show#record=${$id.value}&mode=edit`;
 
     return ({
       alertState: connectedToAndpad && !hasPaymentHistory,

--- a/packages-automation/auto-paymentAlertV2/src/notificationFunc/generateMessage.test.ts
+++ b/packages-automation/auto-paymentAlertV2/src/notificationFunc/generateMessage.test.ts
@@ -6,13 +6,13 @@ import { PaymentReminder } from '../../types/paymentReminder';
 
 
 describe('generateMessage', () => {
-  it('should generate chatwork message', async () => {
+  it('should generate chatwork message', () => {
 
-    // set output file of createPaymentAlert.test.ts
-    const paymentAlertPath = path.join(__dirname, '../__TEST__/createPaymentAlert.json');
+    // set output file of createPaymentAlertFromAPPayments.test.ts
+    const paymentAlertPath = path.join(__dirname, '../__TEST__/createPaymentAlertFromAPPayments.json');
     const reminderDat = JSON.parse(fs.readFileSync(paymentAlertPath, 'utf8')) as PaymentReminder[];
 
-    const result = await generateMessage(reminderDat[0]);
+    const result = generateMessage(reminderDat[0]);
 
     console.log('message::', result);
 

--- a/packages-automation/auto-paymentAlertV2/src/notificationFunc/generateMessage.ts
+++ b/packages-automation/auto-paymentAlertV2/src/notificationFunc/generateMessage.ts
@@ -30,12 +30,15 @@ export const generateMessage = (reminderJson: PaymentReminder) => {
   const contractDateMsg = contractDate === '' ?
     '取得に失敗しました。' : `${format(parseISO(contractDate), 'yyyy年M月d日')}`;
 
+  const paymentDateMsg = !expectedPaymentDate ?
+    '取得に失敗しました' : format(parseISO(expectedPaymentDate), 'yyyy年MM月dd日');
 
 
   const content = `契約日  : ${contractDateMsg}
 工事名  : ${projName}
 契約金額: ${(+totalContractAmount).toLocaleString()} 円
 請求金額: ${(+expectedPaymentAmt).toLocaleString()} 円
+入金予定日: ${paymentDateMsg}
 担当者  : ${agentNames}
 夢てつAG: ${yumeAG}`;
 

--- a/packages-automation/auto-paymentAlertV2/src/notificationFunc/generateMessageForManager.test.ts
+++ b/packages-automation/auto-paymentAlertV2/src/notificationFunc/generateMessageForManager.test.ts
@@ -6,10 +6,10 @@ import { generateMessageForManager } from './generateMessageForManager';
 
 
 describe('generateMessageForManager', () => {
-  it('should generate chatwork message', async () => {
+  it('should generate chatwork message', () => {
 
-    // set output file of createPaymentAlert.test.ts
-    const paymentAlertPath = path.join(__dirname, '../__TEST__/createPaymentAlert.json');
+    // set output file of createPaymentAlertFromAPPayments.test.ts
+    const paymentAlertPath = path.join(__dirname, '../__TEST__/createPaymentAlertFromAPPayments.json');
     const reminderDat = JSON.parse(fs.readFileSync(paymentAlertPath, 'utf8')) as PaymentReminder[];
 
     const result = generateMessageForManager(reminderDat);

--- a/packages-automation/auto-paymentAlertV2/src/notifyPaymentAlertToChatwork.ts
+++ b/packages-automation/auto-paymentAlertV2/src/notifyPaymentAlertToChatwork.ts
@@ -7,6 +7,7 @@ import { chatworkRooms, isProd } from '../config';
 import { getCocoAreaMngrByTerritory } from 'api-kintone/src/employees/getCocoAreaMngrByTerritory';
 
 
+
 /**
  * chatworkへ通知する
  * @param param0 
@@ -17,7 +18,12 @@ export const notifyPaymentAlertToChatwork = async ({
   reminderJson: PaymentReminder[]
 }) => {
 
-  const alertReminder = reminderJson.filter(({ alertState }) => alertState);
+  // 通知必要かつ、支払予定日を過ぎている請求を通知対象とする(通知予定日が更新された際の対策)
+  const alertReminder = reminderJson.filter(({
+    alertState,
+    expectedPaymentDate,
+  }) => alertState && (expectedPaymentDate && new Date() >= new Date(expectedPaymentDate)));
+
 
   // 営業担当者へアラートメッセージを送信する
   for (const reminderInfo of alertReminder) {

--- a/packages-kintone-customize/app-261-paymentReminder/package.json
+++ b/packages-kintone-customize/app-261-paymentReminder/package.json
@@ -23,6 +23,5 @@
     "devDependencies": {
     },
     "dependencies": {
-        "api-kintone": "*"
     }
 }


### PR DESCRIPTION
## 変更

1. リマインダーURLの修正
2. 入金予定日を更新した際、リマインダー通知日も更新する

## 理由

1. URLに"/"(スラッシュ)が誤って重複して入力されていたため
2. 入金予定日を更新しても、リマインダーが通知されてしまっていたため

