### PR TITLE
hotfix-顧客一覧の入金のタブの内容に入金予定金額がは表示されない

### DIFF
--- a/packages/kokoas-client/src/pages/projSearch/sections/result/details/paymentDetails/paymentsTable/PayTableBody.tsx
+++ b/packages/kokoas-client/src/pages/projSearch/sections/result/details/paymentDetails/paymentsTable/PayTableBody.tsx
@@ -43,14 +43,14 @@ export const PayTableBody = ({
           paymentDate,
           paymentStatus,
           billingDate,
-          //expectedPaymentAmount,
+          expectedPaymentAmount,
         
         } = record;
 
         const parsedHandlingFee = +handlingFee.value;
         const parsedPaymentAmount = +paymentAmount.value;
 
-        const actualPaymentAmount = parsedPaymentAmount + parsedHandlingFee;
+        const actualPaymentAmount = parsedPaymentAmount;
 
         return {
           key: ID.value,
@@ -59,8 +59,8 @@ export const PayTableBody = ({
           paymentDate: paymentDate.value,
           paymentMethod: paymentMethod.value,
           billingDate: billingDate.value,
-          paymentAmount: parsedPaymentAmount,
-          actualPaymentAmount,
+          paymentAmount: +expectedPaymentAmount.value,
+          actualPaymentAmount: actualPaymentAmount,
           handlingFee: parsedHandlingFee,
           // random japanese string
           remarks: '-',

--- a/packages/kokoas-client/src/pages/projSearch/sections/result/details/paymentDetails/paymentsTable/PayTableHead.tsx
+++ b/packages/kokoas-client/src/pages/projSearch/sections/result/details/paymentDetails/paymentsTable/PayTableHead.tsx
@@ -93,14 +93,14 @@ export const PayTableHead = (props : PayTableHeadProps) => {
         paymentAmount={(
           <EnhancedTableCell
             fieldName='paymentAmount'
-            label='金額'
+            label='入金予定額'
             {...props}
           />
         )}
         actualPaymentAmount={(
           <EnhancedTableCell
             fieldName='actualPaymentAmount'
-            label='金額'
+            label='入金額'
             {...props}
           />
         )}

--- a/packages/kokoas-client/src/pages/projSearch/sections/result/details/paymentDetails/paymentsTable/RowLayout.tsx
+++ b/packages/kokoas-client/src/pages/projSearch/sections/result/details/paymentDetails/paymentsTable/RowLayout.tsx
@@ -96,10 +96,8 @@ export const RowLayout = ({
       <TableCell width={100}>
         {paymentDate}
       </TableCell>
-      <TableCell width={100}>
-        {billingDate}
-      </TableCell>
 
+      
       <NumberCell width={100}>
         {actualPaymentAmount}
       </NumberCell>
@@ -108,6 +106,10 @@ export const RowLayout = ({
         {handlingFee}
       </NumberCell>
 
+      <TableCell width={100}>
+        {billingDate}
+      </TableCell>
+      
       <NumberCell width={100}>
         {paymentAmount}
       </NumberCell>


### PR DESCRIPTION
変更前：

![image](https://github.com/Lorenzras/yumecoco-monorepo/assets/2501255/9e534285-c78a-4512-ad00-d8e41d456c73)


変更後：

![image](https://github.com/Lorenzras/yumecoco-monorepo/assets/2501255/20263dd9-40cf-4044-9846-a3a6f38199fc)
