### PR TITLE
963-契約書の返金チェックボックスに0円でもチェックを許可し、カテゴリにも返金を追加する

### DIFF
--- a/packages/kokoas-client/src/pages/projContractV2/schema.tsx
+++ b/packages/kokoas-client/src/pages/projContractV2/schema.tsx
@@ -237,15 +237,6 @@ const schema = z.object({
     path: ['othersAmt'],
     message: 'その他の金額を入力してください。',
   })
-  .refine(({ hasRefund, refundAmt }) => {
-    if (hasRefund && !refundAmt) {
-      return false;
-    }
-    return true;
-  }, {
-    path: ['refundAmt'],
-    message: '返金額を入力してください。',
-  })
   .refine(({ hasReduction, reductionAmt }) => {
     if (hasReduction && !reductionAmt) {
       return false;

--- a/packages/kokoas-client/src/pages/projContractV2/sections/contractType/AdditionalContract.tsx
+++ b/packages/kokoas-client/src/pages/projContractV2/sections/contractType/AdditionalContract.tsx
@@ -5,6 +5,7 @@ import { TypeOfForm } from '../../schema';
 export const choices = [ 
   '追加工事',
   '減額工事',
+  '返金',
   'その他',
 ] as const;
 


### PR DESCRIPTION
## 変更

1. タイトル通り

## 理由

1. closes #963
