### PR TITLE
hotfix-工事情報の管理台帳情報の表示値を修正します

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32594,7 +32594,7 @@
       "devDependencies": {}
     },
     "packages/kokoas-client": {
-      "version": "20240126",
+      "version": "20240126.1",
       "dependencies": {
         "api-kintone": "*",
         "auto-kintone": "*",

--- a/packages/kokoas-client/package.json
+++ b/packages/kokoas-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kokoas-client",
-  "version": "20240126",
+  "version": "20240126.1",
   "devDependencies": {},
   "scripts": {
     "dev": "npm run build -- --watch --mode development",

--- a/packages/kokoas-client/src/pages/projRegisterV2/api/convertProjToForm.ts
+++ b/packages/kokoas-client/src/pages/projRegisterV2/api/convertProjToForm.ts
@@ -73,6 +73,8 @@ export const convertProjToForm = ({
     storeCode,
     store: storeName,
     territory,
+
+    ledgerInfo,
     
   } = projRec;
 
@@ -181,6 +183,9 @@ export const convertProjToForm = ({
     storeName: storeName.value || cgStoreName.value,
     storeCode: storeCode.value || cgStoreCode.value,
     territory: (territory?.value as Territory || cgTerritory.value) || '',
+
+    // 管理台帳
+    ledgerInfo: ledgerInfo.value || '',
   };
 
 };

--- a/packages/kokoas-client/src/pages/projRegisterV2/api/convertProjToForm.ts
+++ b/packages/kokoas-client/src/pages/projRegisterV2/api/convertProjToForm.ts
@@ -185,7 +185,7 @@ export const convertProjToForm = ({
     territory: (territory?.value as Territory || cgTerritory.value) || '',
 
     // 管理台帳
-    ledgerInfo: ledgerInfo.value || '',
+    ledgerInfo: ledgerInfo.value || 'ANDPAD',
   };
 
 };

--- a/packages/kokoas-client/src/pages/projRegisterV2/sections/LedgerInformation/LedgerInformation.tsx
+++ b/packages/kokoas-client/src/pages/projRegisterV2/sections/LedgerInformation/LedgerInformation.tsx
@@ -5,7 +5,6 @@ import { Alert } from '@mui/material';
 
 
 export const LedgerInformation = () => {
-  // 見栄えを他のコンポーネントと合わせる
   return (
     <StaticContentContainer>
       <Alert severity='info'>

--- a/packages/kokoas-client/src/pages/projRegisterV2/sections/LedgerInformation/LedgerRadioButton.tsx
+++ b/packages/kokoas-client/src/pages/projRegisterV2/sections/LedgerInformation/LedgerRadioButton.tsx
@@ -1,7 +1,7 @@
 import { FormControlLabel, Radio, RadioGroup } from '@mui/material';
 import { Controller } from 'react-hook-form';
 import { KForm } from '../../schema';
-import { useTypedFormContext, useTypedWatch } from '../../hooks';
+import { useTypedFormContext } from '../../hooks';
 
 
 

--- a/packages/kokoas-client/src/pages/projRegisterV2/sections/LedgerInformation/LedgerRadioButton.tsx
+++ b/packages/kokoas-client/src/pages/projRegisterV2/sections/LedgerInformation/LedgerRadioButton.tsx
@@ -33,7 +33,7 @@ export const LedgerRadioButton = ({
           <RadioGroup
             row
             {...otherValue}
-            value={value || 'ANDPAD'} // 初期値を'ANDPAD'とする
+            value={value}
           >
             {radioLabels.map((radioLabel) => {
               return (<FormControlLabel

--- a/packages/kokoas-client/src/pages/projRegisterV2/sections/LedgerInformation/LedgerRadioButton.tsx
+++ b/packages/kokoas-client/src/pages/projRegisterV2/sections/LedgerInformation/LedgerRadioButton.tsx
@@ -1,8 +1,7 @@
 import { FormControlLabel, Radio, RadioGroup } from '@mui/material';
 import { Controller } from 'react-hook-form';
 import { KForm } from '../../schema';
-import { useTypedFormContext } from '../../hooks';
-import { padding } from '@mui/system';
+import { useTypedFormContext, useTypedWatch } from '../../hooks';
 
 
 
@@ -11,14 +10,13 @@ const radioLabels = ['ANDPAD', '大黒さん'];
 
 export const LedgerRadioButton = ({
   name,
-  defaultValue = 'ANDPAD',
 }: {
   name: KForm,
-  defaultValue?: string,
 }) => {
   const {
     control,
   } = useTypedFormContext();
+
 
   return (
     <Controller
@@ -35,8 +33,7 @@ export const LedgerRadioButton = ({
           <RadioGroup
             row
             {...otherValue}
-            defaultValue={defaultValue}
-            value={value || ''}
+            value={value || 'ANDPAD'} // 初期値を'ANDPAD'とする
           >
             {radioLabels.map((radioLabel) => {
               return (<FormControlLabel


### PR DESCRIPTION
## 変更

1. タイトルの通り

## 理由

1. 保存されている値の取得処理が漏れてしまっていたため
