### PR TITLE
hotfix-請求書アラートのリマインダーの間隔を修正します

### DIFF
--- a/packages-automation/auto-invoiceAlert/src/helpers/updateReportedReminders.ts
+++ b/packages-automation/auto-invoiceAlert/src/helpers/updateReportedReminders.ts
@@ -1,9 +1,9 @@
 import format from 'date-fns/format';
 import { InvoiceReminder } from '../../types/InvoiceReminder';
-import addDays from 'date-fns/addDays';
 import { updateInvoiceReminder } from '../api-kintone';
 import { convertReminderToKintoneUpdate } from './convertReminderToKintoneUpdate';
 import { IInvoiceReminder } from '../../config';
+import addWeeks from 'date-fns/addWeeks';
 
 
 /**
@@ -20,7 +20,7 @@ export const updateReportedReminders = async ({
   // 通知実施後のリマインダーレコード更新処理、通知日は今日、再通知日は仮に3日後を設定する
   const kintoneRecords = convertReminderToKintoneUpdate({
     invoiceReminderJson: reportedReminder,
-    alertDate: format(addDays(new Date(), 3), 'yyyy-MM-dd'),
+    alertDate: format(addWeeks(new Date(), 1), 'yyyy-MM-dd'),
     lastAlertDate: format(new Date(), 'yyyy-MM-dd'),
     existedReminder: existedReminder,
   });


### PR DESCRIPTION
## 変更

1. タイトルの通り

## 理由

1. [k293](https://rdmuhwtt6gx7.cybozu.com/k/236/show#record=293)より一部先行対応
2. #996 にて入金アラートには反映済みで、アラート間でリマインダー間隔に差が出てしまっているため
