### PR TITLE
入金一覧のクリーンアップ処理を修正する

### DIFF
--- a/packages-automation/auto-cleanUpPayments/cleanUpAndpadPaymentsV2.ts
+++ b/packages-automation/auto-cleanUpPayments/cleanUpAndpadPaymentsV2.ts
@@ -23,7 +23,11 @@ export const cleanUpAndpadPaymentsV2 = async () => {
     andpadPaymentsCsv: andpadPaymentsCsv,
   });
 
-  await deleteAndpadPayments(deleteRecordIDs);
+  if (deleteRecordIDs.length) {
+    await deleteAndpadPayments(deleteRecordIDs);
+  } else {
+    console.log('削除対象のレコードはありませんでした。');
+  }
 
   
   console.log('finish cleanup andpad payments');


### PR DESCRIPTION
## 変更

1. 入金一覧のクリーンアップ処理を修正する

## 理由

1. 削除対象レコードが無い時でも、レコード削除処理を呼んでしまい、エラーとなっていたため
