### PR TITLE
hotfix-入金アラートのサマリー送信の際の対象レコードを修正します

### DIFF
--- a/packages-automation/auto-paymentAlertV2/src/notifyPaymentAlertToChatwork.ts
+++ b/packages-automation/auto-paymentAlertV2/src/notifyPaymentAlertToChatwork.ts
@@ -64,7 +64,7 @@ export const notifyPaymentAlertToChatwork = async ({
 
   // 各エリアの店長へ、件数とメッセージを送信する
   for (let i = 0; i < territories.length; i++) {
-    const reminderDat = reminderJson.filter(({
+    const reminderDat = alertReminder.filter(({
       territory,
       alertState,
     }) => (territory === territories[i]) && alertState);
@@ -109,12 +109,12 @@ export const notifyPaymentAlertToChatwork = async ({
     let reminderDat = [] as PaymentReminder[];
 
     if (accountant.territory_v2.value === '東') {
-      reminderDat = reminderJson.filter(({
+      reminderDat = alertReminder.filter(({
         territory,
         alertState,
       }) => (territory === '東') && alertState);
     } else {
-      reminderDat = reminderJson.filter(({ alertState })=> alertState);
+      reminderDat = alertReminder.filter(({ alertState })=> alertState);
     }
 
 


### PR DESCRIPTION
## 変更

1. タイトルの通り

## 理由

1. フィルタリング前の全件をサマリーとして送付してしまっていたため
