### PR TITLE
工事情報編集画面に台帳情報を追加する

### DIFF
--- a/packages/kokoas-client/src/pages/projRegisterV2/Contents.tsx
+++ b/packages/kokoas-client/src/pages/projRegisterV2/Contents.tsx
@@ -10,6 +10,7 @@ import { ContractsSummary } from './sections/contractsSummary/ContractsSummary';
 import { OfficersInput } from './sections/officersInput/OfficersInput';
 import { ProjectDates } from './sections/projectDates/ProjectDates';
 import { Prospect } from './sections/prospect/Prospect';
+import { LedgerInformation } from './sections/LedgerInformation/LedgerInformation';
 
 export const Contents = () => {
   const projId = useTypedWatch({
@@ -24,6 +25,9 @@ export const Contents = () => {
         <>
           <PageSubTitle3 label={'Andpad情報'} />
           <AndpadSummary />
+          
+          <PageSubTitle3 label={'台帳情報'} />
+          <LedgerInformation />
 
           <PageSubTitle3 label={'契約情報'} />
           <ContractsSummary />

--- a/packages/kokoas-client/src/pages/projRegisterV2/api/convertToKintone.ts
+++ b/packages/kokoas-client/src/pages/projRegisterV2/api/convertToKintone.ts
@@ -57,6 +57,7 @@ export const convertToKintone = (
     // 利益率
     profitRate,
 
+    ledgerInfo,
 
   } = rawValues;
 
@@ -175,6 +176,8 @@ export const convertToKintone = (
     // 利益率
     profitRate: { value: String(profitRate) },
 
+    // 台帳情報
+    ledgerInfo: { value: ledgerInfo },
 
   };
 

--- a/packages/kokoas-client/src/pages/projRegisterV2/form.ts
+++ b/packages/kokoas-client/src/pages/projRegisterV2/form.ts
@@ -77,6 +77,8 @@ export const initialValues : TForm = {
   territory: '',
   storeCode: '',
 
+  // 台帳情報
+  ledgerInfo: 'ANDPAD',
 };
 
 

--- a/packages/kokoas-client/src/pages/projRegisterV2/schema.ts
+++ b/packages/kokoas-client/src/pages/projRegisterV2/schema.ts
@@ -115,6 +115,8 @@ export const schema = z.object({
   storeCode: z.string(),
   territory: z.string(),
 
+  // 台帳情報
+  ledgerInfo: z.string(),
 })
   .superRefine((
     {

--- a/packages/kokoas-client/src/pages/projRegisterV2/sections/LedgerInformation/LedgerInformation.tsx
+++ b/packages/kokoas-client/src/pages/projRegisterV2/sections/LedgerInformation/LedgerInformation.tsx
@@ -1,9 +1,19 @@
+import { StaticContentContainer } from 'kokoas-client/src/components';
 import { LedgerRadioButton } from './LedgerRadioButton';
+import { Alert } from '@mui/material';
+
+
 
 export const LedgerInformation = () => {
+  // 見栄えを他のコンポーネントと合わせる
   return (
-    <LedgerRadioButton
-      name='ledgerInfo'
-    />
+    <StaticContentContainer>
+      <Alert severity='info'>
+        受発注管理を大黒さんで行う場合は、大黒さんを選択してください
+      </Alert>
+      <LedgerRadioButton
+        name='ledgerInfo'
+      />
+    </StaticContentContainer>
   );
 };

--- a/packages/kokoas-client/src/pages/projRegisterV2/sections/LedgerInformation/LedgerInformation.tsx
+++ b/packages/kokoas-client/src/pages/projRegisterV2/sections/LedgerInformation/LedgerInformation.tsx
@@ -1,0 +1,9 @@
+import { LedgerRadioButton } from './LedgerRadioButton';
+
+export const LedgerInformation = () => {
+  return (
+    <LedgerRadioButton
+      name='ledgerInfo'
+    />
+  );
+};

--- a/packages/kokoas-client/src/pages/projRegisterV2/sections/LedgerInformation/LedgerRadioButton.tsx
+++ b/packages/kokoas-client/src/pages/projRegisterV2/sections/LedgerInformation/LedgerRadioButton.tsx
@@ -1,0 +1,53 @@
+import { FormControlLabel, Radio, RadioGroup } from '@mui/material';
+import { Controller } from 'react-hook-form';
+import { KForm } from '../../schema';
+import { useTypedFormContext } from '../../hooks';
+
+
+
+const radioLabels = ['ANDPAD', '大黒さん'];
+
+
+export const LedgerRadioButton = ({
+  name,
+  defaultValue = 'ANDPAD',
+}: {
+  name: KForm,
+  defaultValue?: string,
+}) => {
+  const {
+    control,
+  } = useTypedFormContext();
+
+  return (
+    <Controller
+      control={control}
+      name={name}
+      render={({
+        field: {
+          value,
+          ...otherValue
+        },
+      }) => {
+
+        return (
+          <RadioGroup          
+            {...otherValue}
+            defaultValue={defaultValue}
+            value={value || ''}
+          >
+            {radioLabels.map((radioLabel) => {
+              return (<FormControlLabel
+                key={radioLabel}
+                value={radioLabel}
+                control={<Radio />}
+                label={radioLabel}
+                      />);
+            })}
+          </RadioGroup>
+        );
+      }}
+    />
+
+  );
+};

--- a/packages/kokoas-client/src/pages/projRegisterV2/sections/LedgerInformation/LedgerRadioButton.tsx
+++ b/packages/kokoas-client/src/pages/projRegisterV2/sections/LedgerInformation/LedgerRadioButton.tsx
@@ -2,6 +2,7 @@ import { FormControlLabel, Radio, RadioGroup } from '@mui/material';
 import { Controller } from 'react-hook-form';
 import { KForm } from '../../schema';
 import { useTypedFormContext } from '../../hooks';
+import { padding } from '@mui/system';
 
 
 
@@ -31,7 +32,8 @@ export const LedgerRadioButton = ({
       }) => {
 
         return (
-          <RadioGroup          
+          <RadioGroup
+            row
             {...otherValue}
             defaultValue={defaultValue}
             value={value || ''}
@@ -42,6 +44,7 @@ export const LedgerRadioButton = ({
                 value={radioLabel}
                 control={<Radio />}
                 label={radioLabel}
+                sx={{ px: '20px' }}
                       />);
             })}
           </RadioGroup>

--- a/packages/kokoas-client/src/pages/projSearch/sections/result/details/projectDetails/ProjectDetails.tsx
+++ b/packages/kokoas-client/src/pages/projSearch/sections/result/details/projectDetails/ProjectDetails.tsx
@@ -84,6 +84,8 @@ export const ProjectDetails = ({
       deliveryDate,
       projFinDate,
       payFinDate,
+
+      ledgerInfo,
     } = recProj;
 
     const projDates: IDetail[] = [
@@ -98,6 +100,13 @@ export const ProjectDetails = ({
       {
         label: '物件完了日',
         value: projFinDate.value || '-',
+      },
+    ];
+
+    const ledgerDetails: IDetail[] = [
+      {
+        label: '管理台帳',
+        value: ledgerInfo.value || 'ANDPAD',
       },
     ];
 
@@ -198,6 +207,7 @@ export const ProjectDetails = ({
       mainDetails,
       otherDetails,
       logDetails,
+      ledgerDetails,
     };
 
   }, [
@@ -227,6 +237,11 @@ export const ProjectDetails = ({
       />
 
       <AndpadDetails recProj={recProj} />
+
+      <DetailSection
+        title="台帳情報"
+        details={details.ledgerDetails}
+      />
 
       <DetailSection
         title="工事情報"

--- a/packages/types/src/dtsgen/db.projects.d.ts
+++ b/packages/types/src/dtsgen/db.projects.d.ts
@@ -34,6 +34,7 @@ declare namespace DBProjects {
     isChkAddressKari: kintone.fieldTypes.Number;
     andpadSystemId: kintone.fieldTypes.SingleLineText;
     planApplicationDate: kintone.fieldTypes.Date;
+    ledgerInfo: kintone.fieldTypes.SingleLineText;
     address2: kintone.fieldTypes.SingleLineText;
     address1: kintone.fieldTypes.SingleLineText;
     projName: kintone.fieldTypes.SingleLineText;


### PR DESCRIPTION
## 変更

1. 工事情報編集画面に、台帳情報の選択を追加する

## 理由

1. アラートにて大黒さん案件の判定に使用したいため
2. 今後のシステム移行期に備えて
