### PR TITLE
請求書アラートで、リマインダー通知前に契約書からの情報を更新します

### DIFF
--- a/packages-automation/auto-invoiceAlert/src/api-kintone/getAllInvoiceReminder.test.ts
+++ b/packages-automation/auto-invoiceAlert/src/api-kintone/getAllInvoiceReminder.test.ts
@@ -21,7 +21,7 @@ describe('getAllInvoiceReminder', () => {
 
     // save json file
     fs.writeFileSync(
-      path.join(dir, `invoiceReminder_${format(new Date(), 'yyyyMMddHHmmss')}.json`),
+      path.join(dir, `getAllInvoiceReminder_${format(new Date(), 'yyyyMMddHHmmss')}.json`),
       JSON.stringify(result, null, 2),
     );
   });

--- a/packages-automation/auto-invoiceAlert/src/createInvoiceAlertFromContracts.test.ts
+++ b/packages-automation/auto-invoiceAlert/src/createInvoiceAlertFromContracts.test.ts
@@ -1,7 +1,4 @@
 import { describe, it/* , expect */ } from '@jest/globals';
-import fs from 'fs';
-import path from 'path';
-import format from 'date-fns/format';
 import { createInvoiceAlertFromContracts } from './createInvoiceAlertFromContracts';
 import { getAllAndpadPayments, getAllContracts, getAllProjects, getAllStores, getEmployees } from 'api-kintone';
 import { filterContractsByTargetProjType } from './helpers/filterContractsByTargetProjType';
@@ -33,7 +30,7 @@ describe('createInvoiceAlertFromContracts', () => {
     ]);
 
 
-    const result = createInvoiceAlertFromContracts({
+    await createInvoiceAlertFromContracts({
       allContracts: allContracts,
       andpadPayments: allAndpadPayments,
       employees: allMembers,
@@ -44,16 +41,7 @@ describe('createInvoiceAlertFromContracts', () => {
       allOrders: allOrders,
     });
 
-    const dir = path.join(__dirname, '__TEST__');
-
-    if (!fs.existsSync(dir)) {
-      fs.mkdirSync(dir);
-    }
-
-    // save json file
-    fs.writeFileSync(
-      path.join(dir, `createInvAlrtFromContracts_${format(new Date(), 'yyyyMMddHHmmss')}.json`),
-      JSON.stringify(result, null, 2),
-    );
-  }, 10000);
+    console.log('DBにて実行結果を確認してください');
+    
+  }, 1000000);
 });

--- a/packages-automation/auto-invoiceAlert/src/createInvoiceAlertFromContracts.ts
+++ b/packages-automation/auto-invoiceAlert/src/createInvoiceAlertFromContracts.ts
@@ -39,7 +39,7 @@ export const createInvoiceAlertFromContracts = async ({
     projects: projects,
   });
 
-  const consoleContracts1 = alertContracts.map(({ projName }) => projName.value);
+  const consoleContracts1 = alertContracts.map(({ contract }) => contract.projName.value);
   console.log('通知対象の契約', alertContracts.length, consoleContracts1);
 
 

--- a/packages-automation/auto-invoiceAlert/src/helpers/calcAlertDate.test.ts
+++ b/packages-automation/auto-invoiceAlert/src/helpers/calcAlertDate.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from '@jest/globals';
 import { calcAlertDate } from './calcAlertDate';
+import format from 'date-fns/format';
 
 
 describe('calcAlertDate', () => {
@@ -12,7 +13,7 @@ describe('calcAlertDate', () => {
       contractAmtPaymentDateStr: '2023-05-31',
     });
 
-    expect(result).toBe('2023-04-30');
+    expect(format(result, 'yyyy-MM-dd')).toBe('2023-04-30');
   }, 60000);
 
   it('リフォーム工事(500万円以上)の時、3か月後の日付が返ってくること', () => {
@@ -24,7 +25,7 @@ describe('calcAlertDate', () => {
       contractAmtPaymentDateStr: '2023-10-01',
     });
 
-    expect(result).toBe('2024-02-29');
+    expect(format(result, 'yyyy-MM-dd')).toBe('2024-02-29');
   }, 60000);
 
   it('リフォーム工事(300万円以上)の時、2か月後の日付が返ってくること', () => {
@@ -36,7 +37,7 @@ describe('calcAlertDate', () => {
       contractAmtPaymentDateStr: '2023-10-01',
     });
 
-    expect(result).toBe('2023-09-30');
+    expect(format(result, 'yyyy-MM-dd')).toBe('2023-09-30');
   }, 60000);
 
   it('リフォーム工事(300万円以上)の時、1か月後の日付が返ってくること', () => {
@@ -48,7 +49,7 @@ describe('calcAlertDate', () => {
       contractAmtPaymentDateStr: '2023-02-01',
     });
 
-    expect(result).toBe('2023-02-28');
+    expect(format(result, 'yyyy-MM-dd')).toBe('2023-02-28');
   }, 60000);
 
   it('新築工事の時、契約日が返ってくること', () => {
@@ -60,7 +61,7 @@ describe('calcAlertDate', () => {
       contractAmtPaymentDateStr: '2023-10-15',
     });
 
-    expect(result).toBe('2023-10-15');
+    expect(format(result, 'yyyy-MM-dd')).toBe('2023-10-15');
   }, 60000);
 
   it('新築工事の時、契約日が空の場合は3か月後の日付が返ってくること', () => {
@@ -72,6 +73,6 @@ describe('calcAlertDate', () => {
       contractAmtPaymentDateStr: null,
     });
 
-    expect(result).toBe('2023-08-31');
+    expect(format(result, 'yyyy-MM-dd')).toBe('2023-08-31');
   }, 60000);
 });

--- a/packages-automation/auto-invoiceAlert/src/helpers/compileNotificationSettings.test.ts
+++ b/packages-automation/auto-invoiceAlert/src/helpers/compileNotificationSettings.test.ts
@@ -26,7 +26,7 @@ describe('compileNotificationSettings', () => {
     console.log('既存の通知先', JSON.stringify(reminder, null, 2));
 
     const result = compileNotificationSettings({
-      exsistingSettings: reminder,
+      existingSettings: reminder,
       updateSettings: updateSettings,
     });
 

--- a/packages-automation/auto-invoiceAlert/src/helpers/convAlertDate.test.ts
+++ b/packages-automation/auto-invoiceAlert/src/helpers/convAlertDate.test.ts
@@ -24,4 +24,15 @@ describe('convAlertDate', () => {
     expect(result).toBe('2024-04-30');
 
   }, 100000);
+
+  
+  it('同一の場合はその日付を返すこと', async () => {
+    const result = convAlertDate({
+      scheduledAlertDate: '2023-12-16',
+      expectedPaymentDate: '2023-12-16',
+    });
+
+    expect(result).toBe('2023-12-16');
+
+  }, 100000);
 });

--- a/packages-automation/auto-invoiceAlert/src/helpers/convAlertDate.test.ts
+++ b/packages-automation/auto-invoiceAlert/src/helpers/convAlertDate.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from '@jest/globals';
+import { convAlertDate } from './convAlertDate';
+
+
+describe('convAlertDate', () => {
+  it('通知予定日を返すこと', async () => {
+
+    const result = convAlertDate({
+      scheduledAlertDate: '2023-12-16',
+      expectedPaymentDate: '2023-04-30',
+    });
+
+    expect(result).toBe('2023-12-16');
+
+  }, 100000);
+
+
+  it('支払予定日を返すこと', async () => {
+    const result = convAlertDate({
+      scheduledAlertDate: '2023-12-16',
+      expectedPaymentDate: '2024-04-30',
+    });
+
+    expect(result).toBe('2024-04-30');
+
+  }, 100000);
+});

--- a/packages-automation/auto-invoiceAlert/src/helpers/convAlertDate.ts
+++ b/packages-automation/auto-invoiceAlert/src/helpers/convAlertDate.ts
@@ -13,7 +13,8 @@ export const convAlertDate = ({
   expectedPaymentDate: string | null
 }) => {
 
-  if (expectedPaymentDate && new Date(scheduledAlertDate) <= new Date(expectedPaymentDate)) {
+  if (expectedPaymentDate 
+    && new Date(scheduledAlertDate).getTime() <= new Date(expectedPaymentDate).getTime()) {
     return expectedPaymentDate;
   }
 

--- a/packages-automation/auto-invoiceAlert/src/helpers/convAlertDate.ts
+++ b/packages-automation/auto-invoiceAlert/src/helpers/convAlertDate.ts
@@ -1,0 +1,21 @@
+
+/**
+ * 通知予定日と支払予定日を比較し、遅い方の日付を次回の通知日に設定する
+ * @param param.scheduledAlertDate: 通知予定日
+ * @param param.expectedPaymentDate: 支払予定日
+ * @returns 
+ */
+export const convAlertDate = ({
+  scheduledAlertDate,
+  expectedPaymentDate,
+}: {
+  scheduledAlertDate: string
+  expectedPaymentDate: string | null
+}) => {
+
+  if (expectedPaymentDate && new Date(scheduledAlertDate) <= new Date(expectedPaymentDate)) {
+    return expectedPaymentDate;
+  }
+
+  return scheduledAlertDate;
+};

--- a/packages-automation/auto-invoiceAlert/src/helpers/convertContractsToJson.test.ts
+++ b/packages-automation/auto-invoiceAlert/src/helpers/convertContractsToJson.test.ts
@@ -11,8 +11,8 @@ describe('convertContractsToJson', () => {
   it('should convert contract data to JSON data', async () => {
 
     // set output file of filterContractsByTargetProjType.test.ts
-    const contractsPath = path.join(__dirname, './__TEST__/contracts.json');
-    const contracts = JSON.parse(fs.readFileSync(contractsPath, 'utf8'));
+    const contractsPath = path.join(__dirname, './__TEST__/alertTargetList.json');
+    const alertTargetList = JSON.parse(fs.readFileSync(contractsPath, 'utf8'));
 
     const [
       allProjects,
@@ -30,7 +30,7 @@ describe('convertContractsToJson', () => {
 
     const result = convertContractsToJson({
       allContracts: allContracts,
-      contracts: contracts,
+      contracts: alertTargetList,
       projects: allProjects,
       employees: allEmployees,
       stores: allStores,

--- a/packages-automation/auto-invoiceAlert/src/helpers/convertContractsToJson.ts
+++ b/packages-automation/auto-invoiceAlert/src/helpers/convertContractsToJson.ts
@@ -21,8 +21,8 @@ export const convertContractsToJson = ({
   stores,
   allOrders,
 }: {
-  contracts: ContractRecordTypeAndExPayDay[]
-  allContracts: ContractRecordType[]
+  contracts: ContractRecordTypeAndExPayDay[] // アラート対象の契約書
+  allContracts: ContractRecordType[] // 全契約書
   projects: IProjects[]
   employees: IEmployees[]
   stores: IStores[]

--- a/packages-automation/auto-invoiceAlert/src/helpers/convertContractsToJson.ts
+++ b/packages-automation/auto-invoiceAlert/src/helpers/convertContractsToJson.ts
@@ -4,6 +4,7 @@ import { InvoiceReminder } from '../../types/InvoiceReminder';
 import { calcContractInformation } from './calcContractInformation';
 import { GetMyOrdersResponse } from 'api-andpad';
 import { compileInfoFromProjId } from './compileInfoFromProjId';
+import { ContractRecordTypeAndExPayDay } from './filterContractsToAlertTarget';
 
 
 
@@ -20,7 +21,7 @@ export const convertContractsToJson = ({
   stores,
   allOrders,
 }: {
-  contracts: ContractRecordType[]
+  contracts: ContractRecordTypeAndExPayDay[]
   allContracts: ContractRecordType[]
   projects: IProjects[]
   employees: IEmployees[]
@@ -30,13 +31,13 @@ export const convertContractsToJson = ({
 
 
 
-  const alertContracts: InvoiceReminder[] = contracts.reduce((acc, {
-    projId,
-    projType,
-    projName,
-    storeName,
-  }) => {
-
+  const alertContracts: InvoiceReminder[] = contracts.reduce((acc, { contract, expectPaymentDate }) => {
+    const {
+      projId,
+      projType,
+      projName,
+      storeName,
+    } = contract;
 
     const tgtContracts = allContracts
       .filter(({ projId: contractProjId }) => contractProjId.value === projId.value) || [];
@@ -75,6 +76,7 @@ export const convertContractsToJson = ({
       cwRoomIds: chatworkRoomIds,
       andpadInvoiceUrl: andpadInvoiceUrl ?? '',
       expectedCreateInvoiceDate: '',
+      expectedPaymentDate: expectPaymentDate,
       storeName: storeName.value,
     });
 

--- a/packages-automation/auto-invoiceAlert/src/helpers/convertReminderToJson.test.ts
+++ b/packages-automation/auto-invoiceAlert/src/helpers/convertReminderToJson.test.ts
@@ -3,7 +3,7 @@ import fs from 'fs';
 import path from 'path';
 import format from 'date-fns/format';
 import { convertReminderToJson } from './convertReminderToJson';
-import { getAllAndpadPayments, getAllProjects, getAllStores, getEmployees } from 'api-kintone';
+import { getAllAndpadPayments, getAllContracts, getAllProjects, getAllStores, getEmployees } from 'api-kintone';
 import { getAllAndpadOrders } from 'api-andpad/src/@get/getAllAndpadOrders';
 
 
@@ -20,12 +20,14 @@ describe('convertReminderToJson', () => {
       allProjects,
       employees,
       allStores,
+      allContracts,
     ] = await Promise.all([
       getAllAndpadPayments(),
       getAllAndpadOrders({ beforeInvoiceIssue: true }),
       getAllProjects(),
       getEmployees(),
       getAllStores(),
+      getAllContracts(),
     ]);
 
     const result = convertReminderToJson({
@@ -35,6 +37,7 @@ describe('convertReminderToJson', () => {
       allProjects:allProjects,
       employees: employees,
       stores: allStores,
+      contracts: allContracts,
     });
 
     const dir = path.join(__dirname, '__TEST__');

--- a/packages-automation/auto-invoiceAlert/src/helpers/convertReminderToJson.ts
+++ b/packages-automation/auto-invoiceAlert/src/helpers/convertReminderToJson.ts
@@ -1,9 +1,10 @@
 import { kintoneBaseUrl } from 'api-kintone';
 import { IInvoiceReminder, reminderAppId } from '../../config';
 import { InvoiceReminder } from '../../types/InvoiceReminder';
-import { IAndpadpayments, IEmployees, IProjects, IStores, Territory } from 'types';
+import { IAndpadpayments, IContracts, IEmployees, IProjects, IStores, Territory } from 'types';
 import { GetMyOrdersResponse } from 'api-andpad';
 import { compileInfoFromProjId } from './compileInfoFromProjId';
+import { updateExpectedPaymentDate } from './updateExpectedPaymentDate';
 
 
 
@@ -21,6 +22,7 @@ export const convertReminderToJson = ({
   employees,
   stores,
   allProjects,
+  contracts,
 }: {
   reminder: IInvoiceReminder[]
   andpadPayments: IAndpadpayments[]
@@ -28,6 +30,7 @@ export const convertReminderToJson = ({
   employees: IEmployees[]
   stores: IStores[]
   allProjects: IProjects[]
+  contracts: IContracts[]
 }) => {
 
   const alertReminderJson = reminder.map(({
@@ -39,6 +42,7 @@ export const convertReminderToJson = ({
     contractDate,
     totalContractAmount,
     expectedCreateInvoiceDate,
+    expectedPaymentDate,
     store,
   }): InvoiceReminder => {
 
@@ -70,6 +74,14 @@ export const convertReminderToJson = ({
       }) => ((systemId === paymentSystemId.value)));
     }
 
+    // 支払予定日に更新がないかを確認する
+    const updateExPaymentDate = updateExpectedPaymentDate({
+      projId: projIdReminder.value,
+      projType: projType.value,
+      expectedPaymentDate: expectedPaymentDate.value,
+      contracts,
+    });
+
 
     return ({
       alertState: connectedToAndpad && !hasInvoice, // ANDPADに接続かつ、請求書未発行の場合に通知する
@@ -86,6 +98,7 @@ export const convertReminderToJson = ({
       cwRoomIds: chatworkRoomIds,
       andpadInvoiceUrl: andpadInvoiceUrl ?? '',
       expectedCreateInvoiceDate: expectedCreateInvoiceDate.value,
+      expectedPaymentDate: updateExPaymentDate || '',
       storeName: storeName || store.value,
     });
   });

--- a/packages-automation/auto-invoiceAlert/src/helpers/convertReminderToKintone.ts
+++ b/packages-automation/auto-invoiceAlert/src/helpers/convertReminderToKintone.ts
@@ -30,6 +30,7 @@ export const convertReminderToKintone = ({
     yumeAG,
     storeName,
     systemId,
+    expectedPaymentDate,
   }) => {
 
     const cwRoomIdsKintone = cwRoomIds.map(({ agentName, agentId, cwRoomId }) => {
@@ -58,6 +59,7 @@ export const convertReminderToKintone = ({
       projName: { value: projName },
       store: { value: storeName },
       //lastAlertDate: { value: '' }, //このタイミングではまだ通知はしていないため登録しない
+      expectedPaymentDate:{ value: expectedPaymentDate },
       andpadUrl: { value: andpadInvoiceUrl },
       contractId: { value: contractId },
       yumeAG: { value: yumeAG },

--- a/packages-automation/auto-invoiceAlert/src/helpers/convertReminderToKintoneUpdate.ts
+++ b/packages-automation/auto-invoiceAlert/src/helpers/convertReminderToKintoneUpdate.ts
@@ -46,7 +46,7 @@ export const convertReminderToKintoneUpdate = ({
     }) => projId === reminderProjId.value) || {} as IInvoiceReminder;
 
     const updateRooms = compileNotificationSettings({
-      exsistingSettings: notificationSettingsRec.notificationSettings,
+      existingSettings: notificationSettingsRec.notificationSettings,
       updateSettings: cwRoomIds,
     });
 

--- a/packages-automation/auto-invoiceAlert/src/helpers/convertReminderToKintoneUpdate.ts
+++ b/packages-automation/auto-invoiceAlert/src/helpers/convertReminderToKintoneUpdate.ts
@@ -2,6 +2,7 @@ import { IInvoiceReminder } from '../../config';
 import { InvoiceReminder } from '../../types/InvoiceReminder';
 import { UpdateInvoiceReminder } from '../api-kintone';
 import { compileNotificationSettings } from './compileNotificationSettings';
+import { convAlertDate } from './convAlertDate';
 
 
 
@@ -36,6 +37,7 @@ export const convertReminderToKintoneUpdate = ({
     systemId,
     storeName,
     andpadInvoiceUrl,
+    expectedPaymentDate,
   }) => {
 
     //リマインダーレコードから　notificationSettings　を取得する
@@ -46,6 +48,11 @@ export const convertReminderToKintoneUpdate = ({
     const updateRooms = compileNotificationSettings({
       exsistingSettings: notificationSettingsRec.notificationSettings,
       updateSettings: cwRoomIds,
+    });
+
+    const updateAlertDate = convAlertDate({
+      scheduledAlertDate: alertDate,
+      expectedPaymentDate: expectedPaymentDate,
     });
 
 
@@ -60,7 +67,7 @@ export const convertReminderToKintoneUpdate = ({
         yumeAG: { value: yumeAG },
         projType: { value: projType },
         totalContractAmount: { value: totalContractAmount },
-        scheduledAlertDate: { value: alertDate },
+        scheduledAlertDate: { value: updateAlertDate },
         alertState: { value: alertState ? '1' : '0' },
         andpadUrl: { value: andpadInvoiceUrl },
         store: { value: storeName },

--- a/packages-automation/auto-invoiceAlert/src/helpers/filterContractsToAlertTarget.ts
+++ b/packages-automation/auto-invoiceAlert/src/helpers/filterContractsToAlertTarget.ts
@@ -5,6 +5,12 @@ import { getEarliestDateOfContract } from './getEarliestDateOfContract';
 
 
 
+export type ContractRecordTypeAndExPayDay = {
+  contract: ContractRecordType,
+  expectPaymentDate: string,
+};
+
+
 /**
  * 通知対象の契約のみに絞り込む
  */
@@ -88,11 +94,14 @@ export const filterContractsToAlertTarget = ({
 
     // 通知対象日を過ぎている場合
     if ((alertDate.getTime() <= new Date().getTime())) {
-      acc?.push(contract);
+      acc?.push({
+        contract: contract,
+        expectPaymentDate: contractAmtPaymentDate || '',
+      });
     }
 
     return acc;
 
-  }, [] as ContractRecordType[]);
+  }, [] as ContractRecordTypeAndExPayDay[]);
 
 };

--- a/packages-automation/auto-invoiceAlert/src/helpers/updateExpectedPaymentDate.test.ts
+++ b/packages-automation/auto-invoiceAlert/src/helpers/updateExpectedPaymentDate.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from '@jest/globals';
+import { updateExpectedPaymentDate } from './updateExpectedPaymentDate';
+import { getAllContracts } from 'api-kintone';
+
+
+describe('updateExpectedPaymentDate', () => {
+  it('should update expectedPaymentDate', async () => {
+
+    const contracts = await getAllContracts();
+    const testProjId = '5e50bc4a-0646-448d-94af-8512bac1e1da';
+    const testProjType = '新築工事';
+    const testDate = '2023-01-01';
+
+    const result = updateExpectedPaymentDate({
+      projId: testProjId,
+      projType: testProjType,
+      expectedPaymentDate: testDate,
+      contracts,
+    });
+
+    expect(result).toBe('2024-01-14');
+  }, 60000);
+
+  it('should not changed expectedPaymentDate', async () => {
+
+    const contracts = await getAllContracts();
+    const testProjId = 'fortestDummy';
+    const testProjType = '新築工事';
+    const testDate = '2025-01-01';
+
+    const result = updateExpectedPaymentDate({
+      projId: testProjId,
+      projType: testProjType,
+      expectedPaymentDate: testDate,
+      contracts,
+    });
+
+    expect(result).toBe('2025-01-01');
+  }, 60000);
+
+});

--- a/packages-automation/auto-invoiceAlert/src/helpers/updateExpectedPaymentDate.ts
+++ b/packages-automation/auto-invoiceAlert/src/helpers/updateExpectedPaymentDate.ts
@@ -1,0 +1,58 @@
+import { IContracts } from 'types';
+import { getEarliestDateOfContract } from './getEarliestDateOfContract';
+import { calcAlertDate } from './calcAlertDate';
+import { TgtProjType } from '../../config';
+import format from 'date-fns/format';
+
+
+
+/** 支払予定日を契約書の情報から更新します */
+export const updateExpectedPaymentDate = ({
+  projId,
+  projType,
+  expectedPaymentDate,
+  contracts,
+}: {
+  projId: string
+  projType: string
+  expectedPaymentDate: string
+  contracts: IContracts[]
+}) => {
+
+  const tgtContract = contracts.find(({
+    projId: projIdContract,
+    contractType,
+  }) => {
+    return contractType.value === '契約' && projIdContract.value === projId;
+  });
+
+  if (!tgtContract) return expectedPaymentDate; // 契約書の紐づけに失敗した場合は、前回値のままとする
+
+  const updateExpPayDate = getEarliestDateOfContract({
+    dates: [
+      tgtContract.contractAmtDate.value,
+      tgtContract.initialAmtDate.value,
+      tgtContract.interimAmtDate.value,
+      tgtContract.finalAmtDate.value,
+      tgtContract.othersAmtDate.value,
+    ],
+    contractAmts: [
+      tgtContract.contractAmt.value,
+      tgtContract.initialAmt.value,
+      tgtContract.interimAmt.value,
+      tgtContract.finalAmt.value,
+      tgtContract.othersAmt.value,
+    ],
+  });
+
+  
+  const alertDate = calcAlertDate({
+    contractDateStr: tgtContract.contractDate.value,
+    projType: projType as TgtProjType,
+    contractAmt: +tgtContract.totalContractAmt.value,
+    contractAmtPaymentDateStr: updateExpPayDate,
+  });
+
+  return format(alertDate, 'yyyy-MM-dd');
+
+};

--- a/packages-automation/auto-invoiceAlert/src/invoiceReminder.ts
+++ b/packages-automation/auto-invoiceAlert/src/invoiceReminder.ts
@@ -60,6 +60,7 @@ export const invoiceReminder = async () => {
     allProjects: allProjects,
     employees: allMembers,
     stores: allStores,
+    contracts: allContracts,
   });
 
 

--- a/packages-automation/auto-invoiceAlert/src/notifyInvoiceAlertToChatwork.ts
+++ b/packages-automation/auto-invoiceAlert/src/notifyInvoiceAlertToChatwork.ts
@@ -6,6 +6,7 @@ import { generateMessageForManager } from './notificationFunc/generateMessageFor
 import { chatworkRooms, isProd } from '../config';
 import { getCocoAccountant, getCocoAreaMngrByTerritory } from 'api-kintone';
 import { generateMessageForAccountant } from './notificationFunc/generateMessageForAccountant';
+import isPast from 'date-fns/isPast';
 
 
 /**
@@ -21,7 +22,7 @@ export const notifyInvoiceAlertToChatwork = async ({
   const alertReminder = reminderJson.filter(({ 
     alertState,
     expectedPaymentDate,
-  }) => alertState && (expectedPaymentDate && new Date() >= new Date(expectedPaymentDate)));
+  }) => alertState && (expectedPaymentDate && isPast(new Date(expectedPaymentDate))));
 
   // 各担当者への通知
   for (const reminderInfo of alertReminder) {

--- a/packages-automation/auto-invoiceAlert/src/notifyInvoiceAlertToChatwork.ts
+++ b/packages-automation/auto-invoiceAlert/src/notifyInvoiceAlertToChatwork.ts
@@ -18,7 +18,10 @@ export const notifyInvoiceAlertToChatwork = async ({
   reminderJson: InvoiceReminder[]
 }) => {
 
-  const alertReminder = reminderJson.filter(({ alertState }) => alertState);
+  const alertReminder = reminderJson.filter(({ 
+    alertState,
+    expectedPaymentDate,
+  }) => alertState && (expectedPaymentDate && new Date() >= new Date(expectedPaymentDate)));
 
   // 各担当者への通知
   for (const reminderInfo of alertReminder) {

--- a/packages-automation/auto-invoiceAlert/types/InvoiceReminder.ts
+++ b/packages-automation/auto-invoiceAlert/types/InvoiceReminder.ts
@@ -19,6 +19,7 @@ export interface InvoiceReminder {
   contractDate: string
   territory: Territory
   expectedCreateInvoiceDate: string | null
+  expectedPaymentDate: string
   yumeAG: string
   cwRoomIds: CwRoomIds[]
   totalContractAmount: string

--- a/packages-automation/auto-invoiceAlert/types/kintone.data.d.ts
+++ b/packages-automation/auto-invoiceAlert/types/kintone.data.d.ts
@@ -3,6 +3,7 @@ declare namespace DBInvoiceReminder {
     projId: kintone.fieldTypes.SingleLineText;
     contractDate: kintone.fieldTypes.Date;
     yumeAG: kintone.fieldTypes.SingleLineText;
+    expectedPaymentDate: kintone.fieldTypes.Date;
     projType: kintone.fieldTypes.SingleLineText;
     totalContractAmount: kintone.fieldTypes.Number;
     scheduledAlertDate: kintone.fieldTypes.Date;


### PR DESCRIPTION
## 変更

1. リマインダー通知の際に、契約書からの情報更新を行います

## 理由

1. closes #970 

## テスト

- convertReminderToJson.test.ts
- filterContractsToAlertTarget.test.ts
- updateExpectedPaymentDate.test.ts
